### PR TITLE
Fix removing NaN results

### DIFF
--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -64,6 +64,20 @@ def test_single_point_none():
         assert prop in results
 
 
+def test_single_point_clean():
+    """Test single point stress using MACE calculator."""
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "H2O.cif",
+        architecture="mace",
+        calc_kwargs={"model_paths": MODEL_PATH},
+    )
+
+    results = single_point.run_single_point()
+    for prop in ["energy", "forces"]:
+        assert prop in results
+    assert "stress" not in results
+
+
 def test_single_point_traj():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(


### PR DESCRIPTION
Resolves #66

Ideally, we'd probably remove the separate `results` dictionary and rely on clean-up of `calc.results`, but we would still need something of similar form in order to return lists of properties for trajectories.

An alternative could be to remove setting results until after clean-up, but then we don't make use of the values returned by `Atoms.get_potential_energy` etc. This might still be slightly tidier, but is perhaps slightly more dangerous too given that MACE sets multiple results simultaneously, so in many cases, `energy` would be taken from the results from `get_stress`.