### PR TITLE
Add geomopt to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,11 @@ poetry add git+https://gitlab.com:ase/ase.git#b31569210d739bd12c8ad2b6ec0290108e
 
 ## Examples
 
-Perform a single point calcuation:
+### Single Point Calculations
+
+Perform a single point calcuation (using the [MACE-MP](https://github.com/ACEsuit/mace-mp) "small" force-field):
 ```shell
-janus singlepoint --struct tests/data/NaCl.cif
+janus singlepoint --struct tests/data/NaCl.cif --arch mace_mp --calc-kwargs "{'model' : 'small'}"
 ```
 
 This will calculate the energy, stress and forces and save this in `NaCl-results.xyz`, in addition to generating a log file, `singlepoint.log`.
@@ -72,17 +74,22 @@ This will calculate the energy, stress and forces and save this in `NaCl-results
 Additional options may be specified. For example:
 
 ```shell
-janus singlepoint --struct tests/data/NaCl.cif --property energy --arch mace_mp --calc-kwargs "{'model' : './tests/models/mace_mp_small.model'}" --log './example.log' --write-kwargs "{'filename': './example.xyz'}"
+janus singlepoint --struct tests/data/NaCl.cif --arch mace --calc-kwargs "{'model' : '/path/to/your/ml.model'}" --property energy --log './example.log' --write-kwargs "{'filename': './example.xyz'}"
 ```
 
-This defines the MLIP architecture and path to the saved model, as well as changing where the log and results files are saved.
+This defines the MLIP architecture and path to your locally saved model, as well as changing where the log and results files are saved.
 
 Note: the MACE calculator currently returns energy, forces and stress together, so in this case the choice of property will not change the output.
 
+For all options, run `janus singlepoint --help`.
 
-Perform geometry optimization:
+
+### Geometry optimization
+
+Perform geometry optimization (using the [MACE-MP](https://github.com/ACEsuit/mace-mp) "small" force-field):
+
 ```shell
-janus geomopt --struct tests/data/H2O.cif
+janus geomopt --struct tests/data/H2O.cif --arch mace_mp --calc-kwargs "{'model' : 'small'}"
 ```
 
 This will calculate optimize the atomic positions and save the resulting structure in `H2O-opt.xyz`, in addition to generating a log file, `geomopt.log`.
@@ -90,10 +97,12 @@ This will calculate optimize the atomic positions and save the resulting structu
 Additional options may be specified. This shares most options with `singlepoint`, as well as a few additional options, such as:
 
 ```shell
-janus geomopt --struct tests/data/NaCl.cif --fully-opt --vectors-only --traj 'NaCl-traj.xyz'
+janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --calc-kwargs "{'model' : 'small'}" --fully-opt --vectors-only --traj 'NaCl-traj.xyz'
 ```
 
 This allows the cell to be optimised, allowing only hydrostatic deformation, and saves the optimization trajector in addition to the final structure and log.
+
+For all options, run `janus geomopt --help`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Tools for machine learnt interatomic potentials
 
 The code relies heavily on ASE, unless something else is mentioned.
 
-
 ## Development
 
 1. Install [poetry](https://python-poetry.org/docs/#installation)
@@ -60,6 +59,41 @@ To prevent poetry downgrading ASE when installing in future, add the commit to p
 ```shell
 poetry add git+https://gitlab.com:ase/ase.git#b31569210d739bd12c8ad2b6ec0290108e049eea
 ```
+
+## Examples
+
+Perform a single point calcuation:
+```shell
+janus singlepoint --struct tests/data/NaCl.cif
+```
+
+This will calculate the energy, stress and forces and save this in `NaCl-results.xyz`, in addition to generating a log file, `singlepoint.log`.
+
+Additional options may be specified. For example:
+
+```shell
+janus singlepoint --struct tests/data/NaCl.cif --property energy --arch mace_mp --calc-kwargs "{'model' : './tests/models/mace_mp_small.model'}" --log './example.log' --write-kwargs "{'filename': './example.xyz'}"
+```
+
+This defines the MLIP architecture and path to the saved model, as well as changing where the log and results files are saved.
+
+Note: the MACE calculator currently returns energy, forces and stress together, so in this case the choice of property will not change the output.
+
+
+Perform geometry optimization:
+```shell
+janus geomopt --struct tests/data/H2O.cif
+```
+
+This will calculate optimize the atomic positions and save the resulting structure in `H2O-opt.xyz`, in addition to generating a log file, `geomopt.log`.
+
+Additional options may be specified. This shares most options with `singlepoint`, as well as a few additional options, such as:
+
+```shell
+janus geomopt --struct tests/data/NaCl.cif --fully-opt --vectors-only --traj 'NaCl-traj.xyz'
+```
+
+This allows the cell to be optimised, allowing only hydrostatic deformation, and saves the optimization trajector in addition to the final structure and log.
 
 ## License
 

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -160,7 +160,7 @@ def singlepoint(
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
-        log_file=log_file,
+        log_kwargs={"filename": log_file, "filemode": "a"},
     )
     s_point.run_single_point(
         properties=properties, write_results=True, write_kwargs=write_kwargs
@@ -242,7 +242,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
-        log_file=log_file,
+        log_kwargs={"filename": log_file, "filemode": "w"},
     )
 
     opt_kwargs = {"trajectory": traj_file} if traj_file else None

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -177,22 +177,25 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     device: Device = "cpu",
     fully_opt: Annotated[
         bool,
-        typer.Option("--fully-opt", help="Optimise cell and atomic positions"),
+        typer.Option(
+            "--fully-opt",
+            help="Fully optimize the cell vectors, angles, and atomic positions",
+        ),
     ] = False,
     vectors_only: Annotated[
         bool,
-        typer.Option("--vectors-only", help="Allow only hydrostatic deformations"),
+        typer.Option("--vectors-only", help="Allow only cell vectors to change"),
     ] = False,
     read_kwargs: ReadKwargs = None,
     calc_kwargs: CalcKwargs = None,
     write_kwargs: WriteKwargs = None,
     traj_file: Annotated[
-        str, typer.Option("--traj", help="Path to save trajectory to")
+        str, typer.Option("--traj", help="Path to save optimization frames to")
     ] = None,
     log_file: LogFile = "geomopt.log",
 ):
     """
-    Perform geometry optimization and save to file.
+    Perform geometry optimization and save optimized structure to file.
 
     Parameters
     ----------

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -160,7 +160,7 @@ def singlepoint(
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
-        log_kwargs={"filename": log_file, "filemode": "a"},
+        log_kwargs={"filename": log_file, "filemode": "w"},
     )
     s_point.run_single_point(
         properties=properties, write_results=True, write_kwargs=write_kwargs

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -178,6 +178,9 @@ def geomopt(
     read_kwargs: ReadKwargs = None,
     calc_kwargs: CalcKwargs = None,
     write_kwargs: WriteKwargs = None,
+    traj_file: Annotated[
+        str, typer.Option("--traj", help="Path to save trajectory to")
+    ] = None,
     log_file: LogFile = "geomopt.log",
 ):
     """
@@ -201,6 +204,8 @@ def geomopt(
         Keyword arguments to pass to the selected calculator. Default is {}.
     write_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
+    traj_file : Optional[str]
+        Path to save optimization trajectory to. Default is None.
     log_file : Optional[Path]
         Path to write logs to. Default is "geomopt.log".
     """
@@ -224,4 +229,13 @@ def geomopt(
         log_file=log_file,
     )
 
-    optimize(s_point.struct, fmax=fmax)
+    opt_kwargs = {"trajectory": traj_file} if traj_file else None
+    traj_kwargs = {"filename": traj_file} if traj_file else None
+
+    optimize(
+        s_point.struct,
+        fmax=fmax,
+        opt_kwargs=opt_kwargs,
+        traj_kwargs=traj_kwargs,
+        log_kwargs={"filename": log_file, "filemode": "a"},
+    )

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -27,7 +27,7 @@ def optimize(  # pylint: disable=too-many-arguments
     write_results: bool = False,
     write_kwargs: Optional[ASEWriteArgs] = None,
     traj_kwargs: Optional[ASEWriteArgs] = None,
-    log_kwargs: Optional[dict[str, any]] = None,
+    log_kwargs: Optional[dict[str, Any]] = None,
 ) -> Atoms:
     """
     Optimize geometry of input structure.
@@ -58,7 +58,7 @@ def optimize(  # pylint: disable=too-many-arguments
     traj_kwargs : Optional[ASEWriteArgs]
         Keyword arguments to pass to ase.io.write to save optimization trajectory.
         Must include "filename" keyword. Default is {}.
-    log_kwargs : Optional[dict[str, any]]
+    log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
 
     Returns

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -34,6 +34,7 @@ def optimize(
         Atoms object to optimize geometry for.
     fmax : float
         Set force convergence criteria for optimizer in units eV/Å.
+        Default is 0.1.
     dyn_kwargs : Optional[ASEOptRunArgs]
         Keyword arguments to pass to dyn.run. Default is {}.
     filter_func : Optional[callable]

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -1,5 +1,6 @@
 """Geometry optimization."""
 
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 from ase import Atoms
@@ -15,7 +16,7 @@ from janus_core.janus_types import ASEOptArgs, ASEOptRunArgs, ASEWriteArgs
 from janus_core.log import config_logger
 
 
-def optimize(
+def optimize(  # pylint: disable=too-many-arguments
     atoms: Atoms,
     fmax: float = 0.1,
     dyn_kwargs: Optional[ASEOptRunArgs] = None,
@@ -23,7 +24,8 @@ def optimize(
     filter_kwargs: Optional[dict[str, Any]] = None,
     optimizer: Callable = LBFGS,
     opt_kwargs: Optional[ASEOptArgs] = None,
-    struct_kwargs: Optional[ASEWriteArgs] = None,
+    write_results: bool = False,
+    write_kwargs: Optional[ASEWriteArgs] = None,
     traj_kwargs: Optional[ASEWriteArgs] = None,
     log_kwargs: Optional[dict[str, any]] = None,
 ) -> Atoms:
@@ -48,9 +50,11 @@ def optimize(
         ASE optimization function. Default is `LBFGS`.
     opt_kwargs : Optional[ASEOptArgs]
         Keyword arguments to pass to optimizer. Default is {}.
-    struct_kwargs : Optional[ASEWriteArgs]
+    write_results : bool
+        True to write out optimized structure. Default is False.
+    write_kwargs : Optional[ASEWriteArgs],
         Keyword arguments to pass to ase.io.write to save optimized structure.
-        Must include "filename" keyword. Default is {}.
+        Default is {}.
     traj_kwargs : Optional[ASEWriteArgs]
         Keyword arguments to pass to ase.io.write to save optimization trajectory.
         Must include "filename" keyword. Default is {}.
@@ -65,12 +69,12 @@ def optimize(
     dyn_kwargs = dyn_kwargs if dyn_kwargs else {}
     filter_kwargs = filter_kwargs if filter_kwargs else {}
     opt_kwargs = opt_kwargs if opt_kwargs else {}
-    struct_kwargs = struct_kwargs if struct_kwargs else {}
+    write_kwargs = write_kwargs if write_kwargs else {}
     traj_kwargs = traj_kwargs if traj_kwargs else {}
     log_kwargs = log_kwargs if log_kwargs else {}
 
-    if struct_kwargs and "filename" not in struct_kwargs:
-        raise ValueError("'filename' must be included in `struct_kwargs`")
+    if write_kwargs and "filename" not in write_kwargs:
+        raise ValueError("'filename' must be included in `write_kwargs`")
 
     if traj_kwargs and "filename" not in traj_kwargs:
         raise ValueError("'filename' must be included in `traj_kwargs`")
@@ -89,6 +93,10 @@ def optimize(
     if filter_func is not None:
         filtered_atoms = filter_func(atoms, **filter_kwargs)
         dyn = optimizer(filtered_atoms, **opt_kwargs)
+        if logger:
+            logger.info("Using filter %s", filter_func.__name__)
+            logger.info("Using optimizer %s", optimizer.__name__)
+
     else:
         dyn = optimizer(atoms, **opt_kwargs)
 
@@ -98,8 +106,12 @@ def optimize(
     dyn.run(fmax=fmax, **dyn_kwargs)
 
     # Write out optimized structure
-    if struct_kwargs:
-        write(images=atoms, **struct_kwargs)
+    if write_results:
+        if "filename" not in write_kwargs:
+            write_kwargs["filename"] = Path(
+                f"./{atoms.get_chemical_formula()}-opt.xyz"
+            ).absolute()
+        write(images=atoms, **write_kwargs)
 
     # Reformat trajectory file from binary
     if traj_kwargs:

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -73,8 +73,10 @@ def optimize(  # pylint: disable=too-many-arguments
     traj_kwargs = traj_kwargs if traj_kwargs else {}
     log_kwargs = log_kwargs if log_kwargs else {}
 
-    if write_kwargs and "filename" not in write_kwargs:
-        raise ValueError("'filename' must be included in `write_kwargs`")
+    write_kwargs.setdefault(
+        "filename",
+        Path(f"./{atoms.get_chemical_formula()}-opt.xyz").absolute(),
+    )
 
     if traj_kwargs and "filename" not in traj_kwargs:
         raise ValueError("'filename' must be included in `traj_kwargs`")
@@ -107,10 +109,6 @@ def optimize(  # pylint: disable=too-many-arguments
 
     # Write out optimized structure
     if write_results:
-        if "filename" not in write_kwargs:
-            write_kwargs["filename"] = Path(
-                f"./{atoms.get_chemical_formula()}-opt.xyz"
-            ).absolute()
         write(images=atoms, **write_kwargs)
 
     # Reformat trajectory file from binary

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -19,6 +19,7 @@ def config_logger(
     filename: Optional[str] = None,
     level: LogLevel = logging.INFO,
     capture_warnings: bool = True,
+    filemode: str = "w",
 ):
     """
     Configure logger with yaml-styled format.
@@ -33,6 +34,8 @@ def config_logger(
         Threshold for logger. Default is logging.INFO.
     capture_warnings : bool
         Whether to capture warnings in log. Default is True.
+    filemode : str
+        Mode of file to open. Default is "w".
 
     Returns
     -------
@@ -45,7 +48,7 @@ def config_logger(
         logging.basicConfig(
             level=level,
             filename=filename,
-            filemode="w",
+            filemode=filemode,
             format=FORMAT,
             encoding="utf-8",
         )

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -1,7 +1,7 @@
 """Configure logger with yaml-styled format."""
 
 import logging
-from typing import Optional
+from typing import Literal, Optional
 
 from janus_core.janus_types import LogLevel
 
@@ -19,7 +19,7 @@ def config_logger(
     filename: Optional[str] = None,
     level: LogLevel = logging.INFO,
     capture_warnings: bool = True,
-    filemode: str = "w",
+    filemode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+"] = "w",
 ):
     """
     Configure logger with yaml-styled format.

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -45,7 +45,7 @@ class SinglePoint:
         Keyword arguments to pass to ase.io.read. Default is {}.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
-    log_kwargs : Optional[dict[str, any]]
+    log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
 
     Attributes
@@ -82,7 +82,7 @@ class SinglePoint:
         device: Devices = "cpu",
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
-        log_kwargs: Optional[dict[str, any]] = None,
+        log_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Read the structure being simulated and attach an MLIP calculator.
@@ -107,7 +107,7 @@ class SinglePoint:
             Keyword arguments to pass to ase.io.read. Default is {}.
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
-        log_kwargs : Optional[dict[str, any]]
+        log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         """
         if struct and struct_path:

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -144,6 +144,9 @@ class SinglePoint:
         # Configure calculator
         self.set_calculator(**calc_kwargs)
 
+        if self.logger:
+            self.logger.info("Single point calculator configured")
+
     def read_structure(self, **kwargs) -> None:
         """
         Read structure and structure name.

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -334,8 +334,11 @@ class SinglePoint:
                 )
 
         write_kwargs = write_kwargs if write_kwargs else {}
-        if write_kwargs and "filename" not in write_kwargs:
-            raise ValueError("'filename' must be included in write_kwargs")
+
+        write_kwargs.setdefault(
+            "filename",
+            Path(f"./{self.struct_name}-results.xyz").absolute(),
+        )
 
         if self.logger:
             self.logger.info("Starting single point calculation")
@@ -354,9 +357,6 @@ class SinglePoint:
             self.logger.info("Single point calculation complete")
 
         if write_results:
-            if "filename" not in write_kwargs:
-                filename = f"{self.struct_name}-results.xyz"
-                write_kwargs["filename"] = Path(".").absolute() / filename
             write(images=self.struct, **write_kwargs)
 
         return results

--- a/janus_core/single_point.py
+++ b/janus_core/single_point.py
@@ -16,7 +16,6 @@ from janus_core.janus_types import (
     Devices,
     MaybeList,
     MaybeSequence,
-    PathLike,
 )
 from janus_core.log import config_logger
 from janus_core.mlip_calculators import choose_calculator
@@ -46,8 +45,8 @@ class SinglePoint:
         Keyword arguments to pass to ase.io.read. Default is {}.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
-    log_file : Optional[PathLike]
-        Name of log file if writing logs. Default is None.
+    log_kwargs : Optional[dict[str, any]]
+            Keyword arguments to pass to `config_logger`. Default is {}.
 
     Attributes
     ----------
@@ -83,7 +82,7 @@ class SinglePoint:
         device: Devices = "cpu",
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
-        log_file: Optional[PathLike] = None,
+        log_kwargs: Optional[dict[str, any]] = None,
     ) -> None:
         """
         Read the structure being simulated and attach an MLIP calculator.
@@ -108,8 +107,8 @@ class SinglePoint:
             Keyword arguments to pass to ase.io.read. Default is {}.
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
-        log_file : Optional[PathLike]
-            Name of log file if writing logs. Default is None.
+        log_kwargs : Optional[dict[str, any]]
+            Keyword arguments to pass to `config_logger`. Default is {}.
         """
         if struct and struct_path:
             raise ValueError(
@@ -123,10 +122,15 @@ class SinglePoint:
                 "or a path to the structure file (`struct_path`)"
             )
 
-        self.logger = config_logger(name=__name__, filename=log_file)
-
         read_kwargs = read_kwargs if read_kwargs else {}
         calc_kwargs = calc_kwargs if calc_kwargs else {}
+        log_kwargs = log_kwargs if log_kwargs else {}
+
+        if log_kwargs and "filename" not in log_kwargs:
+            raise ValueError("'filename' must be included in `log_kwargs`")
+
+        log_kwargs.setdefault("name", __name__)
+        self.logger = config_logger(**log_kwargs)
 
         self.architecture = architecture
         self.device = device

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -67,7 +67,8 @@ def test_saving_struct(tmp_path):
 
     optimize(
         single_point.struct,
-        struct_kwargs={"filename": struct_path, "format": "extxyz"},
+        write_results=True,
+        write_kwargs={"filename": struct_path, "format": "extxyz"},
     )
     opt_struct = read(struct_path)
 

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -2,11 +2,11 @@
 
 from pathlib import Path
 
-from ase import Atoms
 from ase.io import read
 from typer.testing import CliRunner
 
 from janus_core.cli import app
+from tests.utils import read_atoms
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -23,7 +23,7 @@ def test_geomopt_help():
 
 def test_geomopt():
     """Test geomopt calculation."""
-    results_path = Path(".").absolute() / "Cl4Na4-opt.xyz"
+    results_path = Path("./Cl4Na4-opt.xyz").absolute()
     assert not results_path.exists()
 
     result = runner.invoke(
@@ -36,10 +36,9 @@ def test_geomopt():
             "0.2",
         ],
     )
+
+    read_atoms(results_path)
     assert result.exit_code == 0
-    atoms = read(results_path)
-    assert isinstance(atoms, Atoms)
-    results_path.unlink()
 
 
 def test_geomopt_log(tmp_path, caplog):

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -1,7 +1,8 @@
-"""Test singlepoint commandline interface."""
+"""Test geomopt commandline interface."""
 
 from pathlib import Path
 
+from ase.io import read
 from typer.testing import CliRunner
 
 from janus_core.cli import app
@@ -36,3 +37,38 @@ def test_geomopt(tmp_path):
         ],
     )
     assert result.exit_code == 0
+
+
+def test_geomopt_log(tmp_path, caplog):
+    """Test log correctly written for geomopt."""
+    with caplog.at_level("INFO", logger="janus_core.geom_opt"):
+        result = runner.invoke(
+            app,
+            [
+                "geomopt",
+                "--struct",
+                DATA_PATH / "NaCl.cif",
+                "--log",
+                f"{tmp_path}/test.log",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Starting geometry optimization" in caplog.text
+
+
+def test_geomopt_traj(tmp_path):
+    """Test log correctly written for geomopt."""
+    traj_path = f"{tmp_path}/test.xyz"
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--traj",
+            traj_path,
+        ],
+    )
+    assert result.exit_code == 0
+    atoms = read(traj_path)
+    assert "forces" in atoms.arrays

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -1,0 +1,38 @@
+"""Test singlepoint commandline interface."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from janus_core.cli import app
+
+DATA_PATH = Path(__file__).parent / "data"
+
+runner = CliRunner()
+
+
+def test_geomopt_help():
+    """Test calling `janus geomopt --help`."""
+    result = runner.invoke(app, ["geomopt", "--help"])
+    assert result.exit_code == 0
+    # Command is returned as "root"
+    assert "Usage: root geomopt [OPTIONS]" in result.stdout
+
+
+def test_geomopt(tmp_path):
+    """Test geomopt calculation."""
+    results_path = tmp_path / "NaCl-results.xyz"
+
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--write-kwargs",
+            f"{{'filename': '{str(results_path)}'}}",
+            "--max-force",
+            "0.2",
+        ],
+    )
+    assert result.exit_code == 0

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -97,7 +97,7 @@ def test_single_point_write():
     """Test writing singlepoint results."""
     data_path = DATA_PATH / "NaCl.cif"
     results_path = Path(".").absolute() / "NaCl-results.xyz"
-    assert not Path(results_path).exists()
+    assert not results_path.exists()
 
     single_point = SinglePoint(
         struct_path=data_path,

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -7,6 +7,7 @@ from numpy import isfinite
 import pytest
 
 from janus_core.single_point import SinglePoint
+from tests.utils import read_atoms
 
 DATA_PATH = Path(__file__).parent / "data"
 MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"
@@ -96,7 +97,7 @@ def test_single_point_traj():
 def test_single_point_write():
     """Test writing singlepoint results."""
     data_path = DATA_PATH / "NaCl.cif"
-    results_path = Path(".").absolute() / "NaCl-results.xyz"
+    results_path = Path("./NaCl-results.xyz").absolute()
     assert not results_path.exists()
 
     single_point = SinglePoint(
@@ -107,11 +108,10 @@ def test_single_point_write():
     assert "forces" not in single_point.struct.arrays
 
     single_point.run_single_point(write_results=True)
-    atoms = read(results_path)
+
+    atoms = read_atoms(results_path)
     assert atoms.get_potential_energy() is not None
     assert "forces" in atoms.arrays
-
-    Path(results_path).unlink()
 
 
 def test_single_point_write_kwargs(tmp_path):

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -6,6 +6,7 @@ from ase.io import read
 from typer.testing import CliRunner
 
 from janus_core.cli import app
+from tests.utils import read_atoms
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -28,9 +29,9 @@ def test_singlepoint_help():
     assert "Usage: root singlepoint [OPTIONS]" in result.stdout
 
 
-def test_singlepoint(tmp_path):
+def test_singlepoint():
     """Test singlepoint calculation."""
-    results_path = tmp_path / "NaCl-results.xyz"
+    results_path = Path("./NaCl-results.xyz").absolute()
 
     result = runner.invoke(
         app,
@@ -38,20 +39,19 @@ def test_singlepoint(tmp_path):
             "singlepoint",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            "--write-kwargs",
-            f"{{'filename': '{str(results_path)}'}}",
         ],
     )
-    assert result.exit_code == 0
 
-    atoms = read(results_path)
+    atoms = read_atoms(results_path)
+    assert result.exit_code == 0
     assert atoms.get_potential_energy() is not None
     assert "forces" in atoms.arrays
 
 
 def test_singlepoint_properties(tmp_path):
     """Test properties for singlepoint calculation."""
-    results_path = tmp_path / "H2O-results.xyz"
+    results_path_1 = tmp_path / "H2O-energy-results.xyz"
+    results_path_2 = tmp_path / "H2O-stress-results.xyz"
 
     # Check energy is can be calculated successfully
     result = runner.invoke(
@@ -63,13 +63,12 @@ def test_singlepoint_properties(tmp_path):
             "--property",
             "energy",
             "--write-kwargs",
-            f"{{'filename': '{str(results_path)}'}}",
+            f"{{'filename': '{str(results_path_1)}'}}",
         ],
     )
     assert result.exit_code == 0
 
-    atoms = read(results_path)
-    results_path.unlink()
+    atoms = read(results_path_1)
     assert atoms.get_potential_energy() is not None
 
     result = runner.invoke(
@@ -81,11 +80,11 @@ def test_singlepoint_properties(tmp_path):
             "--property",
             "stress",
             "--write-kwargs",
-            f"{{'filename': '{str(results_path)}'}}",
+            f"{{'filename': '{str(results_path_2)}'}}",
         ],
     )
     assert result.exit_code == 1
-    assert not results_path.is_file()
+    assert not results_path_2.is_file()
     assert isinstance(result.exception, ValueError)
 
 
@@ -133,28 +132,6 @@ def test_singlepoint_calc_kwargs(tmp_path):
     )
     assert result.exit_code == 0
     assert "Using float32 for MACECalculator" in result.stdout
-
-
-def test_singlepoint_default_write():
-    """Test default write path."""
-    results_path = Path(".").absolute() / "NaCl-results.xyz"
-    assert not results_path.exists()
-
-    result = runner.invoke(
-        app,
-        [
-            "singlepoint",
-            "--struct",
-            DATA_PATH / "NaCl.cif",
-            "--property",
-            "energy",
-        ],
-    )
-    assert result.exit_code == 0
-    atoms = read(results_path)
-    assert "forces" in atoms.arrays
-
-    results_path.unlink()
 
 
 def test_singlepoint_log(tmp_path, caplog):

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -1,4 +1,4 @@
-"""Test commandline interface."""
+"""Test singlepoint commandline interface."""
 
 from pathlib import Path
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,32 @@
+"""Utility functions for tests"""
+
+from pathlib import Path
+from typing import Union
+
+from ase import Atoms
+from ase.io import read
+
+
+def read_atoms(path: Path) -> Union[Atoms, None]:
+    """
+    Read Atoms structure file, and delete file regardless of success.
+
+    Parameters
+    ----------
+    path : Path
+        Path to file containing Atoms structure to be read.
+
+    Returns
+    -------
+    Union[Atoms, None]
+        Atoms structure read from file, or None is any Exception is thrown.
+    """
+    assert path.exists()
+    try:
+        atoms = read(path)
+        assert isinstance(atoms, Atoms)
+    finally:
+        # Ensure file is still deleted if read fails
+        path.unlink()
+
+    return atoms if atoms else None


### PR DESCRIPTION
Resolves #65

See issue for remaining work.

This also implements the logger in geom_opt.py slightly differently to single_point.py, in order to pass kwargs (specifically, to allow appending rather than write only). It probably makes sense to update single_point.py to match this too. 