### PR TITLE
Fix duplicate model_paths kwarg

### DIFF
--- a/janus_core/mlip_calculators.py
+++ b/janus_core/mlip_calculators.py
@@ -58,7 +58,7 @@ def choose_calculator(
         from mace.calculators import mace_mp
 
         kwargs.setdefault("default_dtype", "float64")
-        kwargs.setdefault("model", "small")
+        kwargs["model"] = kwargs.pop("model_paths", "small")
         calculator = mace_mp(**kwargs)
 
     elif architecture == "mace_off":
@@ -66,7 +66,7 @@ def choose_calculator(
         from mace.calculators import mace_off
 
         kwargs.setdefault("default_dtype", "float64")
-        kwargs.setdefault("model", "small")
+        kwargs["model"] = kwargs.pop("model_paths", "small")
         calculator = mace_off(**kwargs)
 
     elif architecture == "m3gnet":

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -14,6 +14,16 @@ test_data_mace = [
     ),
     ("mace_off", "cpu", {}),
     ("mace_mp", "cpu", {}),
+    (
+        "mace_mp",
+        "cpu",
+        {"model_paths": Path(__file__).parent / "models" / "mace_mp_small.model"},
+    ),
+    (
+        "mace_off",
+        "cpu",
+        {"model_paths": "small"},
+    ),
 ]
 
 test_data_extras = [("m3gnet", "cpu"), ("chgnet", "")]


### PR DESCRIPTION
Resolves issue with duplicated `kwargs` for `mace_off` and `mace_mp`.

The new tests throws an error without the fix, e.g.:

```python
E       TypeError: mace.calculators.mace.MACECalculator() got multiple values for keyword argument 'model_paths'

../venv_janus_11_new/lib/python3.11/site-packages/mace/calculators/foundations_models.py:105: TypeError
------------------------------------------------------- Captured stdout call --------------------------------------------------------
Using Materials Project MACE for MACECalculator with /home/ek/.cache/mace/46jrkm3v
Using float64 for MACECalculator, which is slower but more accurate. Recommended for geometry optimization.
====================================================== short test summary info ======================================================
FAILED tests/test_mlip_calculators.py::test_mace[mace_mp-cpu-kwargs3] - TypeError: mace.calculators.mace.MACECalculator() got multiple values for keyword argument 'model_paths'
```