### PR TITLE
Add logger skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.lock
+*.log
 *.pyc
 *.swo
 *.swp

--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -34,6 +34,16 @@ janus\_core.geom\_opt module
    :undoc-members:
    :show-inheritance:
 
+janus\_core.log module
+------------------------------------
+
+.. automodule:: janus_core.log
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
 janus\_core.mlip\_calculators module
 ------------------------------------
 

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -107,6 +107,9 @@ def singlepoint(
             metavar="DICT",
         ),
     ] = None,
+    log_file: Annotated[
+        str, typer.Option("--log", help="File to save logs")
+    ] = "singlepoint.log",
 ):
     """
     Perform single point calculations and save to file.
@@ -128,6 +131,8 @@ def singlepoint(
         Keyword arguments to pass to the selected calculator. Default is {}.
     write_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
+    log_file : Optional[str]
+        Name of log file to write logs to. Default is "singlepoint.log".
     """
     read_kwargs = read_kwargs.value if read_kwargs else {}
     calc_kwargs = calc_kwargs.value if calc_kwargs else {}
@@ -146,6 +151,7 @@ def singlepoint(
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
+        log_file=log_file,
     )
     s_point.run_single_point(
         properties=properties, write_results=True, write_kwargs=write_kwargs

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -108,7 +108,7 @@ def singlepoint(
         ),
     ] = None,
     log_file: Annotated[
-        str, typer.Option("--log", help="File to save logs")
+        Path, typer.Option("--log", help="Path to save logs to")
     ] = "singlepoint.log",
 ):
     """
@@ -131,8 +131,8 @@ def singlepoint(
         Keyword arguments to pass to the selected calculator. Default is {}.
     write_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
-    log_file : Optional[str]
-        Name of log file to write logs to. Default is "singlepoint.log".
+    log_file : Optional[Path]
+        Path to write logs to. Default is "singlepoint.log".
     """
     read_kwargs = read_kwargs.value if read_kwargs else {}
     calc_kwargs = calc_kwargs.value if calc_kwargs else {}

--- a/janus_core/janus_types.py
+++ b/janus_core/janus_types.py
@@ -3,6 +3,8 @@ Module containing types used in Janus-Core.
 """
 
 from collections.abc import Sequence
+from enum import Enum
+import logging
 from pathlib import Path, PurePath
 from typing import IO, Literal, Optional, TypedDict, TypeVar, Union
 
@@ -54,6 +56,18 @@ class ASEOptRunArgs(TypedDict, total=False):
 
     fmax: float
     steps: int
+
+
+class Log(Enum):
+    """Supported options for logger levels."""
+
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+
+
+LogType = Literal[Log.DEBUG, Log.INFO, Log.ERROR, Log.WARNING]
 
 
 # Janus specific

--- a/janus_core/janus_types.py
+++ b/janus_core/janus_types.py
@@ -58,16 +58,13 @@ class ASEOptRunArgs(TypedDict, total=False):
     steps: int
 
 
-class Log(Enum):
+class LogLevel(Enum):
     """Supported options for logger levels."""
 
     DEBUG = logging.DEBUG
     INFO = logging.INFO
     WARNING = logging.WARNING
     ERROR = logging.ERROR
-
-
-LogType = Literal[Log.DEBUG, Log.INFO, Log.ERROR, Log.WARNING]
 
 
 # Janus specific

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -1,0 +1,51 @@
+"""Configure logger."""
+
+import logging
+
+from janus_core.janus_types import LogType
+
+FORMAT = """
+- timestamp: %(asctime)s
+  level: %(levelname)s
+  message: %(message)s
+  trace: %(module)s
+  line: %(lineno)d
+""".strip()
+
+
+def config_logger(
+    name: str,
+    level: LogType = logging.INFO,
+    filename: str = "janus.log",
+    capture_warnings: bool = True,
+):
+    """
+    Configure logger.
+
+    Parameters
+    ----------
+    name : str
+        Name of logger.
+    level : LogType
+        Threshold for logger. Default is logging.INFO.
+    filename : str
+        Name of log file to write logs to. Default is "janus.log".
+    capture_warnings : bool
+        Whether to capture warnings in log. Default is True.
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger.
+    """
+    logger = logging.getLogger(name)
+    logging.basicConfig(
+        level=level,
+        filename=filename,
+        filemode="w",
+        format=FORMAT,
+        encoding="utf-8",
+    )
+    logging.captureWarnings(capture=capture_warnings)
+
+    return logger

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -1,8 +1,9 @@
-"""Configure logger."""
+"""Configure logger with yaml-styled format."""
 
 import logging
+from typing import Optional
 
-from janus_core.janus_types import LogType
+from janus_core.janus_types import LogLevel
 
 FORMAT = """
 - timestamp: %(asctime)s
