### PR TITLE
Fix tox configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ good-names = ["e"]
 # Configuration for [pytest](https://docs.pytest.org)
 python_files = "test_*.py"
 addopts = '--cov-report xml'
+pythonpath = ["."]
 
 [tool.coverage.run]
 # Configuration of [coverage.py](https://coverage.readthedocs.io)

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ envlist = py311
 [testenv]
 usedevelop=True
 
-[testenv:py{39,310,312}]
+[testenv:py{39,310,311,312}]
 description = Run the test suite against Python versions
 allowlist_externals = poetry
 commands_pre = poetry install --no-root --sync
-commands = poetry run pytest --cov janus_core --import-mode importlib
+commands = poetry run pytest {posargs} --cov janus_core --import-mode importlib
 
 [testenv:pre-commit]
 description = Run the pre-commit checks
@@ -26,4 +26,4 @@ commands = poetry run sphinx-build -nW --keep-going -b html {posargs} docs/sourc
 description = Run the additional tests suite against Python versions
 allowlist_externals = poetry
 commands_pre = poetry install --no-root --sync --with extra-mlips
-commands = poetry run pytest --run-extra-mlips --run-slow --cov janus_core --import-mode importlib
+commands = poetry run pytest {posargs} --run-extra-mlips --run-slow --cov janus_core --import-mode importlib


### PR DESCRIPTION
- Fixes python path so tests.utils module is found correctly
- Adds python 3.11 tests which I had erroneously removed
- Adds `posargs` to pytest to enable additional arguments to be passed e.g. `tox run -- tests/test_singlepoint_cli.py::test_janus_help` to run an individual test