### PR TITLE
Add option to pass Atoms structure directly

### DIFF
--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -1,6 +1,7 @@
 """Set up commandline interface."""
 
 import ast
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -62,8 +63,8 @@ def parse_dict_class(value: str):
 
 @app.command()
 def singlepoint(
-    structure: Annotated[
-        str, typer.Option(help="Path to structure to perform calculations")
+    struct_path: Annotated[
+        Path, typer.Option("--struct", help="Path of structure to simulate")
     ],
     architecture: Annotated[
         str, typer.Option("--arch", help="MLIP architecture to use for calculations")
@@ -112,8 +113,8 @@ def singlepoint(
 
     Parameters
     ----------
-    structure : str
-        Structure to simulate.
+    struct_path : Path
+        Path of structure to simulate.
     architecture : Optional[str]
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
@@ -140,7 +141,7 @@ def singlepoint(
         raise ValueError("write_kwargs must be a dictionary")
 
     s_point = SinglePoint(
-        structure=structure,
+        struct_path=struct_path,
         architecture=architecture,
         device=device,
         read_kwargs=read_kwargs,

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -28,7 +28,7 @@ class SinglePoint:
     Parameters
     ----------
     struct : Optional[MaybeSequence[Atoms]]
-        Structure or list of structures to simulate. Required if `struct_path` is None.
+        ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
         Default is None.
     struct_path : Optional[str]
         Path of structure to simulate. Required if `struct` is None.
@@ -51,7 +51,7 @@ class SinglePoint:
     architecture : Architectures
         MLIP architecture to use for single point calculations.
     struct : MaybeSequence[Atoms]
-        ASE Atoms or list of Atoms structures to simulate.
+        ASE Atoms structure(s) to simulate.
     device : Devices
         Device to run MLIP model on.
     struct_path : Optional[str]
@@ -85,8 +85,8 @@ class SinglePoint:
         Parameters
         ----------
         struct : Optional[MaybeSequence[Atoms]]
-            Structure or list of structures to simulate.
-            Required if `struct_path` is None. Default is None.
+            ASE Atoms structure(s) to simulate. Required if `struct_path`
+            is None. Default is None.
         struct_path : Optional[str]
             Path of structure to simulate. Required if `struct` is None.
             Default is None.
@@ -104,10 +104,16 @@ class SinglePoint:
             Keyword arguments to pass to the selected calculator. Default is {}.
         """
         if struct and struct_path:
-            raise ValueError("Only one of `struct` and `struct_path` may be specified")
+            raise ValueError(
+                "You cannot specify both the ASE Atoms structure (`struct`) "
+                "and a path to the structure file (`struct_path`)"
+            )
 
         if not struct and not struct_path:
-            raise ValueError("Please specify either `struct` or `struct_path`")
+            raise ValueError(
+                "Please specify either the ASE Atoms structure (`struct`) "
+                "or a path to the structure file (`struct_path`)"
+            )
 
         read_kwargs = read_kwargs if read_kwargs else {}
         calc_kwargs = calc_kwargs if calc_kwargs else {}
@@ -228,7 +234,7 @@ class SinglePoint:
         Parameters
         ----------
         struct : Atoms
-            Structure with attached results from calculator.
+            ASE Atoms structure with attached calculator results.
         properties : Collection[str]
             Physical properties requested to be calculated. Default is ().
         """

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -34,8 +34,8 @@ class SinglePoint:
         Path of structure to simulate. Required if `struct` is None.
         Default is None.
     struct_name : Optional[str]
-        Name of structure. Default is "struct" if `struct` is specified, else
-        inferred from `struct_path`.
+        Name of structure. Default is inferred from chemical formula if `struct`
+        is specified, else inferred from `struct_path`.
     architecture : Literal[architectures]
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
@@ -91,8 +91,8 @@ class SinglePoint:
             Path of structure to simulate. Required if `struct` is None.
             Default is None.
         struct_name : Optional[str]
-            Name of structure. Default is "struct" if `struct` is specified, else
-            inferred from `struct_path`.
+            Name of structure. Default is inferred from chemical formula if `struct`
+            is specified, else inferred from `struct_path`.
         architecture : Architectures
             MLIP architecture to use for single point calculations.
             Default is "mace_mp".
@@ -123,7 +123,7 @@ class SinglePoint:
         else:
             self.struct = struct
             if not self.struct_name:
-                self.struct_name = "struct"
+                self.struct_name = self.struct.get_chemical_formula()
 
         # Configure calculator
         self.set_calculator(**calc_kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ def test_singlepoint(tmp_path):
         app,
         [
             "singlepoint",
-            "--structure",
+            "--struct",
             DATA_PATH / "NaCl.cif",
             "--write-kwargs",
             f"{{'filename': '{str(results_path)}'}}",
@@ -58,7 +58,7 @@ def test_singlepoint_properties(tmp_path):
         app,
         [
             "singlepoint",
-            "--structure",
+            "--struct",
             DATA_PATH / "H2O.cif",
             "--property",
             "energy",
@@ -76,7 +76,7 @@ def test_singlepoint_properties(tmp_path):
         app,
         [
             "singlepoint",
-            "--structure",
+            "--struct",
             DATA_PATH / "H2O.cif",
             "--property",
             "stress",
@@ -97,7 +97,7 @@ def test_singlepoint_read_kwargs(tmp_path):
         app,
         [
             "singlepoint",
-            "--structure",
+            "--struct",
             DATA_PATH / "benzene-traj.xyz",
             "--read-kwargs",
             "{'index': ':'}",
@@ -121,7 +121,7 @@ def test_singlepoint_calc_kwargs(tmp_path):
         app,
         [
             "singlepoint",
-            "--structure",
+            "--struct",
             DATA_PATH / "NaCl.cif",
             "--calc-kwargs",
             "{'default_dtype': 'float32'}",
@@ -144,7 +144,7 @@ def test_singlepoint_default_write():
         app,
         [
             "singlepoint",
-            "--structure",
+            "--struct",
             DATA_PATH / "NaCl.cif",
             "--property",
             "energy",

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -36,11 +36,11 @@ test_data = [
 ]
 
 
-@pytest.mark.parametrize("architecture, structure, expected, kwargs", test_data)
-def test_optimize(architecture, structure, expected, kwargs):
+@pytest.mark.parametrize("architecture, struct_path, expected, kwargs", test_data)
+def test_optimize(architecture, struct_path, expected, kwargs):
     """Test optimizing geometry using MACE."""
     single_point = SinglePoint(
-        structure=DATA_PATH / structure,
+        struct_path=DATA_PATH / struct_path,
         architecture=architecture,
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -58,7 +58,7 @@ def test_saving_struct(tmp_path):
     struct_path = tmp_path / "NaCl.xyz"
 
     single_point = SinglePoint(
-        structure=DATA_PATH / "NaCl.cif",
+        struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -77,7 +77,7 @@ def test_saving_struct(tmp_path):
 def test_saving_traj(tmp_path):
     """Test saving optimization trajectory output."""
     single_point = SinglePoint(
-        structure=DATA_PATH / "NaCl.cif",
+        struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -91,7 +91,7 @@ def test_saving_traj(tmp_path):
 def test_traj_reformat(tmp_path):
     """Test saving optimization trajectory in different format."""
     single_point = SinglePoint(
-        structure=DATA_PATH / "NaCl.cif",
+        struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -112,7 +112,7 @@ def test_traj_reformat(tmp_path):
 def test_missing_traj_kwarg(tmp_path):
     """Test saving optimization trajectory in different format."""
     single_point = SinglePoint(
-        structure=DATA_PATH / "NaCl.cif",
+        struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -175,7 +175,7 @@ def test_default_atoms_name():
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
-    assert single_point.struct_name == "struct"
+    assert single_point.struct_name == "Cl4Na4"
 
 
 def test_default_path_name():

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -27,13 +27,15 @@ test_data = [
 
 
 @pytest.mark.parametrize(
-    "structure, expected, properties, prop_key, calc_kwargs, idx", test_data
+    "struct_path, expected, properties, prop_key, calc_kwargs, idx", test_data
 )
-def test_potential_energy(structure, expected, properties, prop_key, calc_kwargs, idx):
+def test_potential_energy(
+    struct_path, expected, properties, prop_key, calc_kwargs, idx
+):
     """Test single point energy using MACE calculators."""
     calc_kwargs["model_paths"] = MODEL_PATH
     single_point = SinglePoint(
-        structure=structure, architecture="mace", calc_kwargs=calc_kwargs
+        struct_path=struct_path, architecture="mace", calc_kwargs=calc_kwargs
     )
     results = single_point.run_single_point(properties)[prop_key]
 
@@ -52,7 +54,7 @@ def test_potential_energy(structure, expected, properties, prop_key, calc_kwargs
 def test_single_point_none():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(
-        structure=DATA_PATH / "NaCl.cif",
+        struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -65,7 +67,7 @@ def test_single_point_none():
 def test_single_point_traj():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(
-        structure=DATA_PATH / "benzene-traj.xyz",
+        struct_path=DATA_PATH / "benzene-traj.xyz",
         architecture="mace",
         read_kwargs={"index": ":"},
         calc_kwargs={"model_paths": MODEL_PATH},
@@ -84,7 +86,7 @@ def test_single_point_write():
     assert not Path(results_path).exists()
 
     single_point = SinglePoint(
-        structure=data_path,
+        struct_path=data_path,
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -104,7 +106,7 @@ def test_single_point_write_kwargs(tmp_path):
     results_path = tmp_path / "NaCl.xyz"
 
     single_point = SinglePoint(
-        structure=data_path,
+        struct_path=data_path,
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -123,7 +125,7 @@ def test_single_point_write_nan(tmp_path):
     data_path = DATA_PATH / "H2O.cif"
     results_path = tmp_path / "H2O.xyz"
     single_point = SinglePoint(
-        structure=data_path,
+        struct_path=data_path,
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
@@ -144,9 +146,78 @@ def test_single_point_write_nan(tmp_path):
 def test_invalid_prop():
     """Test invalid property request."""
     single_point = SinglePoint(
-        structure=DATA_PATH / "H2O.cif",
+        struct_path=DATA_PATH / "H2O.cif",
         architecture="mace",
         calc_kwargs={"model_paths": MODEL_PATH},
     )
     with pytest.raises(NotImplementedError):
         single_point.run_single_point("invalid")
+
+
+def test_atoms():
+    """Test passing ASE Atoms structure."""
+    struct = read(DATA_PATH / "NaCl.cif")
+    single_point = SinglePoint(
+        struct=struct,
+        struct_name="NaCl",
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
+    )
+    assert single_point.struct_name == "NaCl"
+    assert single_point.run_single_point("energy")["energy"] < 0
+
+
+def test_default_atoms_name():
+    """Test default structure name when passing ASE Atoms structure."""
+    struct = read(DATA_PATH / "NaCl.cif")
+    single_point = SinglePoint(
+        struct=struct,
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
+    )
+    assert single_point.struct_name == "struct"
+
+
+def test_default_path_name():
+    """Test default structure name when passing structure path."""
+    struct_path = DATA_PATH / "NaCl.cif"
+    single_point = SinglePoint(
+        struct_path=struct_path,
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
+    )
+    assert single_point.struct_name == "NaCl"
+
+
+def test_path_specify_name():
+    """Test specifying structure name with structure path."""
+    struct_path = DATA_PATH / "NaCl.cif"
+    single_point = SinglePoint(
+        struct_path=struct_path,
+        struct_name="example_name",
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
+    )
+    assert single_point.struct_name == "example_name"
+
+
+def test_atoms_and_path():
+    """Test passing ASE Atoms structure and structure path togther."""
+    struct = read(DATA_PATH / "NaCl.cif")
+    struct_path = DATA_PATH / "NaCl.cif"
+    with pytest.raises(ValueError):
+        SinglePoint(
+            struct=struct,
+            struct_path=struct_path,
+            architecture="mace",
+            calc_kwargs={"model_paths": MODEL_PATH},
+        )
+
+
+def test_no_atoms_or_path():
+    """Test passing neither ASE Atoms structure nor structure path."""
+    with pytest.raises(ValueError):
+        SinglePoint(
+            architecture="mace",
+            calc_kwargs={"model_paths": MODEL_PATH},
+        )


### PR DESCRIPTION
Resolves #47

As mentioned  in #49, my preference is not to overload something like `read_struct`, as was originally proposed in #47, but to separate reading from file (which could be overloaded for non-ASE readers) with passing a structure directly (which could also include non-ASE objects in future).

This is largely to enable changing the confusingly named `structure` (as opposed to `struct`) attribute to `struct_path`.