@@ -15,37 +16,40 @@ FORMAT = """
 
 def config_logger(
     name: str,
-    level: LogType = logging.INFO,
-    filename: str = "janus.log",
+    filename: Optional[str] = None,
+    level: LogLevel = logging.INFO,
     capture_warnings: bool = True,
 ):
     """
-    Configure logger.
+    Configure logger with yaml-styled format.
 
     Parameters
     ----------
     name : str
-        Name of logger.
-    level : LogType
+        Name of logger. Default is None.
+    filename : Optional[str]
+        Name of log file if writing logs. Default is None.
+    level : LogLevel
         Threshold for logger. Default is logging.INFO.
-    filename : str
-        Name of log file to write logs to. Default is "janus.log".
     capture_warnings : bool
         Whether to capture warnings in log. Default is True.
 
     Returns
     -------
-    logging.Logger
-        Configured logger.
+    Optional[logging.Logger]
+        Configured logger if `filename` has been specified.
     """
-    logger = logging.getLogger(name)
-    logging.basicConfig(
-        level=level,
-        filename=filename,
-        filemode="w",
-        format=FORMAT,
-        encoding="utf-8",
-    )
-    logging.captureWarnings(capture=capture_warnings)
+    if filename:
+        logger = logging.getLogger(name)
 
+        logging.basicConfig(
+            level=level,
+            filename=filename,
+            filemode="w",
+            format=FORMAT,
+            encoding="utf-8",
+        )
+        logging.captureWarnings(capture=capture_warnings)
+    else:
+        logger = None
     return logger

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -16,6 +16,7 @@ from janus_core.janus_types import (
     Devices,
     MaybeList,
     MaybeSequence,
+    PathLike,
 )
 from janus_core.log import config_logger
 from janus_core.mlip_calculators import choose_calculator
@@ -45,7 +46,7 @@ class SinglePoint:
         Keyword arguments to pass to ase.io.read. Default is {}.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
-    log_file : Optional[str]
+    log_file : Optional[PathLike]
         Name of log file if writing logs. Default is None.
 
     Attributes
@@ -82,7 +83,7 @@ class SinglePoint:
         device: Devices = "cpu",
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
-        log_file: Optional[str] = None,
+        log_file: Optional[PathLike] = None,
     ) -> None:
         """
         Read the structure being simulated and attach an MLIP calculator.
