### PR TITLE
Add CLI option for geomopt structure path

### DIFF
--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -130,7 +130,7 @@ WriteKwargs = Annotated[
 LogFile = Annotated[Path, typer.Option("--log", help="Path to save logs to")]
 
 
-@app.command()
+@app.command(help="Perform single point calculations and save to file.")
 def singlepoint(
     struct_path: StructPath,
     architecture: Architecture = "mace_mp",
@@ -188,7 +188,9 @@ def singlepoint(
     s_point.run(properties=properties, write_results=True, write_kwargs=write_kwargs)
 
 
-@app.command()
+@app.command(
+    help="Perform geometry optimization and save optimized structure to file.",
+)
 def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     struct_path: StructPath,
     fmax: Annotated[

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -283,7 +283,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         Whether to fully optimize the cell vectors, angles, and atomic positions.
         Default is False.
     opt_file : Optional[Path]
-        Path to save optimized structure. Default is inferred from name of
+        Path to save optimized structure or last structure if optimization did not converge. Default is inferred from name of
         structure file.
     traj_file : Optional[str]
         Path if saving optimization frames. Default is None.

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -90,17 +90,22 @@ def parse_typer_dicts(typer_dicts: list[TyperDict]) -> list[dict]:
 
 # Shared type aliases
 StructPath = Annotated[
-    Path, typer.Option("--struct", help="Path of structure to simulate")
+    Path, typer.Option("--struct", help="Path of structure to simulate.")
 ]
 Architecture = Annotated[
-    str, typer.Option("--arch", help="MLIP architecture to use for calculations")
+    str, typer.Option("--arch", help="MLIP architecture to use for calculations.")
 ]
-Device = Annotated[str, typer.Option(help="Device to run calculations on")]
+Device = Annotated[str, typer.Option(help="Device to run calculations on.")]
 ReadKwargs = Annotated[
     TyperDict,
     typer.Option(
         parser=parse_dict_class,
-        help="Keyword arguments to pass to ase.io.read  [default: {}]",
+        help=(
+            """
+            Keyword arguments to pass to ase.io.read. Must be passed as a dictionary
+            wrapped in quotes, e.g. "{'key' : value}".  [default: "{}"]
+            """
+        ),
         metavar="DICT",
     ),
 ]
@@ -109,9 +114,11 @@ CalcKwargs = Annotated[
     typer.Option(
         parser=parse_dict_class,
         help=(
-            "Keyword arguments to pass to selected calculator. For the default "
-            "architecture ('mace_mp'), {'model':'small'} is set by default  "
-            "[default: {}]"
+            """
+            Keyword arguments to pass to selected calculator. Must be passed as a
+            dictionary wrapped in quotes, e.g. "{'key' : value}". For the default
+            architecture ('mace_mp'), "{'model':'small'}" is set unless overwritten.
+            """
         ),
         metavar="DICT",
     ),
@@ -121,13 +128,16 @@ WriteKwargs = Annotated[
     typer.Option(
         parser=parse_dict_class,
         help=(
-            "Keyword arguments to pass to ase.io.write when saving "
-            "results  [default: {}]"
+            """
+            Keyword arguments to pass to ase.io.write when saving results. Must be
+            passed as a dictionary wrapped in quotes, e.g. "{'key' : value}".
+             [default: "{}"]
+            """
         ),
         metavar="DICT",
     ),
 ]
-LogFile = Annotated[Path, typer.Option("--log", help="Path to save logs to")]
+LogFile = Annotated[Path, typer.Option("--log", help="Path to save logs to.")]
 
 
 @app.command(help="Perform single point calculations and save to file.")
@@ -194,10 +204,10 @@ def singlepoint(
 def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     struct_path: StructPath,
     fmax: Annotated[
-        float, typer.Option("--max-force", help="Maximum force for convergence")
+        float, typer.Option("--max-force", help="Maximum force for convergence.")
     ] = 0.1,
     steps: Annotated[
-        int, typer.Option("--steps", help="Maximum number of optimization steps")
+        int, typer.Option("--steps", help="Maximum number of optimization steps.")
     ] = 1000,
     architecture: Architecture = "mace_mp",
     device: Device = "cpu",
@@ -205,14 +215,14 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         bool,
         typer.Option(
             "--vectors-only",
-            help=("Optimize cell vectors, as well as atomic positions"),
+            help=("Optimize cell vectors, as well as atomic positions."),
         ),
     ] = False,
     fully_opt: Annotated[
         bool,
         typer.Option(
             "--fully-opt",
-            help="Fully optimize the cell vectors, angles, and atomic positions",
+            help="Fully optimize the cell vectors, angles, and atomic positions.",
         ),
     ] = False,
     opt_file: Annotated[
@@ -221,7 +231,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
             "--opt",
             help=(
                 "Path to save optimized structure. Default is inferred from name "
-                "of structure file"
+                "of structure file."
             ),
         ),
     ] = None,
@@ -237,7 +247,12 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         TyperDict,
         typer.Option(
             parser=parse_dict_class,
-            help=("Keyword arguments to pass to optimizer  [default: {}]"),
+            help=(
+                """
+                Keyword arguments to pass to optimizer. Must be passed as a dictionary
+                wrapped in quotes, e.g. "{'key' : value}".  [default: "{}"]
+                """
+            ),
             metavar="DICT",
         ),
     ] = None,

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -283,8 +283,8 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         Whether to fully optimize the cell vectors, angles, and atomic positions.
         Default is False.
     opt_file : Optional[Path]
-        Path to save optimized structure or last structure if optimization did not converge. Default is inferred from name of
-        structure file.
+        Path to save optimized structure, or last structure if optimization did not
+        converge. Default is inferred from name of structure file.
     traj_file : Optional[str]
         Path if saving optimization frames. Default is None.
     read_kwargs : Optional[dict[str, Any]]

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -99,6 +99,10 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
         if logger:
             logger.info("Using filter %s", filter_func.__name__)
             logger.info("Using optimizer %s", optimizer.__name__)
+            if "hydrostatic_strain" in filter_kwargs:
+                logger.info(
+                    "hydrostatic_strain: %s", filter_kwargs["hydrostatic_strain"]
+                )
 
     else:
         dyn = optimizer(atoms, **opt_kwargs)

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -24,7 +24,7 @@ def test_geomopt_help():
 
 def test_geomopt():
     """Test geomopt calculation."""
-    results_path = Path("./Cl4Na4-opt.xyz").absolute()
+    results_path = Path("./NaCl-opt.xyz").absolute()
     assert not results_path.exists()
 
     result = runner.invoke(
@@ -53,8 +53,8 @@ def test_geomopt_log(tmp_path, caplog):
                 "geomopt",
                 "--struct",
                 DATA_PATH / "NaCl.cif",
-                "--write-kwargs",
-                f"{{'filename': '{str(results_path)}'}}",
+                "--opt",
+                results_path,
                 "--log",
                 f"{tmp_path}/test.log",
             ],
@@ -75,8 +75,8 @@ def test_geomopt_traj(tmp_path):
             "geomopt",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            "--write-kwargs",
-            f"{{'filename': '{str(results_path)}'}}",
+            "--opt",
+            results_path,
             "--traj",
             traj_path,
         ],
@@ -97,13 +97,14 @@ def test_fully_opt(tmp_path, caplog):
                 "geomopt",
                 "--struct",
                 DATA_PATH / "NaCl-deformed.cif",
-                "--write-kwargs",
-                f"{{'filename': '{str(results_path)}'}}",
+                "--opt",
+                results_path,
                 "--fully-opt",
             ],
         )
         assert result.exit_code == 0
         assert "Using filter" in caplog.text
