### PR TITLE
Fix Python versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,17 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install poetry
-      run: pipx install poetry
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install poetry
+      run: pipx install poetry
+
     - name: Install python dependencies
       run: |
+        poetry env use ${{ matrix.python-version }}
         poetry install --with dev
 
     - name: Run test suite
@@ -53,16 +54,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install poetry
-      run: pipx install poetry
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
 
+    - name: Install poetry
+      run: pipx install poetry
+
     - name: Install python dependencies
-      run: poetry install --with docs
+      run: |
+        poetry env use 3.11
+        poetry install --with docs
 
     - name: Build docs
       run: cd docs && poetry run make
@@ -73,16 +77,18 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install poetry
-      run: pipx install poetry
-
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
 
+    - name: Install poetry
+      run: pipx install poetry
+
     - name: Install python dependencies
-      run: poetry install --with pre-commit,docs,dev
+      run: |
+        poetry env use 3.11
+        poetry install --with pre-commit,docs,dev
 
     - name: Run pre-commit
       run: |

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -15,16 +15,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Install poetry
-      run: pipx install poetry
-
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
         python-version: 3.11
 
+    - name: Install poetry
+      run: pipx install poetry
+
     - name: Build project for distribution
-      run: poetry build
+      run: |
+        poetry env use 3.11
+        poetry build
 
     - name: Check Version
       id: check-version


### PR DESCRIPTION
Resolves #41

Note: poetry is still installed with the same version of Python (3.10.12) for each job, but I don't think this is a problem, and the virtual environment created by poetry appears to use the correct Python version.