### PR TITLE
Specify device consistently

### DIFF
--- a/janus_core/mlip_calculators.py
+++ b/janus_core/mlip_calculators.py
@@ -10,10 +10,13 @@ from typing import Literal
 from ase.calculators.calculator import Calculator
 
 architectures = ["mace", "mace_mp", "mace_off", "m3gnet", "chgnet"]
+devices = ["cpu", "cuda", "mps"]
 
 
 def choose_calculator(
-    architecture: Literal[architectures] = "mace", **kwargs
+    architecture: Literal[architectures] = "mace",
+    device: Literal[devices] = "cuda",
+    **kwargs,
 ) -> Calculator:
     """Choose MLIP calculator to configure.
 
@@ -42,15 +45,13 @@ def choose_calculator(
         from mace.calculators import MACECalculator
 
         kwargs.setdefault("default_dtype", "float64")
-        kwargs.setdefault("device", "cuda")
-        calculator = MACECalculator(**kwargs)
+        calculator = MACECalculator(device=device, **kwargs)
 
     elif architecture == "mace_mp":
         from mace import __version__
         from mace.calculators import mace_mp
 
         kwargs.setdefault("default_dtype", "float64")
-        kwargs.setdefault("device", "cuda")
         kwargs.setdefault("model", "small")
         calculator = mace_mp(**kwargs)
 
@@ -59,7 +60,6 @@ def choose_calculator(
         from mace.calculators import mace_off
 
         kwargs.setdefault("default_dtype", "float64")
-        kwargs.setdefault("device", "cuda")
         kwargs.setdefault("model", "small")
         calculator = mace_off(**kwargs)
 
@@ -75,7 +75,7 @@ def choose_calculator(
         from chgnet import __version__
         from chgnet.model.dynamics import CHGNetCalculator
 
-        calculator = CHGNetCalculator(**kwargs)
+        calculator = CHGNetCalculator(use_device=device, **kwargs)
 
     else:
         raise ValueError(

--- a/janus_core/mlip_calculators.py
+++ b/janus_core/mlip_calculators.py
@@ -34,53 +34,41 @@ def choose_calculator(
     calculator : Calculator
         Configured MLIP calculator.
     """
-    # pylint: disable=import-outside-toplevel
-    # pylint: disable=too-many-branches
-    # pylint: disable=import-error
+    # pylint: disable=import-outside-toplevel, too-many-branches, import-error
     # Optional imports handled via `architecture`. We could catch these,
     # but the error message is clear if imports are missing.
     if architecture == "mace":
         from mace import __version__
         from mace.calculators import MACECalculator
 
-        if "default_dtype" not in kwargs:
-            kwargs["default_dtype"] = "float64"
-        if "device" not in kwargs:
-            kwargs["device"] = "cuda"
+        kwargs.setdefault("default_dtype", "float64")
+        kwargs.setdefault("device", "cuda")
         calculator = MACECalculator(**kwargs)
 
     elif architecture == "mace_mp":
         from mace import __version__
         from mace.calculators import mace_mp
 
-        if "default_dtype" not in kwargs:
-            kwargs["default_dtype"] = "float64"
-        if "device" not in kwargs:
-            kwargs["device"] = "cuda"
-        if "model" not in kwargs:
-            kwargs["model"] = "small"
+        kwargs.setdefault("default_dtype", "float64")
+        kwargs.setdefault("device", "cuda")
+        kwargs.setdefault("model", "small")
         calculator = mace_mp(**kwargs)
 
     elif architecture == "mace_off":
         from mace import __version__
         from mace.calculators import mace_off
 
-        if "default_dtype" not in kwargs:
-            kwargs["default_dtype"] = "float64"
-        if "device" not in kwargs:
-            kwargs["device"] = "cuda"
-        if "model" not in kwargs:
-            kwargs["model"] = "small"
+        kwargs.setdefault("default_dtype", "float64")
+        kwargs.setdefault("device", "cuda")
+        kwargs.setdefault("model", "small")
         calculator = mace_off(**kwargs)
 
     elif architecture == "m3gnet":
         from matgl import __version__, load_model
         from matgl.ext.ase import M3GNetCalculator
 
-        if "model" not in kwargs:
-            model = load_model("M3GNet-MP-2021.2.8-DIRECT-PES")
-        if "stress_weight" not in kwargs:
-            kwargs.setdefault("stress_weight", 1.0 / 160.21766208)
+        model = kwargs.setdefault("model", load_model("M3GNet-MP-2021.2.8-DIRECT-PES"))
+        kwargs.setdefault("stress_weight", 1.0 / 160.21766208)
         calculator = M3GNetCalculator(potential=model, **kwargs)
 
     elif architecture == "chgnet":

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, Optional, Union
 from ase.io import read
 from numpy import ndarray
 