+        assert "hydrostatic_strain: False" in caplog.text
 
         atoms = read(results_path)
         expected = [5.68834069, 5.68893345, 5.68932555, 89.75938298, 90.0, 90.0]
@@ -122,36 +123,38 @@ def test_fully_opt_and_vectors(tmp_path, caplog):
                 DATA_PATH / "NaCl-deformed.cif",
                 "--fully-opt",
                 "--vectors-only",
-                "--write-kwargs",
-                f"{{'filename': '{str(results_path)}'}}",
+                "--opt",
+                results_path,
                 "--log",
                 f"{tmp_path}/test.log",
             ],
         )
         assert result.exit_code == 0
         assert "Using filter" in caplog.text
+        assert "hydrostatic_strain: True" in caplog.text
 
         atoms = read(results_path)
         expected = [5.69139709, 5.69139709, 5.69139709, 89.0, 90.0, 90.0]
         assert atoms.cell.cellpar() == pytest.approx(expected)
 
 
-def test_vectors_not_fully_opt(tmp_path):
+def test_vectors_not_fully_opt(tmp_path, caplog):
     """Test passing --vectors-only without --fully-opt."""
     results_path = tmp_path / "NaCl-opt.xyz"
-    result = runner.invoke(
-        app,
-        [
-            "geomopt",
-            "--struct",
-            DATA_PATH / "NaCl.cif",
-            "--write-kwargs",
-            f"{{'filename': '{str(results_path)}'}}",
-            "--vectors-only",
-        ],
-    )
-    assert result.exit_code == 1
-    assert isinstance(result.exception, ValueError)
+    with caplog.at_level("INFO", logger="janus_core.geom_opt"):
+        result = runner.invoke(
+            app,
+            [
+                "geomopt",
+                "--struct",
+                DATA_PATH / "NaCl.cif",
+                "--opt",
+                results_path,
+                "--vectors-only",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "hydrostatic_strain: True" in caplog.text
 
 
 def duplicate_traj(tmp_path):
@@ -183,8 +186,8 @@ def test_restart(tmp_path):
             "geomopt",
             "--struct",
             data_path,
-            "--write-kwargs",
-            f"{{'filename': '{str(results_path)}'}}",
+            "--opt",
+            results_path,
             "--opt-kwargs",
             f"{{'restart': '{str(restart_path)}'}}",
             "--steps",
@@ -201,8 +204,8 @@ def test_restart(tmp_path):
             "geomopt",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            "--write-kwargs",
-            f"{{'filename': '{str(results_path)}'}}",
+            "--opt",
+            results_path,
             "--opt-kwargs",
             f"{{'restart': '{str(restart_path)}'}}",
             "--steps",


### PR DESCRIPTION
Adds `--opt` flag, similar to `--traj` flag, to specify the path to save the optimized structure

Also tidies other parts of the CLI, including

- Allows `--vectors-only` without `--fully-opt`
- Tidies help/docstrings
- Fix full docstring being printed with `--help`
- Clarify how to pass `kwargs` via CLI