### PR TITLE
Fix model path kwargs

### DIFF
--- a/janus_core/mlip_calculators.py
+++ b/janus_core/mlip_calculators.py
@@ -43,10 +43,17 @@ def choose_calculator(
     # pylint: disable=import-outside-toplevel, too-many-branches, import-error
     # Optional imports handled via `architecture`. We could catch these,
     # but the error message is clear if imports are missing.
+    if "model" in kwargs and "model_paths" in kwargs:
+        raise ValueError("Please specify either `model` or `model_paths`")
+
     if architecture == "mace":
         from mace import __version__
         from mace.calculators import MACECalculator
 
+        # `model_paths` is keyword for path to model, so take from kwargs if specified
+        # Otherwise, take `model` if specified, then default to `None`, which will
+        # raise a ValueError
+        kwargs.setdefault("model_paths", kwargs.pop("model", None))
         kwargs.setdefault("default_dtype", "float64")
         calculator = MACECalculator(device=device, **kwargs)
 
@@ -54,16 +61,20 @@ def choose_calculator(
         from mace import __version__
         from mace.calculators import mace_mp
 
+        # `model` is keyword for path to model, so take from kwargs if specified
+        # Otherwise, take `model_paths` if specified, then default to "small"
+        kwargs.setdefault("model", kwargs.pop("model_paths", "small"))
         kwargs.setdefault("default_dtype", "float64")
-        kwargs["model"] = kwargs.pop("model_paths", "small")
         calculator = mace_mp(**kwargs)
 
     elif architecture == "mace_off":
         from mace import __version__
         from mace.calculators import mace_off
 
+        # `model` is keyword for path to model, so take from kwargs if specified
+        # Otherwise, take `model_paths` if specified, then default to "small"
+        kwargs.setdefault("model", kwargs.pop("model_paths", "small"))
         kwargs.setdefault("default_dtype", "float64")
-        kwargs["model"] = kwargs.pop("model_paths", "small")
         calculator = mace_off(**kwargs)
 
     elif architecture == "m3gnet":

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -42,7 +42,7 @@ def test_optimize(architecture, struct_path, expected, kwargs):
     single_point = SinglePoint(
         struct_path=DATA_PATH / struct_path,
         architecture=architecture,
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
 
     init_energy = single_point.run_single_point("energy")["energy"]
@@ -60,7 +60,7 @@ def test_saving_struct(tmp_path):
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
 
     init_energy = single_point.run_single_point("energy")["energy"]
@@ -79,7 +79,7 @@ def test_saving_traj(tmp_path):
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     optimize(
         single_point.struct, opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")}
@@ -93,7 +93,7 @@ def test_traj_reformat(tmp_path):
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
 
     traj_path_binary = tmp_path / "NaCl.traj"
@@ -114,7 +114,7 @@ def test_missing_traj_kwarg(tmp_path):
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     traj_path = tmp_path / "NaCl-traj.xyz"
     with pytest.raises(ValueError):

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -6,24 +6,15 @@ import pytest
 
 from janus_core.mlip_calculators import choose_calculator
 
+MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"
+
 test_data_mace = [
-    (
-        "mace",
-        "cpu",
-        {"model_paths": Path(__file__).parent / "models" / "mace_mp_small.model"},
-    ),
+    ("mace", "cpu", {"model": MODEL_PATH}),
+    ("mace", "cpu", {"model_paths": MODEL_PATH}),
     ("mace_off", "cpu", {}),
     ("mace_mp", "cpu", {}),
-    (
-        "mace_mp",
-        "cpu",
-        {"model_paths": Path(__file__).parent / "models" / "mace_mp_small.model"},
-    ),
-    (
-        "mace_off",
-        "cpu",
-        {"model_paths": "small"},
-    ),
+    ("mace_mp", "cpu", {"model": MODEL_PATH}),
+    ("mace_off", "cpu", {"model": "small"}),
 ]
 
 test_data_extras = [("m3gnet", "cpu"), ("chgnet", "")]
@@ -51,3 +42,25 @@ def test_invalid_arch():
     """Test error raised for invalid architecture."""
     with pytest.raises(ValueError):
         choose_calculator(architecture="invalid")
+
+
+def test_model_model_paths():
+    """Test error raised if both model and model_paths are specified."""
+    with pytest.raises(ValueError):
+        choose_calculator(
+            architecture="mace",
+            model=MODEL_PATH,
+            model_paths=MODEL_PATH,
+        )
+    with pytest.raises(ValueError):
+        choose_calculator(
+            architecture="mace_mp",
+            model=MODEL_PATH,
+            model_paths=MODEL_PATH,
+        )
+    with pytest.raises(ValueError):
+        choose_calculator(
+            architecture="mace_off",
+            model=MODEL_PATH,
+            model_paths=MODEL_PATH,
+        )

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -33,7 +33,7 @@ def test_potential_energy(
     struct_path, expected, properties, prop_key, calc_kwargs, idx
 ):
     """Test single point energy using MACE calculators."""
-    calc_kwargs["model_paths"] = MODEL_PATH
+    calc_kwargs["model"] = MODEL_PATH
     single_point = SinglePoint(
         struct_path=struct_path, architecture="mace", calc_kwargs=calc_kwargs
     )
@@ -56,7 +56,7 @@ def test_single_point_none():
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
 
     results = single_point.run_single_point()
@@ -69,7 +69,7 @@ def test_single_point_clean():
     single_point = SinglePoint(
         struct_path=DATA_PATH / "H2O.cif",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
 
     results = single_point.run_single_point()
@@ -84,7 +84,7 @@ def test_single_point_traj():
         struct_path=DATA_PATH / "benzene-traj.xyz",
         architecture="mace",
         read_kwargs={"index": ":"},
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
 
     assert len(single_point.struct) == 2
@@ -102,7 +102,7 @@ def test_single_point_write():
     single_point = SinglePoint(
         struct_path=data_path,
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     assert "forces" not in single_point.struct.arrays
 
@@ -122,7 +122,7 @@ def test_single_point_write_kwargs(tmp_path):
     single_point = SinglePoint(
         struct_path=data_path,
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     assert "forces" not in single_point.struct.arrays
 
@@ -141,7 +141,7 @@ def test_single_point_write_nan(tmp_path):
     single_point = SinglePoint(
         struct_path=data_path,
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
 
     assert isfinite(single_point.run_single_point("energy")["energy"]).all()
@@ -162,7 +162,7 @@ def test_invalid_prop():
     single_point = SinglePoint(
         struct_path=DATA_PATH / "H2O.cif",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     with pytest.raises(NotImplementedError):
         single_point.run_single_point("invalid")
@@ -175,7 +175,7 @@ def test_atoms():
         struct=struct,
         struct_name="NaCl",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     assert single_point.struct_name == "NaCl"
     assert single_point.run_single_point("energy")["energy"] < 0
@@ -187,7 +187,7 @@ def test_default_atoms_name():
     single_point = SinglePoint(
         struct=struct,
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     assert single_point.struct_name == "Cl4Na4"
 
@@ -198,7 +198,7 @@ def test_default_path_name():
     single_point = SinglePoint(
         struct_path=struct_path,
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     assert single_point.struct_name == "NaCl"
 
@@ -210,7 +210,7 @@ def test_path_specify_name():
         struct_path=struct_path,
         struct_name="example_name",
         architecture="mace",
-        calc_kwargs={"model_paths": MODEL_PATH},
+        calc_kwargs={"model": MODEL_PATH},
     )
     assert single_point.struct_name == "example_name"
 
@@ -224,7 +224,7 @@ def test_atoms_and_path():
             struct=struct,
             struct_path=struct_path,
             architecture="mace",
-            calc_kwargs={"model_paths": MODEL_PATH},
+            calc_kwargs={"model": MODEL_PATH},
         )
 
 
@@ -233,5 +233,5 @@ def test_no_atoms_or_path():
     with pytest.raises(ValueError):
         SinglePoint(
             architecture="mace",
-            calc_kwargs={"model_paths": MODEL_PATH},
+            calc_kwargs={"model": MODEL_PATH},
         )


### PR DESCRIPTION
As reported by @federicazanca, currently if you specify `model` rather than `model_paths` in `kwargs` for `mace_mp`, it will default to using `"small"`, as it expects the value to only be defined through `model_paths`.

This can be confusing, as `mace_mp` (and `mace_off`, but that doesn't accept paths in the expected way anyway) expects the `model` keyword.

These changes ensure only one of `model_paths` and `model` are specified, but allows either to be defined.

Also changes `model_paths` to `model` in various places (mostly tests), as I think it's usually more accurate, particularly as `mace_mp` is our default. 