-from janus_core.mlip_calculators import architectures, choose_calculator
+from janus_core.mlip_calculators import architectures, choose_calculator, devices
 
 
 class SinglePoint:
@@ -16,7 +16,7 @@ class SinglePoint:
         self,
         system: str,
         architecture: Literal[architectures] = "mace_mp",
-        device: str = "cpu",
+        device: Literal[devices] = "cpu",
         read_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
@@ -27,10 +27,10 @@ class SinglePoint:
         ----------
         system : str
             System to simulate.
-        architecture : str
+        architecture : Literal[architectures]
             MLIP architecture to use for single point calculations.
             Default is "mace_mp".
-        device : str
+        device : Literal[devices]
             Device to run model on. Default is "cpu".
         read_kwargs : Optional[dict[str, Any]]
             kwargs to pass to ase.io.read. Default is {}.

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -1,12 +1,12 @@
 """Perpare and perform single point calculations."""
 
 import pathlib
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from ase.io import read
 from numpy import ndarray
 
-from janus_core.mlip_calculators import choose_calculator
+from janus_core.mlip_calculators import architectures, choose_calculator
 
 
 class SinglePoint:
@@ -15,7 +15,7 @@ class SinglePoint:
     def __init__(
         self,
         system: str,
-        architecture: str = "mace_mp",
+        architecture: Literal[architectures] = "mace_mp",
         device: str = "cpu",
         read_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
@@ -87,10 +87,7 @@ class SinglePoint:
             Potential energy of system(s).
         """
         if isinstance(self.sys, list):
-            energies = []
-            for sys in self.sys:
-                energies.append(sys.get_potential_energy())
-            return energies
+            return [sys.get_potential_energy() for sys in self.sys]
 
         return self.sys.get_potential_energy()
 
@@ -103,10 +100,7 @@ class SinglePoint:
             Forces of system(s).
         """
         if isinstance(self.sys, list):
-            forces = []
-            for sys in self.sys:
-                forces.append(sys.get_forces())
-            return forces
+            return [sys.get_forces() for sys in self.sys]
 
         return self.sys.get_forces()
 
@@ -119,10 +113,7 @@ class SinglePoint:
             Stress of system(s).
         """
         if isinstance(self.sys, list):
-            stress = []
-            for sys in self.sys:
-                stress.append(sys.get_stress())
-            return stress
+            return [sys.get_stress() for sys in self.sys]
 
         return self.sys.get_stress()
 

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -6,7 +6,7 @@ import pytest
 
 from janus_core.mlip_calculators import choose_calculator
 
-test_data = [
+test_data_mace = [
     (
         "mace",
         "cpu",
@@ -16,8 +16,10 @@ test_data = [
     ("mace_mp", "cpu", {}),
 ]
 
+test_data_extras = [("m3gnet", "cpu"), ("chgnet", "")]
 
-@pytest.mark.parametrize("architecture, device, kwargs", test_data)
+
+@pytest.mark.parametrize("architecture, device, kwargs", test_data_mace)
 def test_mace(architecture, device, kwargs):
     """Test mace calculators can be configured."""
     calculator = choose_calculator(architecture=architecture, device=device, **kwargs)
@@ -25,19 +27,12 @@ def test_mace(architecture, device, kwargs):
 
 
 @pytest.mark.extra_mlips
-def test_m3gnet():
-    """Test m3gnet calculator can be configured."""
+@pytest.mark.parametrize("architecture, device", test_data_extras)
+def test_extra_mlips(architecture, device):
+    """Test m3gnet and chgnet calculators can be configured."""
     calculator = choose_calculator(
-        architecture="m3gnet",
-    )
-    assert calculator.parameters["version"] is not None
-
-
-@pytest.mark.extra_mlips
-def test_chgnet():
-    """Test chgnet calculator can be configured."""
-    calculator = choose_calculator(
-        architecture="chgnet",
+        architecture=architecture,
+        device=device,
     )
     assert calculator.parameters["version"] is not None
 


### PR DESCRIPTION
Resolves #40

Note: There may be a way to pass device to chgnet as well, but currently this makes things consistent between MACE, m3gnet and most likely other PyTorch-based models.

Also tidies single point calculation and calculator code addressing comments in #32.