### PR TITLE
Add initial CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: '3.11'
 
     - name: Install poetry
       run: pipx install poetry
@@ -80,7 +79,7 @@ jobs:
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: '3.11'
 
     - name: Install poetry
       run: pipx install poetry

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: '3.11'
 
     - name: Install poetry
       run: pipx install poetry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,9 @@ repos:
           docs/.*|
       )$
     entry: pylint
+
+- repo: https://github.com/numpy/numpydoc
+  rev: v1.6.0
+  hooks:
+    - id: numpydoc-validation
+      files: ^janus_core/

--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -4,6 +4,16 @@ janus\_core package
 Submodules
 ----------
 
+janus\_core.cli module
+----------------------
+
+.. automodule:: janus_core.cli
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
 janus\_core.geom\_opt module
 ----------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,12 +26,16 @@ import janus_core
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "numpydoc",
     "sphinx.ext.autodoc",
-    "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinxcontrib.contentui",
 ]
+
+numpydoc_validation_checks = {"all", "EX01", "SA01", "ES01"}
+numpydoc_validation_exclude = {r"\.__weakref__$", r"\.__repr__$"}
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/janus_core/__init__.py
+++ b/janus_core/__init__.py
@@ -1,6 +1,3 @@
-"""janus_core.
-
-Tools for machine learnt interatomic potentials.
-"""
+"""Tools for machine learnt interatomic potentials."""
 
 __version__ = "0.1.0a1"

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -62,7 +62,9 @@ def parse_dict_class(value: str):
 
 @app.command()
 def singlepoint(
-    system: Annotated[str, typer.Option(help="Path to system to perform calculations")],
+    structure: Annotated[
+        str, typer.Option(help="Path to structure to perform calculations")
+    ],
     architecture: Annotated[
         str, typer.Option("--arch", help="MLIP architecture to use for calculations")
     ] = "mace_mp",
@@ -96,8 +98,8 @@ def singlepoint(
 
     Parameters
     ----------
-    system : str
-        System to simulate.
+    structure : str
+        Structure to simulate.
     architecture : Optional[str]
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
@@ -119,7 +121,7 @@ def singlepoint(
         raise ValueError("calc_kwargs must be a dictionary")
 
     s_point = SinglePoint(
-        system=system,
+        structure=structure,
         architecture=architecture,
         device=device,
         read_kwargs=read_kwargs,

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -11,12 +11,35 @@ app = typer.Typer()
 
 
 class TyperDict:  #  pylint: disable=too-few-public-methods
-    """Custom dictionary for typer."""
+    """
+    Custom dictionary for typer.
+
+    Parameters
+    ----------
+    value : str
+        Value of string representing a dictionary.
+    """
 
     def __init__(self, value: str):
+        """
+        Initialise class.
+
+        Parameters
+        ----------
+        value : str
+            Value of string representing a dictionary.
+        """
         self.value = value
 
     def __str__(self):
+        """
+        String representation of class.
+
+        Returns
+        -------
+        str
+            Class name and value of string representing a dictionary.
+        """
         return f"<TyperDict: value={self.value}>"
 
 
@@ -83,9 +106,9 @@ def singlepoint(
     properties : Optional[str]
         Physical properties to calculate. Default is "energy".
     read_kwargs : Optional[dict[str, Any]]
-        kwargs to pass to ase.io.read. Default is {}.
+        Keyword arguments to pass to ase.io.read. Default is {}.
     calc_kwargs : Optional[dict[str, Any]]
-        kwargs to pass to the selected calculator. Default is {}.
+        Keyword arguments to pass to the selected calculator. Default is {}.
     """
     read_kwargs = read_kwargs.value if read_kwargs else {}
     calc_kwargs = calc_kwargs.value if calc_kwargs else {}

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -1,0 +1,118 @@
+"""Set up commandline interface."""
+
+import ast
+from typing import Annotated
+
+import typer
+
+from janus_core.single_point import SinglePoint
+
+app = typer.Typer()
+
+
+class TyperDict:  #  pylint: disable=too-few-public-methods
+    """Custom dictionary for typer."""
+
+    def __init__(self, value: str):
+        self.value = value
+
+    def __str__(self):
+        return f"<TyperDict: value={self.value}>"
+
+
+def parse_dict_class(value: str):
+    """
+    Convert string input into a dictionary.
+
+    Parameters
+    ----------
+    value : str
+        String representing dictionary to be parsed.
+
+    Returns
+    -------
+    TyperDict
+        Parsed string as a dictionary.
+    """
+    return TyperDict(ast.literal_eval(value))
+
+
+@app.command()
+def singlepoint(
+    system: Annotated[str, typer.Option(help="Path to system to perform calculations")],
+    architecture: Annotated[
+        str, typer.Option("--arch", help="MLIP architecture to use for calculations")
+    ] = "mace_mp",
+    device: Annotated[str, typer.Option(help="Device to run calculations on")] = "cpu",
+    properties: Annotated[
+        list[str],
+        typer.Option(
+            "--property",
+            help="Properties to calculate. If not specified, 'energy', 'forces', and 'stress' will be returned.",
+        ),
+    ] = None,
+    read_kwargs: Annotated[
+        TyperDict,
+        typer.Option(
+            parser=parse_dict_class,
+            help="Keyword arguments to pass to ase.io.read  [default: {}]",
+            metavar="DICT",
+        ),
+    ] = None,
+    calc_kwargs: Annotated[
+        TyperDict,
+        typer.Option(
+            parser=parse_dict_class,
+            help="Keyword arguments to pass to selected calculator  [default: {}]",
+            metavar="DICT",
+        ),
+    ] = None,
+):
+    """
+    Perform single point calculations.
+
+    Parameters
+    ----------
+    system : str
+        System to simulate.
+    architecture : Optional[str]
+        MLIP architecture to use for single point calculations.
+        Default is "mace_mp".
+    device : Optional[str]
+        Device to run model on. Default is "cpu".
+    properties : Optional[str]
+        Physical properties to calculate. Default is "energy".
+    read_kwargs : Optional[dict[str, Any]]
+        kwargs to pass to ase.io.read. Default is {}.
+    calc_kwargs : Optional[dict[str, Any]]
+        kwargs to pass to the selected calculator. Default is {}.
+    """
+    read_kwargs = read_kwargs.value if read_kwargs else {}
+    calc_kwargs = calc_kwargs.value if calc_kwargs else {}
+
+    if not isinstance(read_kwargs, dict):
+        raise ValueError("read_kwargs must be a dictionary")
+    if not isinstance(calc_kwargs, dict):
+        raise ValueError("calc_kwargs must be a dictionary")
+
+    s_point = SinglePoint(
+        system=system,
+        architecture=architecture,
+        device=device,
+        read_kwargs=read_kwargs,
+        calc_kwargs=calc_kwargs,
+    )
+    print(s_point.run_single_point(properties=properties))
+
+
+@app.command()
+def test(name: str):
+    """
+    Dummy alternative CLI command.
+
+    Parameters
+    ----------
+    name : str
+        Name of person.
+    """
+    print(f"Hello, {name}!")

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -24,7 +24,8 @@ def optimize(
     struct_kwargs: Optional[dict[str, Any]] = None,
     traj_kwargs: Optional[dict[str, Any]] = None,
 ) -> Atoms:
-    """Optimize geometry of input structure.
+    """
+    Optimize geometry of input structure.
 
     Parameters
     ----------
@@ -33,21 +34,21 @@ def optimize(
     fmax : float
         Set force convergence criteria for optimizer in units eV/Å.
     dyn_kwargs : Optional[dict[str, Any]]
-        kwargs to pass to dyn.run. Default is {}.
+        Keyword arguments to pass to dyn.run. Default is {}.
     filter_func : Optional[callable]
         Apply constraints to atoms through ASE filter function.
         Default is `FrechetCellFilter` if available otherwise `ExpCellFilter`.
     filter_kwargs : Optional[dict[str, Any]]
-        kwargs to pass to filter_func. Default is {}.
-    optimzer : callable
+        Keyword arguments to pass to filter_func. Default is {}.
+    optimizer : callable
         ASE optimization function. Default is `LBFGS`.
     opt_kwargs : Optional[dict[str, Any]]
-        kwargs to pass to optimzer. Default is {}.
+        Keyword arguments to pass to optimizer. Default is {}.
     struct_kwargs : Optional[dict[str, Any]]
-        kwargs to pass to ase.io.write to save optimized structure.
+        Keyword arguments to pass to ase.io.write to save optimized structure.
         Must include "filename" keyword. Default is {}.
     traj_kwargs : Optional[dict[str, Any]]
-        kwargs to pass to ase.io.write to save optimization trajectory.
+        Keyword arguments to pass to ase.io.write to save optimization trajectory.
         Must include "filename" keyword. Default is {}.
 
     Returns

--- a/janus_core/mlip_calculators.py
+++ b/janus_core/mlip_calculators.py
@@ -1,6 +1,7 @@
-"""Configure MLIP calculators.
+"""
+Configure MLIP calculators.
 
-Similar in spirit with matcalc and quacc approaches
+Similar in spirit to matcalc and quacc approaches
 - https://github.com/materialsvirtuallab/matcalc
 - https://github.com/Quantum-Accelerators/quacc.git
 """
@@ -15,15 +16,25 @@ devices = ["cpu", "cuda", "mps"]
 
 def choose_calculator(
     architecture: Literal[architectures] = "mace",
-    device: Literal[devices] = "cuda",
+    device: Literal[devices] = "cpu",
     **kwargs,
 ) -> Calculator:
-    """Choose MLIP calculator to configure.
+    """
+    Choose MLIP calculator to configure.
 
     Parameters
     ----------
     architecture : Literal[architectures], optional
         MLIP architecture. Default is "mace".
+    device : Literal[devices]
+        Device to run calculator on. Default is "cpu".
+    **kwargs
+        Additional keyword arguments passed to the selected calculator.
+
+    Returns
+    -------
+    Calculator
+        Configured MLIP calculator.
 
     Raises
     ------
@@ -31,11 +42,6 @@ def choose_calculator(
         MLIP module not correctly been installed.
     ValueError
         Invalid architecture specified.
-
-    Returns
-    -------
-    calculator : Calculator
-        Configured MLIP calculator.
     """
     # pylint: disable=import-outside-toplevel, too-many-branches, import-error
     # Optional imports handled via `architecture`. We could catch these,

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -24,8 +24,8 @@ class SinglePoint:
         Device to run model on. Default is "cpu".
     read_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to ase.io.read. Default is {}.
-    **kwargs
-        Additional keyword arguments passed to the selected calculator.
+    calc_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to the selected calculator. Default is {}.
 
     Attributes
     ----------
@@ -52,7 +52,7 @@ class SinglePoint:
         architecture: Literal[architectures] = "mace_mp",
         device: Literal[devices] = "cpu",
         read_kwargs: Optional[dict[str, Any]] = None,
-        **kwargs,
+        calc_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Read the system being simulated and attach an MLIP calculator.
@@ -68,8 +68,8 @@ class SinglePoint:
             Device to run MLIP model on. Default is "cpu".
         read_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to ase.io.read. Default is {}.
-        **kwargs
-            Additional keyword arguments passed to the selected calculator.
+        calc_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to the selected calculator. Default is {}.
         """
         self.architecture = architecture
         self.device = device
@@ -77,8 +77,9 @@ class SinglePoint:
 
         # Read system and get calculator
         read_kwargs = read_kwargs if read_kwargs else {}
+        calc_kwargs = calc_kwargs if calc_kwargs else {}
         self.read_system(**read_kwargs)
-        self.set_calculator(**kwargs)
+        self.set_calculator(**calc_kwargs)
 
     def read_system(self, **kwargs) -> None:
         """

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -1,4 +1,4 @@
-"""Perpare and perform single point calculations."""
+"""Prepare and perform single point calculations."""
 
 import pathlib
 from typing import Any, Literal, Optional, Union
@@ -10,7 +10,41 @@ from janus_core.mlip_calculators import architectures, choose_calculator, device
 
 
 class SinglePoint:
-    """Perpare and perform single point calculations."""
+    """
+    Prepare and perform single point calculations.
+
+    Parameters
+    ----------
+    system : str
+        System to simulate.
+    architecture : Literal[architectures]
+        MLIP architecture to use for single point calculations.
+        Default is "mace_mp".
+    device : Literal[devices]
+        Device to run model on. Default is "cpu".
+    read_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to ase.io.read. Default is {}.
+    **kwargs
+        Additional keyword arguments passed to the selected calculator.
+
+    Attributes
+    ----------
+    architecture : Literal[architectures]
+        MLIP architecture to use for single point calculations.
+    system : str
+        System to simulate.
+    device : Literal[devices]
+        Device to run MLIP model on.
+
+    Methods
+    -------
+    read_system(**kwargs)
+        Read system and system name.
+    set_calculator(**kwargs)
+        Configure calculator and attach to system.
+    run_single_point(properties=None)
+        Run single point calculations.
+    """
 
     def __init__(
         self,
@@ -21,9 +55,9 @@ class SinglePoint:
         **kwargs,
     ) -> None:
         """
-        Initialise class.
+        Read the system being simulated and attach an MLIP calculator.
 
-        Attributes
+        Parameters
         ----------
         system : str
             System to simulate.
@@ -31,9 +65,11 @@ class SinglePoint:
             MLIP architecture to use for single point calculations.
             Default is "mace_mp".
         device : Literal[devices]
-            Device to run model on. Default is "cpu".
+            Device to run MLIP model on. Default is "cpu".
         read_kwargs : Optional[dict[str, Any]]
-            kwargs to pass to ase.io.read. Default is {}.
+            Keyword arguments to pass to ase.io.read. Default is {}.
+        **kwargs
+            Additional keyword arguments passed to the selected calculator.
         """
         self.architecture = architecture
         self.device = device
@@ -45,10 +81,16 @@ class SinglePoint:
         self.set_calculator(**kwargs)
 
     def read_system(self, **kwargs) -> None:
-        """Read system and system name.
+        """
+        Read system and system name.
 
         If the file contains multiple structures, only the last configuration
         will be read by default.
+
+        Parameters
+        ----------
+        **kwargs
+            Keyword arguments passed to ase.io.read.
         """
         self.sys = read(self.system, **kwargs)
         self.sysname = pathlib.Path(self.system).stem
@@ -56,12 +98,15 @@ class SinglePoint:
     def set_calculator(
         self, read_kwargs: Optional[dict[str, Any]] = None, **kwargs
     ) -> None:
-        """Configure calculator and attach to system.
+        """
+        Configure calculator and attach to system.
 
         Parameters
         ----------
         read_kwargs : Optional[dict[str, Any]]
-            kwargs to pass to ase.io.read. Default is {}.
+            Keyword arguments to pass to ase.io.read. Default is {}.
+        **kwargs
+            Additional keyword arguments passed to the selected calculator.
         """
         calculator = choose_calculator(
             architecture=self.architecture,
@@ -79,11 +124,12 @@ class SinglePoint:
             self.sys.calc = calculator
 
     def _get_potential_energy(self) -> Union[float, list[float]]:
-        """Calculate potential energy using MLIP.
+        """
+        Calculate potential energy using MLIP.
 
         Returns
         -------
-        potential_energy : Union[float, list[float]]
+        Union[float, list[float]]
             Potential energy of system(s).
         """
         if isinstance(self.sys, list):
@@ -92,11 +138,12 @@ class SinglePoint:
         return self.sys.get_potential_energy()
 
     def _get_forces(self) -> Union[ndarray, list[ndarray]]:
-        """Calculate forces using MLIP.
+        """
+        Calculate forces using MLIP.
 
         Returns
         -------
-        forces : Union[ndarray, list[ndarray]]
+        Union[ndarray, list[ndarray]]
             Forces of system(s).
         """
         if isinstance(self.sys, list):
@@ -105,11 +152,12 @@ class SinglePoint:
         return self.sys.get_forces()
 
     def _get_stress(self) -> Union[ndarray, list[ndarray]]:
-        """Calculate stress using MLIP.
+        """
+        Calculate stress using MLIP.
 
         Returns
         -------
-        stress : Union[ndarray, list[ndarray]]
+        Union[ndarray, list[ndarray]]
             Stress of system(s).
         """
         if isinstance(self.sys, list):
@@ -120,7 +168,8 @@ class SinglePoint:
     def run_single_point(
         self, properties: Optional[Union[str, list[str]]] = None
     ) -> dict[str, Any]:
-        """Run single point calculations.
+        """
+        Run single point calculations.
 
         Parameters
         ----------
@@ -130,7 +179,7 @@ class SinglePoint:
 
         Returns
         -------
-        results : dict[str, Any]
+        dict[str, Any]
             Dictionary of calculated results.
         """
         results = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ classifiers = [
 repository = "https://github.com/stfc/janus-core/"
 documentation = "https://stfc.github.io/janus-core/"
 
+[tool.poetry.scripts]
+janus = "janus_core.cli:app"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 ase = "^3.22.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 furo = "^2024.1.29"
 markupsafe = "<2.1"
+numpydoc = "^1.6.0"
 sphinx = "^7.2.6"
 sphinxcontrib-contentui = "^0.2.5"
 sphinxcontrib-details-directive = "^0.1"
@@ -84,3 +85,17 @@ source=["janus_core"]
 line_length = 120
 force_sort_within_sections = true
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
+
+[tool.numpydoc_validation]
+# report on all checks, except the below
+checks = [
+    "all",
+    "EX01",
+    "SA01",
+    "ES01",
+]
+# Don't report on objects that match any of these regex
+exclude = [
+    ".__weakref__$",
+    ".__repr__$",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ documentation = "https://stfc.github.io/janus-core/"
 python = "^3.9"
 ase = "^3.22.1"
 mace-torch = "^0.3.4"
+typer = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^7.4.1"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def test_singlepoint_help():
 
 def test_singlepoint():
     """Test singlepoint calculation."""
-    result = runner.invoke(app, ["singlepoint", "--system", DATA_PATH / "NaCl.cif"])
+    result = runner.invoke(app, ["singlepoint", "--structure", DATA_PATH / "NaCl.cif"])
     assert result.exit_code == 0
     assert "{'energy': -" in result.stdout
     assert "'forces': array" in result.stdout
@@ -42,7 +42,7 @@ def test_singlepoint_properties():
         app,
         [
             "singlepoint",
-            "--system",
+            "--structure",
             DATA_PATH / "NaCl.cif",
             "--property",
             "energy",
@@ -62,7 +62,7 @@ def test_singlepoint_read_kwargs():
         app,
         [
             "singlepoint",
-            "--system",
+            "--structure",
             DATA_PATH / "benzene-traj.xyz",
             "--read-kwargs",
             "{'index': ':'}",
@@ -80,7 +80,7 @@ def test_singlepoint_calc_kwargs():
         app,
         [
             "singlepoint",
-            "--system",
+            "--structure",
             DATA_PATH / "NaCl.cif",
             "--calc-kwargs",
             "{'default_dtype': 'float32'}",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,92 @@
+"""Test commandline interface."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from janus_core.cli import app
+
+DATA_PATH = Path(__file__).parent / "data"
+
+runner = CliRunner()
+
+
+def test_janus_help():
+    """Test calling `janus --help`."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # Command is returned as "root"
+    assert "Usage: root [OPTIONS] COMMAND [ARGS]..." in result.stdout
+
+
+def test_singlepoint_help():
+    """Test calling `janus singlepoint --help`."""
+    result = runner.invoke(app, ["singlepoint", "--help"])
+    assert result.exit_code == 0
+    # Command is returned as "root"
+    assert "Usage: root singlepoint [OPTIONS]" in result.stdout
+
+
+def test_singlepoint():
+    """Test singlepoint calculation."""
+    result = runner.invoke(app, ["singlepoint", "--system", DATA_PATH / "NaCl.cif"])
+    assert result.exit_code == 0
+    assert "{'energy': -" in result.stdout
+    assert "'forces': array" in result.stdout
+    assert "'stress': array" in result.stdout
+
+
+def test_singlepoint_properties():
+    """Test properties for singlepoint calculation."""
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--system",
+            DATA_PATH / "NaCl.cif",
+            "--property",
+            "energy",
+            "--property",
+            "forces",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "{'energy': -" in result.stdout
+    assert "'forces': array" in result.stdout
+    assert "'stress': array" not in result.stdout
+
+
+def test_singlepoint_read_kwargs():
+    """Test setting read_kwargs for singlepoint calculation."""
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--system",
+            DATA_PATH / "benzene-traj.xyz",
+            "--read-kwargs",
+            "{'index': ':'}",
+            "--property",
+            "energy",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "'energy': [" in result.stdout
+
+
+def test_singlepoint_calc_kwargs():
+    """Test setting calc_kwargs for singlepoint calculation."""
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--system",
+            DATA_PATH / "NaCl.cif",
+            "--calc-kwargs",
+            "{'default_dtype': 'float32'}",
+            "--property",
+            "energy",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Using float32 for MACECalculator" in result.stdout

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -40,14 +40,14 @@ test_data = [
 def test_optimize(architecture, structure, expected, kwargs):
     """Test optimizing geometry using MACE."""
     single_point = SinglePoint(
-        system=DATA_PATH / structure,
+        structure=DATA_PATH / structure,
         architecture=architecture,
         calc_kwargs={"model_paths": MODEL_PATH},
     )
 
     init_energy = single_point.run_single_point("energy")["energy"]
 
-    atoms = optimize(single_point.sys, **kwargs)
+    atoms = optimize(single_point.struct, **kwargs)
 
     assert atoms.get_potential_energy() < init_energy
     assert atoms.get_potential_energy() == pytest.approx(expected)
@@ -58,7 +58,7 @@ def test_saving_struct(tmp_path):
     struct_path = tmp_path / "NaCl.xyz"
 
     single_point = SinglePoint(
-        system=DATA_PATH / "NaCl.cif",
+        structure=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -66,7 +66,7 @@ def test_saving_struct(tmp_path):
     init_energy = single_point.run_single_point("energy")["energy"]
 
     optimize(
-        single_point.sys,
+        single_point.struct,
         struct_kwargs={"filename": struct_path, "format": "extxyz"},
     )
     opt_struct = read(struct_path)
@@ -77,11 +77,13 @@ def test_saving_struct(tmp_path):
 def test_saving_traj(tmp_path):
     """Test saving optimization trajectory output."""
     single_point = SinglePoint(
-        system=DATA_PATH / "NaCl.cif",
+        structure=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
-    optimize(single_point.sys, opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")})
+    optimize(
+        single_point.struct, opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")}
+    )
     traj = read(tmp_path / "NaCl.traj", index=":")
     assert len(traj) == 3
 
@@ -89,7 +91,7 @@ def test_saving_traj(tmp_path):
 def test_traj_reformat(tmp_path):
     """Test saving optimization trajectory in different format."""
     single_point = SinglePoint(
-        system=DATA_PATH / "NaCl.cif",
+        structure=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -98,7 +100,7 @@ def test_traj_reformat(tmp_path):
     traj_path_xyz = tmp_path / "NaCl-traj.xyz"
 
     optimize(
-        single_point.sys,
+        single_point.struct,
         opt_kwargs={"trajectory": str(traj_path_binary)},
         traj_kwargs={"filename": traj_path_xyz},
     )
@@ -110,10 +112,10 @@ def test_traj_reformat(tmp_path):
 def test_missing_traj_kwarg(tmp_path):
     """Test saving optimization trajectory in different format."""
     single_point = SinglePoint(
-        system=DATA_PATH / "NaCl.cif",
+        structure=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
     traj_path = tmp_path / "NaCl-traj.xyz"
     with pytest.raises(ValueError):
-        optimize(single_point.sys, traj_kwargs={"filename": traj_path})
+        optimize(single_point.struct, traj_kwargs={"filename": traj_path})

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -16,48 +16,33 @@ DATA_PATH = Path(__file__).parent / "data"
 MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"
 
 test_data = [
-    ("mace", "NaCl.cif", MODEL_PATH, -27.046359959669214, {}),
-    ("mace", "NaCl.cif", MODEL_PATH, -27.04636199814088, {"fmax": 0.001}),
+    ("mace", "NaCl.cif", -27.046359959669214, {}),
+    ("mace", "NaCl.cif", -27.04636199814088, {"fmax": 0.001}),
+    ("mace", "NaCl.cif", -27.0463392211678, {"filter_func": UnitCellFilter}),
+    ("mace", "H2O.cif", -14.051389496520015, {"filter_func": None}),
     (
         "mace",
         "NaCl.cif",
-        MODEL_PATH,
-        -27.0463392211678,
-        {"filter_func": UnitCellFilter},
-    ),
-    ("mace", "H2O.cif", MODEL_PATH, -14.051389496520015, {"filter_func": None}),
-    (
-        "mace",
-        "NaCl.cif",
-        MODEL_PATH,
         -27.04631447979008,
         {"filter_func": UnitCellFilter, "filter_kwargs": {"scalar_pressure": 0.0001}},
     ),
+    ("mace", "NaCl.cif", -27.046353221978332, {"opt_kwargs": {"alpha": 100}}),
     (
         "mace",
         "NaCl.cif",
-        MODEL_PATH,
-        -27.046353221978332,
-        {"opt_kwargs": {"alpha": 100}},
-    ),
-    (
-        "mace",
-        "NaCl.cif",
-        MODEL_PATH,
         -27.03561540212425,
         {"filter_func": UnitCellFilter, "dyn_kwargs": {"steps": 1}},
     ),
 ]
 
 
-@pytest.mark.parametrize(
-    "architecture, structure, model_path, expected, kwargs", test_data
-)
-def test_optimize(architecture, structure, model_path, expected, kwargs):
+@pytest.mark.parametrize("architecture, structure, expected, kwargs", test_data)
+def test_optimize(architecture, structure, expected, kwargs):
     """Test optimizing geometry using MACE."""
-    data_path = DATA_PATH / structure
     single_point = SinglePoint(
-        system=data_path, architecture=architecture, model_paths=model_path
+        system=DATA_PATH / structure,
+        architecture=architecture,
+        calc_kwargs={"model_paths": MODEL_PATH},
     )
 
     init_energy = single_point.run_single_point("energy")["energy"]
@@ -70,10 +55,12 @@ def test_optimize(architecture, structure, model_path, expected, kwargs):
 
 def test_saving_struct(tmp_path):
     """Test saving optimized structure."""
-    data_path = DATA_PATH / "NaCl.cif"
     struct_path = tmp_path / "NaCl.xyz"
+
     single_point = SinglePoint(
-        system=data_path, architecture="mace", model_paths=MODEL_PATH
+        system=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
     )
 
     init_energy = single_point.run_single_point("energy")["energy"]
@@ -89,9 +76,10 @@ def test_saving_struct(tmp_path):
 
 def test_saving_traj(tmp_path):
     """Test saving optimization trajectory output."""
-    data_path = DATA_PATH / "NaCl.cif"
     single_point = SinglePoint(
-        system=data_path, architecture="mace", model_paths=MODEL_PATH
+        system=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
     )
     optimize(single_point.sys, opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")})
     traj = read(tmp_path / "NaCl.traj", index=":")
@@ -100,13 +88,14 @@ def test_saving_traj(tmp_path):
 
 def test_traj_reformat(tmp_path):
     """Test saving optimization trajectory in different format."""
-    data_path = DATA_PATH / "NaCl.cif"
+    single_point = SinglePoint(
+        system=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
+    )
+
     traj_path_binary = tmp_path / "NaCl.traj"
     traj_path_xyz = tmp_path / "NaCl-traj.xyz"
-
-    single_point = SinglePoint(
-        system=data_path, architecture="mace", model_paths=MODEL_PATH
-    )
 
     optimize(
         single_point.sys,
@@ -120,10 +109,11 @@ def test_traj_reformat(tmp_path):
 
 def test_missing_traj_kwarg(tmp_path):
     """Test saving optimization trajectory in different format."""
-    data_path = DATA_PATH / "NaCl.cif"
-    traj_path = tmp_path / "NaCl-traj.xyz"
     single_point = SinglePoint(
-        system=data_path, architecture="mace", model_paths=MODEL_PATH
+        system=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
     )
+    traj_path = tmp_path / "NaCl-traj.xyz"
     with pytest.raises(ValueError):
         optimize(single_point.sys, traj_kwargs={"filename": traj_path})

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -25,13 +25,13 @@ test_data = [
 
 
 @pytest.mark.parametrize(
-    "system, expected, properties, prop_key, calc_kwargs, idx", test_data
+    "structure, expected, properties, prop_key, calc_kwargs, idx", test_data
 )
-def test_potential_energy(system, expected, properties, prop_key, calc_kwargs, idx):
+def test_potential_energy(structure, expected, properties, prop_key, calc_kwargs, idx):
     """Test single point energy using MACE calculators."""
     calc_kwargs["model_paths"] = MODEL_PATH
     single_point = SinglePoint(
-        system=system, architecture="mace", calc_kwargs=calc_kwargs
+        structure=structure, architecture="mace", calc_kwargs=calc_kwargs
     )
     results = single_point.run_single_point(properties)[prop_key]
 
@@ -50,7 +50,7 @@ def test_potential_energy(system, expected, properties, prop_key, calc_kwargs, i
 def test_single_point_none():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(
-        system=DATA_PATH / "NaCl.cif",
+        structure=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -63,13 +63,13 @@ def test_single_point_none():
 def test_single_point_traj():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(
-        system=DATA_PATH / "benzene-traj.xyz",
+        structure=DATA_PATH / "benzene-traj.xyz",
         architecture="mace",
         read_kwargs={"index": ":"},
         calc_kwargs={"model_paths": MODEL_PATH},
     )
 
-    assert len(single_point.sys) == 2
+    assert len(single_point.struct) == 2
     results = single_point.run_single_point("energy")
     assert results["energy"][0] == pytest.approx(-76.0605725422795)
     assert results["energy"][1] == pytest.approx(-74.80419118083256)


### PR DESCRIPTION
Resolves #39 

Adds CLI commands for single point calculations.

Includes a dummy command so that it runs via `janus singlepoint` rather than just `janus`.

To do:
- [x] Add tests

For reference, this doesn't intend to:
- Add logging
- Write output of single point calculations
- Add geometry optimization CLI command

These will be added (via the CLI and otherwise) in future PRs. 