### PR TITLE
Harmonise max line lengths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,13 @@ repos:
   rev: 5.13.2
   hooks:
     - id: isort
+      args: ["--profile=black"]
 
 - repo: https://github.com/psf/black
   rev: 24.1.1
   hooks:
     - id: black
+      args: [--line-length=88]
 
 - repo: local
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,11 @@ torch-dftd = "^0.4.0"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.black]
+line-length = 88
+
 [tool.pylint.format]
-max-line-length = 125
+max-line-length = 88
 max-args = 10
 good-names = ["e"]
 
@@ -82,7 +85,7 @@ source=["janus_core"]
 
 [tool.isort]
 # Configuration of [isort](https://isort.readthedocs.io)
-line_length = 120
+line_length = 88
 force_sort_within_sections = true
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
 


### PR DESCRIPTION
Sets all maximum line lengths to 88, matching the default for black, which we have implicitly been using so far.

We could increase is slightly if there is strong preference, but otherwise I'd suggest `fmt: off` or `# fmt: skip` should be sufficient for rare exceptions.