@@ -107,7 +108,7 @@ class SinglePoint:
             Keyword arguments to pass to ase.io.read. Default is {}.
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
-        log_file : Optional[str]
+        log_file : Optional[PathLike]
             Name of log file if writing logs. Default is None.
         """
         if struct and struct_path:
@@ -122,10 +123,7 @@ class SinglePoint:
                 "or a path to the structure file (`struct_path`)"
             )
 
-        if log_file is not None:
-            self.logger = config_logger(name=__name__, filename=log_file)
-        else:
-            self.logger = None
+        self.logger = config_logger(name=__name__, filename=log_file)
 
         read_kwargs = read_kwargs if read_kwargs else {}
         calc_kwargs = calc_kwargs if calc_kwargs else {}
@@ -319,7 +317,7 @@ class SinglePoint:
         if write_kwargs and "filename" not in write_kwargs:
             raise ValueError("'filename' must be included in write_kwargs")
 
-        if self.logger is not None:
+        if self.logger:
             self.logger.info("Starting single point calculation")
 
         if "energy" in properties or len(properties) == 0:
@@ -331,7 +329,7 @@ class SinglePoint:
 
         self._clean_results(properties=properties)
 
-        if self.logger is not None:
+        if self.logger:
             self.logger.info("Single point calculation complete")
 
         if write_results:

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -8,9 +8,7 @@ from ase import Atoms
 from ase.io import read, write
 from numpy import isfinite, ndarray
 
-from janus_core.mlip_calculators import choose_calculator
-
-from .janus_types import (
+from janus_core.janus_types import (
     Architectures,
     ASEReadArgs,
     ASEWriteArgs,
@@ -19,6 +17,8 @@ from .janus_types import (
     MaybeList,
     MaybeSequence,
 )
+from janus_core.log import config_logger
+from janus_core.mlip_calculators import choose_calculator
 
 
 class SinglePoint:
@@ -45,6 +45,8 @@ class SinglePoint:
         Keyword arguments to pass to ase.io.read. Default is {}.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
+    log_file : Optional[str]
+        Name of log file if writing logs. Default is None.
 
     Attributes
     ----------
@@ -58,6 +60,8 @@ class SinglePoint:
         Path of structure to simulate.
     struct_name : Optional[str]
         Name of structure.
+    logger : logging.Logger
+        Logger if log file has been specified.
 
     Methods
     -------
@@ -78,6 +82,7 @@ class SinglePoint:
         device: Devices = "cpu",
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
+        log_file: Optional[str] = None,
     ) -> None:
         """
         Read the structure being simulated and attach an MLIP calculator.
@@ -102,6 +107,8 @@ class SinglePoint:
             Keyword arguments to pass to ase.io.read. Default is {}.
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
+        log_file : Optional[str]
+            Name of log file if writing logs. Default is None.
         """
         if struct and struct_path:
             raise ValueError(
@@ -114,6 +121,11 @@ class SinglePoint:
                 "Please specify either the ASE Atoms structure (`struct`) "
                 "or a path to the structure file (`struct_path`)"
             )
+
+        if log_file is not None:
+            self.logger = config_logger(name=__name__, filename=log_file)
+        else:
+            self.logger = None
 
         read_kwargs = read_kwargs if read_kwargs else {}
         calc_kwargs = calc_kwargs if calc_kwargs else {}
@@ -307,6 +319,9 @@ class SinglePoint:
         if write_kwargs and "filename" not in write_kwargs:
             raise ValueError("'filename' must be included in write_kwargs")
 
+        if self.logger is not None:
+            self.logger.info("Starting single point calculation")
+
         if "energy" in properties or len(properties) == 0:
             results["energy"] = self._get_potential_energy()
         if "forces" in properties or len(properties) == 0:
@@ -315,6 +330,9 @@ class SinglePoint:
             results["stress"] = self._get_stress()
 
         self._clean_results(properties=properties)
+
+        if self.logger is not None:
+            self.logger.info("Single point calculation complete")
 
         if write_results:
             if "filename" not in write_kwargs:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,3 +155,25 @@ def test_singlepoint_default_write():
     assert "forces" in atoms.arrays
 
     results_path.unlink()
+
+
+def test_singlepoint_log(tmp_path, caplog):
+    """Test log correctly written for singlepoint."""
+    results_path = tmp_path / "NaCl-results.xyz"
+    with caplog.at_level("INFO", logger="janus_core.single_point"):
+        result = runner.invoke(
+            app,
+            [
+                "singlepoint",
+                "--struct",
+                DATA_PATH / "NaCl.cif",
+                "--property",
+                "energy",
+                "--write-kwargs",
+                f"{{'filename': '{str(results_path)}'}}",
+                "--log",
+                f"{tmp_path}/test.log",
+            ],
+        )
+        assert "Starting single point calculation" in caplog.text
+        assert result.exit_code == 0


### PR DESCRIPTION
Resolves #52

Adds a skeleton for logging, that currently just captures the start and end times for the single point calculation and saves to a log file, so the CLI behaves as expected for aiida-mlip.

I'm not sure there's a way to test the log file more rigorously, as pytest seems to interfere, but it at least tests the contents of the log.