### PR TITLE
Update geometry optimization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,10 @@ repos:
           docs/.*|
       )$
     entry: pylint
+    args:
+      [
+        "--good-names=e,i,j,k"
+      ]
 
 - repo: https://github.com/numpy/numpydoc
   rev: v1.6.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tools for machine learnt interatomic potentials
   - M3GNET
   - CHGNET
 - [x] Single point calculations
-- [ ] Geometry optimisation
+- [x] Geometry optimisation
 - [ ] Molecular Dynamics
   - NVE
   - NVT (Langevin(Eijnden/Ciccotti flavour) and Nosé-Hoover (Melchionna flavour))

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -286,7 +286,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
 
     # Check trajectory not duplicated
     if "trajectory" in opt_kwargs:
-        raise ValueError("'trajectory' must be passed through the --traj_file option")
+        raise ValueError("'trajectory' must be passed through the --traj option")
 
     # Set same name to overwrite saved binary with xyz
     opt_kwargs["trajectory"] = traj_file if traj_file else None

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -62,6 +62,32 @@ def parse_dict_class(value: str):
     return TyperDict(ast.literal_eval(value))
 
 
+def parse_typer_dicts(typer_dicts: list[TyperDict]) -> list[dict]:
+    """
+    Convert list of TyperDict objects to list of dictionaries.
+
+    Parameters
+    ----------
+    typer_dicts : list[TyperDict]
+        List of TyperDict objects to convert.
+
+    Returns
+    -------
+    list[dict]
+        List of converted dictionaries.
+
+    Raises
+    ------
+    ValueError
+        If items in list are not converted to dicts.
+    """
+    for i, typer_dict in enumerate(typer_dicts):
+        typer_dicts[i] = typer_dict.value if typer_dict else {}
+        if not isinstance(typer_dicts[i], dict):
+            raise ValueError(f"{typer_dicts[i]} must be passed as a dictionary")
+    return typer_dicts
+
+
 # Shared type aliases
 StructPath = Annotated[
     Path, typer.Option("--struct", help="Path of structure to simulate")
@@ -147,16 +173,9 @@ def singlepoint(
     log_file : Optional[Path]
         Path to write logs to. Default is "singlepoint.log".
     """
-    read_kwargs = read_kwargs.value if read_kwargs else {}
-    calc_kwargs = calc_kwargs.value if calc_kwargs else {}
-    write_kwargs = write_kwargs.value if write_kwargs else {}
-
-    if not isinstance(read_kwargs, dict):
-        raise ValueError("read_kwargs must be a dictionary")
-    if not isinstance(calc_kwargs, dict):
-        raise ValueError("calc_kwargs must be a dictionary")
-    if not isinstance(write_kwargs, dict):
-        raise ValueError("write_kwargs must be a dictionary")
+    [read_kwargs, calc_kwargs, write_kwargs] = parse_typer_dicts(
+        [read_kwargs, calc_kwargs, write_kwargs]
+    )
 
     s_point = SinglePoint(
         struct_path=struct_path,
@@ -199,6 +218,14 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     ] = False,
     read_kwargs: ReadKwargs = None,
     calc_kwargs: CalcKwargs = None,
+    opt_kwargs: Annotated[
+        TyperDict,
+        typer.Option(
+            parser=parse_dict_class,
+            help=("Keyword arguments to pass to optimizer  [default: {}]"),
+            metavar="DICT",
+        ),
+    ] = None,
     write_kwargs: WriteKwargs = None,
     traj_file: Annotated[
         str, typer.Option("--traj", help="Path to save optimization frames to")
@@ -230,23 +257,19 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         Keyword arguments to pass to ase.io.read. Default is {}.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
-    write_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to ase.io.write when saving results. Default is {}.
+    opt_kwargs : Optional[ASEOptArgs]
+        Keyword arguments to pass to optimizer. Default is {}.
+    write_kwargs : Optional[ASEWriteArgs]
+        Keyword arguments to pass to ase.io.write when saving optimized structure.
+        Default is {}.
     traj_file : Optional[str]
         Path to save optimization trajectory to. Default is None.
     log_file : Optional[Path]
         Path to write logs to. Default is "geomopt.log".
     """
-    read_kwargs = read_kwargs.value if read_kwargs else {}
-    calc_kwargs = calc_kwargs.value if calc_kwargs else {}
-    write_kwargs = write_kwargs.value if write_kwargs else {}
-
-    if not isinstance(read_kwargs, dict):
-        raise ValueError("read_kwargs must be a dictionary")
-    if not isinstance(calc_kwargs, dict):
-        raise ValueError("calc_kwargs must be a dictionary")
-    if not isinstance(write_kwargs, dict):
-        raise ValueError("write_kwargs must be a dictionary")
+    [read_kwargs, calc_kwargs, opt_kwargs, write_kwargs] = parse_typer_dicts(
+        [read_kwargs, calc_kwargs, opt_kwargs, write_kwargs]
+    )
 
     if not fully_opt and vectors_only:
         raise ValueError("--vectors-only requires --fully-opt to be set")
@@ -261,8 +284,14 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         log_kwargs={"filename": log_file, "filemode": "w"},
     )
 
-    opt_kwargs = {"trajectory": traj_file} if traj_file else None
+    # Check trajectory not duplicated
+    if "trajectory" in opt_kwargs:
+        raise ValueError("'trajectory' must be passed through the --traj_file option")
+
+    # Set same name to overwrite saved binary with xyz
+    opt_kwargs["trajectory"] = traj_file if traj_file else None
     traj_kwargs = {"filename": traj_file} if traj_file else None
+
     filter_kwargs = {"hydrostatic_strain": vectors_only} if fully_opt else None
 
     # Use default filter if passed --fully-opt, otherwise override with None

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -175,6 +175,9 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     fmax: Annotated[
         float, typer.Option("--max-force", help="Maximum force for convergence")
     ] = 0.1,
+    steps: Annotated[
+        int, typer.Option("--steps", help="Maximum number of optimization steps")
+    ] = 1000,
     architecture: Architecture = "mace_mp",
     device: Device = "cpu",
     fully_opt: Annotated[
@@ -212,6 +215,8 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     fmax : float
         Set force convergence criteria for optimizer in units eV/Å.
         Default is 0.1.
+    steps : int
+        Set maximum number of optimization steps to run. Default is 1000.
     architecture : Optional[str]
         MLIP architecture to use for geometry optimization.
         Default is "mace_mp".
@@ -267,6 +272,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     optimize(
         s_point.struct,
         fmax=fmax,
+        steps=steps,
         filter_kwargs=filter_kwargs,
         **fully_opt_dict,
         opt_kwargs=opt_kwargs,

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from typing import Any, Callable, Optional
+import warnings
 
 from ase import Atoms
 from ase.io import read, write
@@ -16,7 +17,7 @@ from janus_core.janus_types import ASEOptArgs, ASEWriteArgs
 from janus_core.log import config_logger
 
 
-def optimize(  # pylint: disable=too-many-arguments
+def optimize(  # pylint: disable=too-many-arguments,too-many-locals
     atoms: Atoms,
     fmax: float = 0.1,
     steps: int = 1000,
@@ -104,7 +105,9 @@ def optimize(  # pylint: disable=too-many-arguments
     if logger:
         logger.info("Starting geometry optimization")
 
-    dyn.run(fmax=fmax, steps=steps)
+    converged = dyn.run(fmax=fmax, steps=steps)
+    if not converged:
+        warnings.warn(f"Optimization has not converged after {steps} steps")
 
     # Write out optimized structure
     if write_results:

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -12,14 +12,14 @@ try:
 except ImportError:
     from ase.constraints import ExpCellFilter as DefaultFilter
 
-from janus_core.janus_types import ASEOptArgs, ASEOptRunArgs, ASEWriteArgs
+from janus_core.janus_types import ASEOptArgs, ASEWriteArgs
 from janus_core.log import config_logger
 
 
 def optimize(  # pylint: disable=too-many-arguments
     atoms: Atoms,
     fmax: float = 0.1,
-    dyn_kwargs: Optional[ASEOptRunArgs] = None,
+    steps: int = 1000,
     filter_func: Optional[Callable] = DefaultFilter,
     filter_kwargs: Optional[dict[str, Any]] = None,
     optimizer: Callable = LBFGS,
@@ -39,8 +39,8 @@ def optimize(  # pylint: disable=too-many-arguments
     fmax : float
         Set force convergence criteria for optimizer in units eV/Å.
         Default is 0.1.
-    dyn_kwargs : Optional[ASEOptRunArgs]
-        Keyword arguments to pass to dyn.run. Default is {}.
+    steps : int
+        Set maximum number of optimization steps to run. Default is 1000.
     filter_func : Optional[callable]
         Apply constraints to atoms through ASE filter function.
         Default is `FrechetCellFilter` if available otherwise `ExpCellFilter`.
@@ -66,7 +66,6 @@ def optimize(  # pylint: disable=too-many-arguments
     atoms: Atoms
         Structure with geometry optimized.
     """
-    dyn_kwargs = dyn_kwargs if dyn_kwargs else {}
     filter_kwargs = filter_kwargs if filter_kwargs else {}
     opt_kwargs = opt_kwargs if opt_kwargs else {}
     write_kwargs = write_kwargs if write_kwargs else {}
@@ -105,7 +104,7 @@ def optimize(  # pylint: disable=too-many-arguments
     if logger:
         logger.info("Starting geometry optimization")
 
-    dyn.run(fmax=fmax, **dyn_kwargs)
+    dyn.run(fmax=fmax, steps=steps)
 
     # Write out optimized structure
     if write_results:

--- a/janus_core/janus_types.py
+++ b/janus_core/janus_types.py
@@ -51,13 +51,6 @@ class ASEOptArgs(TypedDict, total=False):
     trajectory: Optional[str]
 
 
-class ASEOptRunArgs(TypedDict, total=False):
-    """Main arugments for running ase optimisers."""
-
-    fmax: float
-    steps: int
-
-
 class LogLevel(Enum):
     """Supported options for logger levels."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ line-length = 88
 [tool.pylint.format]
 max-line-length = 88
 max-args = 10
-good-names = ["e"]
+good-names = ["e", "i", "j", "k"]
 
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -32,7 +32,7 @@ test_data = [
         "mace",
         "NaCl.cif",
         -27.03561540212425,
-        {"filter_func": UnitCellFilter, "dyn_kwargs": {"steps": 1}},
+        {"filter_func": UnitCellFilter, "steps": 1},
     ),
 ]
 

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -28,12 +28,6 @@ test_data = [
         {"filter_func": UnitCellFilter, "filter_kwargs": {"scalar_pressure": 0.0001}},
     ),
     ("mace", "NaCl.cif", -27.046353221978332, {"opt_kwargs": {"alpha": 100}}),
-    (
-        "mace",
-        "NaCl.cif",
-        -27.03561540212425,
-        {"filter_func": UnitCellFilter, "steps": 1},
-    ),
 ]
 
 
@@ -158,3 +152,13 @@ def test_set_calc():
     init_energy = atoms.get_potential_energy()
     opt_atoms = optimize(atoms)
     assert opt_atoms.get_potential_energy() < init_energy
+
+
+def test_converge_warning():
+    """Test warning raised if not converged."""
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl-deformed.cif",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+    with pytest.warns(UserWarning):
+        optimize(single_point.struct, steps=1)

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -162,3 +162,27 @@ def test_converge_warning():
     )
     with pytest.warns(UserWarning):
         optimize(single_point.struct, steps=1)
+
+
+def test_restart(tmp_path):
+    """Test restarting geometry optimization."""
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl-deformed.cif",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+
+    init_energy = single_point.run("energy")["energy"]
+
+    with pytest.warns(UserWarning):
+        optimize(
+            single_point.struct, steps=2, opt_kwargs={"restart": tmp_path / "NaCl.pkl"}
+        )
+
+    intermediate_energy = single_point.run("energy")["energy"]
+    assert intermediate_energy < init_energy
+
+    optimize(
+        single_point.struct, steps=2, opt_kwargs={"restart": tmp_path / "NaCl.pkl"}
+    )
+    final_energy = single_point.run("energy")["energy"]
+    assert final_energy < intermediate_energy

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -152,3 +152,64 @@ def test_vectors_not_fully_opt(tmp_path):
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, ValueError)
+
+
+def duplicate_traj(tmp_path):
+    """Check trajecory not passed via traj_kwargs"""
+    traj_path = tmp_path / "NaCl-traj.xyz"
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--traj-kwargs",
+            f"{{'trajecory': '{str(traj_path)}'}}",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValueError)
+
+
+def test_restart(tmp_path):
+    """Test restarting geometry optimization."""
+    data_path = DATA_PATH / "NaCl-deformed.cif"
+    restart_path = tmp_path / "NaCl-res.pkl"
+    results_path = tmp_path / "NaCl-opt.xyz"
+
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            data_path,
+            "--write-kwargs",
+            f"{{'filename': '{str(results_path)}'}}",
+            "--opt-kwargs",
+            f"{{'restart': '{str(restart_path)}'}}",
+            "--steps",
+            2,
+        ],
+    )
+    assert result.exit_code == 0
+    atoms = read(results_path)
+    intermediate_energy = atoms.get_potential_energy()
+
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--write-kwargs",
+            f"{{'filename': '{str(results_path)}'}}",
+            "--opt-kwargs",
+            f"{{'restart': '{str(restart_path)}'}}",
+            "--steps",
+            2,
+        ],
+    )
+    assert result.exit_code == 0
+    atoms = read(results_path)
+    final_energy = atoms.get_potential_energy()
+    assert final_energy < intermediate_energy


### PR DESCRIPTION
Resolves #82 and #83

- Replaces `dyn_kwargs `with `steps` option
  - Originally planned just for the CLI, but I can't see anything that allows any other options to be passed to `dyn.run` other than `steps` and `fmax`, so it seemed sensible to just replace it (we can always add the option again if it proves useful later)
- Adds convergence warning if fmax is not met
- Adds tests for restarting optimization via Python and CLI

To do(?)

- [ ] Store maximum force
  - This doesn't seem to be immediately accessible, as [only the boolean seems to be returned](https://gitlab.com/ase/ase/-/blob/master/ase/utils/abc.py#L32) (note: implemented slightly differently in the last tagged version, but still not stored)
  - We don't need it for the convergence test, so we'd have to calculate additionally anyway
- [ ] traj_kwargs
  - Probably not needed for now? Adding steps was the main motivation for #83