### PR TITLE
Extend logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
+*.dat
 *.lock
 *.log
 *.pyc
 *.swo
 *.swp
 *.xml
+*.xyz
+*.yml
 ~*
 *~
 .project

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -2,6 +2,7 @@
 
 import ast
 import datetime
+import logging
 from pathlib import Path
 from typing import Annotated, Optional, get_args
 
@@ -242,7 +243,7 @@ def singlepoint(  # pylint: disable=too-many-locals
         "device": device,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
-        "log_kwargs": {"filename": log_file, "filemode": "w"},
+        "log_kwargs": {"filename": log_file, "filemode": "w", "force": True},
     }
 
     # Initialise singlepoint structure and calculator
@@ -302,6 +303,7 @@ def singlepoint(  # pylint: disable=too-many-locals
             outfile,
             default_flow_style=False,
         )
+    logging.shutdown()
 
 
 @app.command(
@@ -420,7 +422,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
-        log_kwargs={"filename": log_file, "filemode": "w"},
+        log_kwargs={"filename": log_file, "filemode": "w", "force": True},
     )
 
     # Check optimized structure path not duplicated
@@ -508,6 +510,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
             outfile,
             default_flow_style=False,
         )
+    logging.shutdown()
 
 
 @app.command(
@@ -745,7 +748,7 @@ def md(  # pylint: disable=too-many-arguments,too-many-locals,invalid-name
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
-        log_kwargs={"filename": log_file, "filemode": "w"},
+        log_kwargs={"filename": log_file, "filemode": "w", "force": True},
     )
 
     log_kwargs = {"filename": log_file, "filemode": "a"}
@@ -860,3 +863,4 @@ def md(  # pylint: disable=too-many-arguments,too-many-locals,invalid-name
             outfile,
             default_flow_style=False,
         )
+    logging.shutdown()

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -5,6 +5,7 @@ import datetime
 from pathlib import Path
 from typing import Annotated, Optional, get_args
 
+from ase import Atoms
 import typer
 import yaml
 
@@ -256,12 +257,23 @@ def singlepoint(  # pylint: disable=too-many-locals
     del inputs["log_kwargs"]
     inputs["log"] = log_file
 
-    inputs["struct"] = {
-        "n_atoms": len(s_point.struct),
-        "struct_path": struct_path,
-        "struct_name": s_point.struct_name,
-        "formula": s_point.struct.get_chemical_formula(),
-    }
+    if isinstance(s_point.struct, Atoms):
+        inputs["struct"] = {
+            "n_atoms": len(s_point.struct),
+            "struct_path": struct_path,
+            "struct_name": s_point.struct_name,
+            "formula": s_point.struct.get_chemical_formula(),
+        }
+    else:
+        inputs["traj"] = {
+            "length": len(s_point.struct),
+            "struct_path": struct_path,
+            "struct_name": s_point.struct_name,
+            "struct": {
+                "n_atoms": len(s_point.struct[0]),
+                "formula": s_point.struct[0].get_chemical_formula(),
+            },
+        }
 
     inputs["run"] = {
         "properties": properties,

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -94,7 +94,7 @@ def _parse_typer_dicts(typer_dicts: list[TyperDict]) -> list[dict]:
     return typer_dicts
 
 
-def _iter_path_to_str(dictionary: dict) -> None:
+def _dict_paths_to_strs(dictionary: dict) -> None:
     """
     Recursively iterate over dictionary, converting Path values to strings.
 
@@ -105,7 +105,7 @@ def _iter_path_to_str(dictionary: dict) -> None:
     """
     for key, value in dictionary.items():
         if isinstance(value, dict):
-            _iter_path_to_str(value)
+            _dict_paths_to_strs(value)
         elif isinstance(value, Path):
             dictionary[key] = str(value)
 
@@ -243,16 +243,14 @@ def singlepoint(  # pylint: disable=too-many-locals
         "device": device,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
-        "log_kwargs": {"filename": log_file, "filemode": "w", "force": True},
+        "log_kwargs": {"filename": log_file, "filemode": "w"},
     }
 
     # Initialise singlepoint structure and calculator
     s_point = SinglePoint(**singlepoint_kwargs)
 
     # Store inputs for yaml summary
-    inputs = {}
-    for key, value in singlepoint_kwargs.items():
-        inputs[key] = value
+    inputs = singlepoint_kwargs.copy()
 
     # Store only filename as filemode is not set by user
     del inputs["log_kwargs"]
@@ -282,7 +280,7 @@ def singlepoint(  # pylint: disable=too-many-locals
     }
 
     # Convert all paths to strings in inputs nested dictionary
-    _iter_path_to_str(inputs)
+    _dict_paths_to_strs(inputs)
 
     # Save summary information before singlepoint calculation begins
     save_info = [
@@ -422,7 +420,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
-        log_kwargs={"filename": log_file, "filemode": "w", "force": True},
+        log_kwargs={"filename": log_file, "filemode": "w"},
     )
 
     # Check optimized structure path not duplicated
@@ -466,9 +464,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     }
 
     # Store inputs for yaml summary
-    inputs = {}
-    for key, value in optimize_kwargs.items():
-        inputs[key] = value
+    inputs = optimize_kwargs.copy()
 
     # Store only filename as filemode is not set by user
     del inputs["log_kwargs"]
@@ -489,7 +485,7 @@ def geomopt(  # pylint: disable=too-many-arguments,too-many-locals
     }
 
     # Convert all paths to strings in inputs nested dictionary
-    _iter_path_to_str(inputs)
+    _dict_paths_to_strs(inputs)
 
     # Save summary information before optimization begins
     save_info = [
@@ -748,7 +744,7 @@ def md(  # pylint: disable=too-many-arguments,too-many-locals,invalid-name
         device=device,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
-        log_kwargs={"filename": log_file, "filemode": "w", "force": True},
+        log_kwargs={"filename": log_file, "filemode": "w"},
     )
 
     log_kwargs = {"filename": log_file, "filemode": "a"}
@@ -819,9 +815,7 @@ def md(  # pylint: disable=too-many-arguments,too-many-locals,invalid-name
         dyn = NVT_NH(**dyn_kwargs)
 
     # Store inputs for yaml summary
-    inputs = {"ensemble": ensemble}
-    for key, value in dyn_kwargs.items():
-        inputs[key] = value
+    inputs = dyn_kwargs | {"ensemble": ensemble}
 
     # Store only filename as filemode is not set by user
     del inputs["log_kwargs"]
@@ -842,7 +836,7 @@ def md(  # pylint: disable=too-many-arguments,too-many-locals,invalid-name
     }
 
     # Convert all paths to strings in inputs nested dictionary
-    _iter_path_to_str(inputs)
+    _dict_paths_to_strs(inputs)
 
     # Save summary information before simulation begins
     save_info = [

--- a/janus_core/geom_opt.py
+++ b/janus_core/geom_opt.py
@@ -21,7 +21,7 @@ from janus_core.utils import none_to_dict
 
 
 def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
-    atoms: Atoms,
+    struct: Atoms,
     fmax: float = 0.1,
     steps: int = 1000,
     filter_func: Optional[Callable] = DefaultFilter,
@@ -38,7 +38,7 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
 
     Parameters
     ----------
-    atoms : Atoms
+    struct : Atoms
         Atoms object to optimize geometry for.
     fmax : float
         Set force convergence criteria for optimizer in units eV/Å.
@@ -67,7 +67,7 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
 
     Returns
     -------
-    atoms: Atoms
+    struct: Atoms
         Structure with geometry optimized.
     """
     [filter_kwargs, opt_kwargs, write_kwargs, traj_kwargs, log_kwargs] = none_to_dict(
@@ -76,7 +76,7 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
 
     write_kwargs.setdefault(
         "filename",
-        Path(f"./{atoms.get_chemical_formula()}-opt.xyz").absolute(),
+        Path(f"./{struct.get_chemical_formula()}-opt.xyz").absolute(),
     )
 
     if traj_kwargs and "filename" not in traj_kwargs:
@@ -94,8 +94,8 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
     logger = config_logger(**log_kwargs)
 
     if filter_func is not None:
-        filtered_atoms = filter_func(atoms, **filter_kwargs)
-        dyn = optimizer(filtered_atoms, **opt_kwargs)
+        filtered_struct = filter_func(struct, **filter_kwargs)
+        dyn = optimizer(filtered_struct, **opt_kwargs)
         if logger:
             logger.info("Using filter %s", filter_func.__name__)
             logger.info("Using optimizer %s", optimizer.__name__)
@@ -105,7 +105,7 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
                 )
 
     else:
-        dyn = optimizer(atoms, **opt_kwargs)
+        dyn = optimizer(struct, **opt_kwargs)
 
     if logger:
         logger.info("Starting geometry optimization")
@@ -114,9 +114,9 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
 
     # Calculate current maximum force
     if filter_func is not None:
-        max_force = linalg.norm(filtered_atoms.get_forces(), axis=1).max()
+        max_force = linalg.norm(filtered_struct.get_forces(), axis=1).max()
     else:
-        max_force = linalg.norm(atoms.get_forces(), axis=1).max()
+        max_force = linalg.norm(struct.get_forces(), axis=1).max()
 
     if logger:
         logger.info("Max force: %.6f", max_force)
@@ -129,7 +129,7 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
 
     # Write out optimized structure
     if write_results:
-        write(images=atoms, **write_kwargs)
+        write(images=struct, **write_kwargs)
 
     # Reformat trajectory file from binary
     if traj_kwargs:
@@ -139,4 +139,4 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
     if logger:
         logger.info("Geometry optimization complete")
 
-    return atoms
+    return struct

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -38,6 +38,9 @@ class CustomFormatter(logging.Formatter):
         str
             Formatted log message.
         """
+        # Replace "" with '' to prevent invalid wrapping
+        record.msg = record.msg.replace('"', "'")
+
         # Convert new lines into yaml list
         if len(record.msg.split("\n")) > 1:
             msg = record.msg

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -18,7 +18,7 @@ class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
     datefmt : Optional[str]
         A format string in the given style for the date/time portion of the logged
         output. Default is taken from logging.Formatter.formatTime().
-    style : Literal['%'] | Literal['{'] | Literal['$']
+    style : Literal['%', '{', '$']
         Determines how the format string will be merged with its data. Can be one of
         '%', '{' or '$'. Default is '%'.
     validate : bool
@@ -79,7 +79,7 @@ class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
         # Convert new lines into yaml list
         msg = record.msg
         record.msg = "\n" + "\n".join(
-            [f'    - "{line.strip()}"' for line in msg.split("\n") if line.strip()],
+            f'    - "{line.strip()}"' for line in msg.split("\n") if line.strip()
         )
         return super().format(record)
 

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -14,9 +14,26 @@ FORMAT = """
 """
 
 
-class CustomFormatter(logging.Formatter):
+class CustomFormatter(logging.Formatter):  # numpydoc ignore=PR02
     """
     Custom formatter to convert multiline messages into yaml list.
+
+    Parameters
+    ----------
+    fmt : str
+        A format string in the given style for the logged output as a whole. Default is
+        '%(message)s'.
+    datefmt : str
+        A format string in the given style for the date/time portion of the logged
+        output. Default is taken from logging.Formatter.formatTime().
+    style : str
+        Determines how the format string will be merged with its data. Can be one of
+        '%', '{' or '$'. Default is '%'.
+    validate : bool
+        If True, incorrect or mismatched fmt and style will raise a ValueError. Default
+        is True.
+    defaults : dict[str, Any]
+         A dictionary with default values to use in custom fields.
 
     Methods
     -------

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -64,7 +64,7 @@ def config_logger(
     level: LogLevel = logging.INFO,
     capture_warnings: bool = True,
     filemode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+"] = "w",
-    force: bool = False,
+    force: bool = True,
 ):
     """
     Configure logger with yaml-styled format.
@@ -83,7 +83,7 @@ def config_logger(
         Mode of file to open. Default is "w".
     force : bool
         If true, remove and close existing handlers attached to the root logger before
-        configuration. Default is False.
+        configuration. Default is True.
 
     Returns
     -------

--- a/janus_core/log.py
+++ b/janus_core/log.py
@@ -37,13 +37,13 @@ class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
         Format log message to convert new lines into a yaml list.
     """
 
-    FORMAT = (
-        "\n- timestamp: %(asctime)s\n"
-        "  level: %(levelname)s\n"
-        "  message: %(message)s\n"
-        "  trace: %(module)s\n"
-        "  line: %(lineno)d\n"
-    )
+    FORMAT = """
+- timestamp: %(asctime)s
+  level: %(levelname)s
+  message: %(message)s
+  trace: %(module)s
+  line: %(lineno)d
+"""
 
     def __init__(self, *args, **kwargs) -> None:
         """
@@ -77,9 +77,10 @@ class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
         record.msg = record.msg.replace('"', "'")
 
         # Convert new lines into yaml list
-        msg = record.msg
         record.msg = "\n" + "\n".join(
-            f'    - "{line.strip()}"' for line in msg.split("\n") if line.strip()
+            f'    - "{line.strip()}"'
+            for line in record.msg.splitlines()
+            if line.strip()
         )
         return super().format(record)
 

--- a/janus_core/md.py
+++ b/janus_core/md.py
@@ -1,6 +1,6 @@
 """Run molecular dynamics simulations."""
 
-import datetime as clock
+import datetime
 from pathlib import Path
 import random
 from typing import Any, Optional
@@ -369,7 +369,7 @@ class MolecularDynamics:  # pylint: disable=too-many-instance-attributes
         self.dyn.atoms.info["time_fs"] = time
         self.dyn.atoms.info["step"] = step
 
-        time_now = clock.datetime.now()
+        time_now = datetime.datetime.now()
         real_time = time_now - self.dyn.atoms.info["real_time"]
         self.dyn.atoms.info["real_time"] = time_now
 
@@ -450,7 +450,7 @@ class MolecularDynamics:  # pylint: disable=too-many-instance-attributes
         if self.logger:
             self.logger.info("Starting molecular dynamics simulation")
 
-        self.struct.info["real_time"] = clock.datetime.now()
+        self.struct.info["real_time"] = datetime.datetime.now()
 
         if self.restart:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ python = "^3.9"
 ase = "^3.22.1"
 mace-torch = "^0.3.4"
 typer = "^0.9.0"
+pyaml = "^23.12.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^7.4.1"}

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -42,10 +42,10 @@ def test_optimize(architecture, struct_path, expected, kwargs):
 
     init_energy = single_point.run("energy")["energy"]
 
-    atoms = optimize(single_point.struct, **kwargs)
+    struct = optimize(single_point.struct, **kwargs)
 
-    assert atoms.get_potential_energy() < init_energy
-    assert atoms.get_potential_energy() == pytest.approx(expected)
+    assert struct.get_potential_energy() < init_energy
+    assert struct.get_potential_energy() == pytest.approx(expected)
 
 
 def test_saving_struct(tmp_path):
@@ -131,27 +131,27 @@ def test_hydrostatic_strain():
         calc_kwargs={"model": MODEL_PATH},
     )
 
-    atoms_1 = optimize(
+    struct_1 = optimize(
         single_point_1.struct, filter_kwargs={"hydrostatic_strain": True}
     )
-    atoms_2 = optimize(
+    struct_2 = optimize(
         single_point_2.struct, filter_kwargs={"hydrostatic_strain": False}
     )
 
     expected_1 = [5.69139709, 5.69139709, 5.69139709, 89.0, 90.0, 90.0]
     expected_2 = [5.68834069, 5.68893345, 5.68932555, 89.75938298, 90.0, 90.0]
-    assert atoms_1.cell.cellpar() == pytest.approx(expected_1)
-    assert atoms_2.cell.cellpar() == pytest.approx(expected_2)
+    assert struct_1.cell.cellpar() == pytest.approx(expected_1)
+    assert struct_2.cell.cellpar() == pytest.approx(expected_2)
 
 
 def test_set_calc():
     """Test setting the calculator without SinglePoint."""
-    atoms = read(DATA_PATH / "NaCl.cif")
-    atoms.calc = choose_calculator(architecture="mace_mp", model=MODEL_PATH)
+    struct = read(DATA_PATH / "NaCl.cif")
+    struct.calc = choose_calculator(architecture="mace_mp", model=MODEL_PATH)
 
-    init_energy = atoms.get_potential_energy()
-    opt_atoms = optimize(atoms)
-    assert opt_atoms.get_potential_energy() < init_energy
+    init_energy = struct.get_potential_energy()
+    opt_struct = optimize(struct)
+    assert opt_struct.get_potential_energy() < init_energy
 
 
 def test_converge_warning():

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli import app
-from tests.utils import check_log_contents, read_atoms
+from tests.utils import assert_log_contains, read_atoms
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -75,7 +75,7 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(
+    assert_log_contains(
         log_path, includes="Starting geometry optimization", excludes="Using filter"
     )
 
@@ -131,7 +131,9 @@ def test_fully_opt(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, includes=["Using filter", "hydrostatic_strain: False"])
+    assert_log_contains(
+        log_path, includes=["Using filter", "hydrostatic_strain: False"]
+    )
 
     atoms = read(results_path)
     expected = [5.68834069, 5.68893345, 5.68932555, 89.75938298, 90.0, 90.0]
@@ -162,7 +164,7 @@ def test_fully_opt_and_vectors(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, includes=["Using filter", "hydrostatic_strain: True"])
+    assert_log_contains(log_path, includes=["Using filter", "hydrostatic_strain: True"])
 
     atoms = read(results_path)
     expected = [5.69139709, 5.69139709, 5.69139709, 89.0, 90.0, 90.0]
@@ -192,7 +194,7 @@ def test_vectors_not_fully_opt(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, includes=["Using filter", "hydrostatic_strain: True"])
+    assert_log_contains(log_path, includes=["Using filter", "hydrostatic_strain: True"])
 
 
 def test_duplicate_traj(tmp_path):

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from ase.io import read
 import pytest
 from typer.testing import CliRunner
+import yaml
 
 from janus_core.cli import app
 from tests.utils import read_atoms
@@ -14,7 +15,7 @@ DATA_PATH = Path(__file__).parent / "data"
 runner = CliRunner()
 
 
-def test_geomopt_help():
+def test_help():
     """Test calling `janus geomopt --help`."""
     result = runner.invoke(app, ["geomopt", "--help"])
     assert result.exit_code == 0
@@ -22,9 +23,11 @@ def test_geomopt_help():
     assert "Usage: root geomopt [OPTIONS]" in result.stdout
 
 
-def test_geomopt():
+def test_geomopt(tmp_path):
     """Test geomopt calculation."""
     results_path = Path("./NaCl-opt.xyz").absolute()
+    summary_path = tmp_path / "summary.yml"
+
     assert not results_path.exists()
 
     result = runner.invoke(
@@ -35,6 +38,8 @@ def test_geomopt():
             DATA_PATH / "NaCl.cif",
             "--max-force",
             "0.2",
+            "--summary",
+            summary_path,
         ],
     )
 
@@ -42,9 +47,11 @@ def test_geomopt():
     assert result.exit_code == 0
 
 
-def test_geomopt_log(tmp_path, caplog):
+def test_log(tmp_path, caplog):
     """Test log correctly written for geomopt."""
     results_path = tmp_path / "NaCl-opt.xyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
 
     with caplog.at_level("INFO", logger="janus_core.geom_opt"):
         result = runner.invoke(
@@ -56,7 +63,9 @@ def test_geomopt_log(tmp_path, caplog):
                 "--out",
                 results_path,
                 "--log",
-                f"{tmp_path}/test.log",
+                log_path,
+                "--summary",
+                summary_path,
             ],
         )
         assert result.exit_code == 0
@@ -64,10 +73,11 @@ def test_geomopt_log(tmp_path, caplog):
         assert "Using filter" not in caplog.text
 
 
-def test_geomopt_traj(tmp_path):
+def test_traj(tmp_path):
     """Test trajectory correctly written for geomopt."""
     results_path = tmp_path / "NaCl-opt.xyz"
     traj_path = f"{tmp_path}/test.xyz"
+    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -79,6 +89,8 @@ def test_geomopt_traj(tmp_path):
             results_path,
             "--traj",
             traj_path,
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -89,6 +101,7 @@ def test_geomopt_traj(tmp_path):
 def test_fully_opt(tmp_path, caplog):
     """Test passing --fully-opt without --vectors-only"""
     results_path = tmp_path / "NaCl-opt.xyz"
+    summary_path = tmp_path / "summary.yml"
 
     with caplog.at_level("INFO", logger="janus_core.geom_opt"):
         result = runner.invoke(
@@ -100,6 +113,8 @@ def test_fully_opt(tmp_path, caplog):
                 "--out",
                 results_path,
                 "--fully-opt",
+                "--summary",
+                summary_path,
             ],
         )
         assert result.exit_code == 0
@@ -114,6 +129,9 @@ def test_fully_opt(tmp_path, caplog):
 def test_fully_opt_and_vectors(tmp_path, caplog):
     """Test passing --fully-opt with --vectors-only."""
     results_path = tmp_path / "NaCl-opt.xyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+
     with caplog.at_level("INFO", logger="janus_core.geom_opt"):
         result = runner.invoke(
             app,
@@ -126,7 +144,9 @@ def test_fully_opt_and_vectors(tmp_path, caplog):
                 "--out",
                 results_path,
                 "--log",
-                f"{tmp_path}/test.log",
+                log_path,
+                "--summary",
+                summary_path,
             ],
         )
         assert result.exit_code == 0
@@ -141,6 +161,8 @@ def test_fully_opt_and_vectors(tmp_path, caplog):
 def test_vectors_not_fully_opt(tmp_path, caplog):
     """Test passing --vectors-only without --fully-opt."""
     results_path = tmp_path / "NaCl-opt.xyz"
+    summary_path = tmp_path / "summary.yml"
+
     with caplog.at_level("INFO", logger="janus_core.geom_opt"):
         result = runner.invoke(
             app,
@@ -151,15 +173,19 @@ def test_vectors_not_fully_opt(tmp_path, caplog):
                 "--out",
                 results_path,
                 "--vectors-only",
+                "--summary",
+                summary_path,
             ],
         )
         assert result.exit_code == 0
         assert "hydrostatic_strain: True" in caplog.text
 
 
-def duplicate_traj(tmp_path):
+def test_duplicate_traj(tmp_path):
     """Test trajectory file cannot be not passed via traj_kwargs."""
     traj_path = tmp_path / "NaCl-traj.xyz"
+    summary_path = tmp_path / "summary.yml"
+
     result = runner.invoke(
         app,
         [
@@ -168,6 +194,8 @@ def duplicate_traj(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--opt-kwargs",
             f"{{'trajectory': '{str(traj_path)}'}}",
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 1
@@ -179,6 +207,7 @@ def test_restart(tmp_path):
     data_path = DATA_PATH / "NaCl-deformed.cif"
     restart_path = tmp_path / "NaCl-res.pkl"
     results_path = tmp_path / "NaCl-opt.xyz"
+    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -192,6 +221,8 @@ def test_restart(tmp_path):
             f"{{'restart': '{str(restart_path)}'}}",
             "--steps",
             2,
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -210,9 +241,46 @@ def test_restart(tmp_path):
             f"{{'restart': '{str(restart_path)}'}}",
             "--steps",
             2,
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 0
     atoms = read(results_path)
     final_energy = atoms.get_potential_energy()
     assert final_energy < intermediate_energy
+
+
+def test_summary(tmp_path):
+    """Test summary file can be read correctly."""
+    results_path = tmp_path / "NaCl-results.xyz"
+    summary_path = tmp_path / "summary.yml"
+
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--out",
+            results_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    # Read geomopt summary file
+    with open(summary_path, encoding="utf8") as file:
+        md_summary = yaml.safe_load(file)
+
+    assert "command" in md_summary[0]
+    assert "janus geomopt" in md_summary[0]["command"]
+    assert "start_time" in md_summary[1]
+    assert "end_time" in md_summary[3]
+
+    assert "inputs" in md_summary[2]
+    assert "opt_kwargs" in md_summary[2]["inputs"]
+    assert "struct" in md_summary[2]["inputs"]
+    assert "n_atoms" in md_summary[2]["inputs"]["struct"]

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -76,7 +76,7 @@ def test_log(tmp_path):
     assert result.exit_code == 0
 
     check_log_contents(
-        log_path, contains="Starting geometry optimization", excludes="Using filter"
+        log_path, includes="Starting geometry optimization", excludes="Using filter"
     )
 
 
@@ -131,7 +131,7 @@ def test_fully_opt(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, contains=["Using filter", "hydrostatic_strain: False"])
+    check_log_contents(log_path, includes=["Using filter", "hydrostatic_strain: False"])
 
     atoms = read(results_path)
     expected = [5.68834069, 5.68893345, 5.68932555, 89.75938298, 90.0, 90.0]
@@ -162,7 +162,7 @@ def test_fully_opt_and_vectors(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, contains=["Using filter", "hydrostatic_strain: True"])
+    check_log_contents(log_path, includes=["Using filter", "hydrostatic_strain: True"])
 
     atoms = read(results_path)
     expected = [5.69139709, 5.69139709, 5.69139709, 89.0, 90.0, 90.0]
@@ -192,7 +192,7 @@ def test_vectors_not_fully_opt(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, contains=["Using filter", "hydrostatic_strain: True"])
+    check_log_contents(log_path, includes=["Using filter", "hydrostatic_strain: True"])
 
 
 def test_duplicate_traj(tmp_path):

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -14,6 +14,10 @@ DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
 
+# Many pylint now warnings raised due to similar log/summary flags
+# These depend on tmp_path, so not easily refactorisable
+# pylint: disable=duplicate-code
+
 
 def test_help():
     """Test calling `janus geomopt --help`."""
@@ -26,6 +30,7 @@ def test_help():
 def test_geomopt(tmp_path):
     """Test geomopt calculation."""
     results_path = Path("./NaCl-opt.xyz").absolute()
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     assert not results_path.exists()
@@ -38,6 +43,8 @@ def test_geomopt(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--max-force",
             "0.2",
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -77,6 +84,7 @@ def test_traj(tmp_path):
     """Test trajectory correctly written for geomopt."""
     results_path = tmp_path / "NaCl-opt.xyz"
     traj_path = f"{tmp_path}/test.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -89,6 +97,8 @@ def test_traj(tmp_path):
             results_path,
             "--traj",
             traj_path,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -101,6 +111,7 @@ def test_traj(tmp_path):
 def test_fully_opt(tmp_path, caplog):
     """Test passing --fully-opt without --vectors-only"""
     results_path = tmp_path / "NaCl-opt.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     with caplog.at_level("INFO", logger="janus_core.geom_opt"):
@@ -113,6 +124,8 @@ def test_fully_opt(tmp_path, caplog):
                 "--out",
                 results_path,
                 "--fully-opt",
+                "--log",
+                log_path,
                 "--summary",
                 summary_path,
             ],
@@ -161,6 +174,7 @@ def test_fully_opt_and_vectors(tmp_path, caplog):
 def test_vectors_not_fully_opt(tmp_path, caplog):
     """Test passing --vectors-only without --fully-opt."""
     results_path = tmp_path / "NaCl-opt.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     with caplog.at_level("INFO", logger="janus_core.geom_opt"):
@@ -173,6 +187,8 @@ def test_vectors_not_fully_opt(tmp_path, caplog):
                 "--out",
                 results_path,
                 "--vectors-only",
+                "--log",
+                log_path,
                 "--summary",
                 summary_path,
             ],
@@ -184,6 +200,7 @@ def test_vectors_not_fully_opt(tmp_path, caplog):
 def test_duplicate_traj(tmp_path):
     """Test trajectory file cannot be not passed via traj_kwargs."""
     traj_path = tmp_path / "NaCl-traj.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -194,6 +211,8 @@ def test_duplicate_traj(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--opt-kwargs",
             f"{{'trajectory': '{str(traj_path)}'}}",
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -207,6 +226,7 @@ def test_restart(tmp_path):
     data_path = DATA_PATH / "NaCl-deformed.cif"
     restart_path = tmp_path / "NaCl-res.pkl"
     results_path = tmp_path / "NaCl-opt.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -221,6 +241,8 @@ def test_restart(tmp_path):
             f"{{'restart': '{str(restart_path)}'}}",
             "--steps",
             2,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -241,6 +263,8 @@ def test_restart(tmp_path):
             f"{{'restart': '{str(restart_path)}'}}",
             "--steps",
             2,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -254,6 +278,7 @@ def test_restart(tmp_path):
 def test_summary(tmp_path):
     """Test summary file can be read correctly."""
     results_path = tmp_path / "NaCl-results.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -264,6 +289,8 @@ def test_summary(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--out",
             results_path,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli import app
-from tests.utils import read_atoms
+from tests.utils import check_log_contents, read_atoms
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -75,16 +75,9 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    # Read log file
-    with open(log_path, encoding="utf8") as log_file:
-        logs = yaml.safe_load(log_file)
-
-    # Check for correct messages anywhere in logs
-    messages = ""
-    for log in logs:
-        messages += log["message"]
-    assert "Starting geometry optimization" in messages
-    assert "Using filter" not in messages
+    check_log_contents(
+        log_path, contains="Starting geometry optimization", excludes="Using filter"
+    )
 
 
 def test_traj(tmp_path):
@@ -138,16 +131,7 @@ def test_fully_opt(tmp_path):
     )
     assert result.exit_code == 0
 
-    # Read log file
-    with open(log_path, encoding="utf8") as log_file:
-        logs = yaml.safe_load(log_file)
-
-    # Check for correct messages anywhere in logs
-    messages = ""
-    for log in logs:
-        messages += log["message"]
-    assert "Using filter" in messages
-    assert "hydrostatic_strain: False" in messages
+    check_log_contents(log_path, contains=["Using filter", "hydrostatic_strain: False"])
 
     atoms = read(results_path)
     expected = [5.68834069, 5.68893345, 5.68932555, 89.75938298, 90.0, 90.0]
@@ -178,16 +162,7 @@ def test_fully_opt_and_vectors(tmp_path):
     )
     assert result.exit_code == 0
 
-    # Read log file
-    with open(log_path, encoding="utf8") as log_file:
-        logs = yaml.safe_load(log_file)
-
-    # Check for correct messages anywhere in logs
-    messages = ""
-    for log in logs:
-        messages += log["message"]
-    assert "Using filter" in messages
-    assert "hydrostatic_strain: True" in messages
+    check_log_contents(log_path, contains=["Using filter", "hydrostatic_strain: True"])
 
     atoms = read(results_path)
     expected = [5.69139709, 5.69139709, 5.69139709, 89.0, 90.0, 90.0]
@@ -217,15 +192,7 @@ def test_vectors_not_fully_opt(tmp_path):
     )
     assert result.exit_code == 0
 
-    # Read log file
-    with open(log_path, encoding="utf8") as log_file:
-        logs = yaml.safe_load(log_file)
-
-    # Check for correct messages anywhere in logs
-    messages = ""
-    for log in logs:
-        messages += log["message"]
-    assert "hydrostatic_strain: True" in messages
+    check_log_contents(log_path, contains=["Using filter", "hydrostatic_strain: True"])
 
 
 def test_duplicate_traj(tmp_path):

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -3,13 +3,14 @@
 import yaml
 
 from janus_core.log import config_logger
+from tests.utils import check_log_contents
 
 
 def test_multiline_log(tmp_path):
     """Test multiline log is written correctly."""
     log_path = tmp_path / "test.log"
 
-    logger = config_logger(name=__name__, filename=log_path, force=True)
+    logger = config_logger(name=__name__, filename=log_path)
     logger.info(
         """
         Line 1
@@ -17,9 +18,13 @@ def test_multiline_log(tmp_path):
         Line 3
         """
     )
+    logger.info("Line 4")
+
     assert log_path.exists()
     with open(log_path, encoding="utf8") as log:
         log_dicts = yaml.safe_load(log)
 
     assert log_dicts[0]["level"] == "INFO"
     assert len(log_dicts[0]["message"]) == 3
+
+    check_log_contents(log_path, includes=["Line 1", "Line 4"])

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -3,7 +3,7 @@
 import yaml
 
 from janus_core.log import config_logger
-from tests.utils import check_log_contents
+from tests.utils import assert_log_contains
 
 
 def test_multiline_log(tmp_path):
@@ -27,4 +27,4 @@ def test_multiline_log(tmp_path):
     assert log_dicts[0]["level"] == "INFO"
     assert len(log_dicts[0]["message"]) == 3
 
-    check_log_contents(log_path, includes=["Line 1", "Line 4"])
+    assert_log_contains(log_path, includes=["Line 1", "Line 4"])

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,25 @@
+"""Test logging module."""
+
+import yaml
+
+from janus_core.log import config_logger
+
+
+def test_multiline_log(tmp_path):
+    """Test multiline log is written correctly."""
+    log_path = tmp_path / "test.log"
+
+    logger = config_logger(name=__name__, filename=log_path, force=True)
+    logger.info(
+        """
+        Line 1
+        Line 2
+        Line 3
+        """
+    )
+    assert log_path.exists()
+    with open(log_path, encoding="utf8") as log:
+        log_dicts = yaml.safe_load(log)
+
+    assert log_dicts[0]["level"] == "INFO"
+    assert len(log_dicts[0]["message"]) == 3

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -6,7 +6,6 @@ from ase import Atoms
 from ase.io import read
 import numpy as np
 import pytest
-import yaml
 
 from janus_core.md import NPH, NPT, NVE, NVT, NVT_NH
 from janus_core.mlip_calculators import choose_calculator
@@ -526,34 +525,3 @@ def test_atoms_struct(tmp_path):
         assert " | Epot/N [eV]" in lines[0]
         # Includes step 0
         assert len(lines) == 6
-
-
-def test_multiline_log(tmp_path):
-    """Test multiline log messages are written correctly."""
-    file_prefix = tmp_path / "nvt-T300"
-    log_path = tmp_path / "test.log"
-
-    single_point = SinglePoint(
-        struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
-        calc_kwargs={"model": MODEL_PATH},
-        log_kwargs={"filename": log_path, "force": True},
-    )
-
-    nvt = NVT(
-        struct=single_point.struct,
-        steps=2,
-        file_prefix=file_prefix,
-        rescale_every=5,
-        rescale_velocities=True,
-        log_kwargs={"filename": log_path, "filemode": "a"},
-    )
-    nvt.run()
-
-    assert log_path.exists()
-    with open(log_path, encoding="utf8") as log:
-        log_dicts = yaml.safe_load(log)
-
-    assert log_dicts[2]["level"] == "WARNING"
-    assert len(log_dicts[2]["message"]) == 2
-    assert "UserWarning: Velocities" in log_dicts[2]["message"][0]

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -6,6 +6,7 @@ from ase import Atoms
 from ase.io import read
 import numpy as np
 import pytest
+import yaml
 
 from janus_core.md import NPH, NPT, NVE, NVT, NVT_NH
 from janus_core.mlip_calculators import choose_calculator
@@ -525,3 +526,34 @@ def test_atoms_struct(tmp_path):
         assert " | Epot/N [eV]" in lines[0]
         # Includes step 0
         assert len(lines) == 6
+
+
+def test_multiline_log(tmp_path):
+    """Test multiline log messages are written correctly."""
+    file_prefix = tmp_path / "nvt-T300"
+    log_path = tmp_path / "test.log"
+
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model": MODEL_PATH},
+        log_kwargs={"filename": log_path, "force": True},
+    )
+
+    nvt = NVT(
+        struct=single_point.struct,
+        steps=2,
+        file_prefix=file_prefix,
+        rescale_every=5,
+        rescale_velocities=True,
+        log_kwargs={"filename": log_path, "filemode": "a"},
+    )
+    nvt.run()
+
+    assert log_path.exists()
+    with open(log_path, encoding="utf8") as log:
+        log_dicts = yaml.safe_load(log)
+
+    assert log_dicts[2]["level"] == "WARNING"
+    assert len(log_dicts[2]["message"]) == 2
+    assert "UserWarning: Velocities" in log_dicts[2]["message"][0]

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -67,7 +67,7 @@ def test_md(ensemble, tmp_path):
     assert isinstance(atoms, Atoms)
 
 
-def test_md_log(tmp_path, caplog):
+def test_log(tmp_path, caplog):
     """Test log correctly written for MD."""
     file_prefix = tmp_path / "nvt-T300"
     stats_path = tmp_path / "nvt-T300-stats.dat"
@@ -225,6 +225,7 @@ def test_summary(tmp_path):
         summary = yaml.safe_load(file)
 
     assert "command" in summary[0]
+    assert "janus md" in summary[0]["command"]
     assert "start_time" in summary[1]
     assert "inputs" in summary[2]
     assert "end_time" in summary[3]

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -105,7 +105,7 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, contains=["Starting molecular dynamics simulation"])
+    check_log_contents(log_path, includes=["Starting molecular dynamics simulation"])
 
     with open(tmp_path / "nvt-T300-stats.dat", encoding="utf8") as stats_file:
         lines = stats_file.readlines()

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -9,6 +9,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli import app
+from tests.utils import check_log_contents
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -104,15 +105,7 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    # Read log file
-    with open(log_path, encoding="utf8") as log_file:
-        logs = yaml.safe_load(log_file)
-
-    # Check for correct messages anywhere in logs
-    messages = ""
-    for log in logs:
-        messages += log["message"]
-    assert "Starting molecular dynamics simulation" in messages
+    check_log_contents(log_path, contains=["Starting molecular dynamics simulation"])
 
     with open(tmp_path / "nvt-T300-stats.dat", encoding="utf8") as stats_file:
         lines = stats_file.readlines()

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -9,7 +9,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli import app
-from tests.utils import check_log_contents
+from tests.utils import assert_log_contains
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -105,7 +105,7 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, includes=["Starting molecular dynamics simulation"])
+    assert_log_contains(log_path, includes=["Starting molecular dynamics simulation"])
 
     with open(tmp_path / "nvt-T300-stats.dat", encoding="utf8") as stats_file:
         lines = stats_file.readlines()

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -14,6 +14,10 @@ DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
 
+# Many pylint now warnings raised due to similar log/summary flags
+# These depend on tmp_path, so not easily refactorisable
+# pylint: disable=duplicate-code
+
 
 def test_md_help():
     """Test calling `janus md --help`."""
@@ -37,6 +41,7 @@ def test_md(ensemble, tmp_path):
     """Test all MD simulations are able to run."""
     file_prefix = tmp_path / f"{ensemble}-T300"
     traj_path = tmp_path / f"{ensemble}-T300-traj.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -55,6 +60,8 @@ def test_md(ensemble, tmp_path):
             2,
             "--traj-every",
             1,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -71,6 +78,7 @@ def test_log(tmp_path, caplog):
     """Test log correctly written for MD."""
     file_prefix = tmp_path / "nvt-T300"
     stats_path = tmp_path / "nvt-T300-stats.dat"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     with caplog.at_level("INFO", logger="janus_core.md"):
@@ -90,12 +98,14 @@ def test_log(tmp_path, caplog):
                 20,
                 "--stats-every",
                 1,
+                "--log",
+                log_path,
                 "--summary",
                 summary_path,
             ],
         )
         assert result.exit_code == 0
-        assert " Starting molecular dynamics simulation" in caplog.text
+        assert "Starting molecular dynamics simulation" in caplog.text
 
         with open(stats_path, encoding="utf8") as stats_file:
             lines = stats_file.readlines()
@@ -121,6 +131,7 @@ def test_seed(tmp_path):
     """Test seed enables reproducable results for NVT."""
     file_prefix = tmp_path / "nvt-T300"
     stats_path = tmp_path / "nvt-T300-stats.dat"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result_1 = runner.invoke(
@@ -141,6 +152,8 @@ def test_seed(tmp_path):
             20,
             "--seed",
             42,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -174,6 +187,8 @@ def test_seed(tmp_path):
             20,
             "--seed",
             42,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -195,6 +210,7 @@ def test_seed(tmp_path):
 def test_summary(tmp_path):
     """Test summary file can be read correctly."""
     file_prefix = tmp_path / "nvt-T300"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -213,6 +229,8 @@ def test_summary(tmp_path):
             2,
             "--traj-every",
             1,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -13,6 +13,10 @@ DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
 
+# Many pylint warnings now raised due to similar log/summary flags
+# These depend on tmp_path, so not easily refactorisable
+# pylint: disable=duplicate-code
+
 
 def test_janus_help():
     """Test calling `janus --help`."""
@@ -33,6 +37,7 @@ def test_singlepoint_help():
 def test_singlepoint(tmp_path):
     """Test singlepoint calculation."""
     results_path = Path("./NaCl-results.xyz").absolute()
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -41,6 +46,8 @@ def test_singlepoint(tmp_path):
             "singlepoint",
             "--struct",
             DATA_PATH / "NaCl.cif",
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -57,6 +64,7 @@ def test_properties(tmp_path):
     """Test properties for singlepoint calculation."""
     results_path_1 = tmp_path / "H2O-energy-results.xyz"
     results_path_2 = tmp_path / "H2O-stress-results.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     # Check energy is can be calculated successfully
@@ -70,6 +78,8 @@ def test_properties(tmp_path):
             "energy",
             "--out",
             results_path_1,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -89,6 +99,8 @@ def test_properties(tmp_path):
             "stress",
             "--out",
             results_path_2,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -101,6 +113,7 @@ def test_properties(tmp_path):
 def test_read_kwargs(tmp_path):
     """Test setting read_kwargs for singlepoint calculation."""
     results_path = tmp_path / "benzene-traj-results.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -115,6 +128,8 @@ def test_read_kwargs(tmp_path):
             results_path,
             "--property",
             "energy",
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -125,9 +140,10 @@ def test_read_kwargs(tmp_path):
     assert isinstance(atoms, list)
 
 
-def test_singlepoint_calc_kwargs(tmp_path):
+def test_calc_kwargs(tmp_path):
     """Test setting calc_kwargs for singlepoint calculation."""
     results_path = tmp_path / "NaCl-results.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -142,6 +158,8 @@ def test_singlepoint_calc_kwargs(tmp_path):
             results_path,
             "--property",
             "energy",
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],
@@ -180,6 +198,7 @@ def test_log(tmp_path, caplog):
 def test_summary(tmp_path):
     """Test summary file can be read correctly."""
     results_path = tmp_path / "benzene-traj-results.xyz"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
@@ -192,6 +211,8 @@ def test_summary(tmp_path):
             "{'index': ':'}",
             "--out",
             results_path,
+            "--log",
+            log_path,
             "--summary",
             summary_path,
         ],

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from ase.io import read
 from typer.testing import CliRunner
+import yaml
 
 from janus_core.cli import app
 from tests.utils import read_atoms
@@ -29,9 +30,10 @@ def test_singlepoint_help():
     assert "Usage: root singlepoint [OPTIONS]" in result.stdout
 
 
-def test_singlepoint():
+def test_singlepoint(tmp_path):
     """Test singlepoint calculation."""
     results_path = Path("./NaCl-results.xyz").absolute()
+    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -39,19 +41,23 @@ def test_singlepoint():
             "singlepoint",
             "--struct",
             DATA_PATH / "NaCl.cif",
+            "--summary",
+            summary_path,
         ],
     )
 
+    # Check atoms can read read, then delete file
     atoms = read_atoms(results_path)
     assert result.exit_code == 0
     assert atoms.get_potential_energy() is not None
     assert "forces" in atoms.arrays
 
 
-def test_singlepoint_properties(tmp_path):
+def test_properties(tmp_path):
     """Test properties for singlepoint calculation."""
     results_path_1 = tmp_path / "H2O-energy-results.xyz"
     results_path_2 = tmp_path / "H2O-stress-results.xyz"
+    summary_path = tmp_path / "summary.yml"
 
     # Check energy is can be calculated successfully
     result = runner.invoke(
@@ -64,6 +70,8 @@ def test_singlepoint_properties(tmp_path):
             "energy",
             "--out",
             results_path_1,
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -81,6 +89,8 @@ def test_singlepoint_properties(tmp_path):
             "stress",
             "--out",
             results_path_2,
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 1
@@ -88,9 +98,10 @@ def test_singlepoint_properties(tmp_path):
     assert isinstance(result.exception, ValueError)
 
 
-def test_singlepoint_read_kwargs(tmp_path):
+def test_read_kwargs(tmp_path):
     """Test setting read_kwargs for singlepoint calculation."""
     results_path = tmp_path / "benzene-traj-results.xyz"
+    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -104,6 +115,8 @@ def test_singlepoint_read_kwargs(tmp_path):
             results_path,
             "--property",
             "energy",
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -115,6 +128,7 @@ def test_singlepoint_read_kwargs(tmp_path):
 def test_singlepoint_calc_kwargs(tmp_path):
     """Test setting calc_kwargs for singlepoint calculation."""
     results_path = tmp_path / "NaCl-results.xyz"
+    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -128,15 +142,20 @@ def test_singlepoint_calc_kwargs(tmp_path):
             results_path,
             "--property",
             "energy",
+            "--summary",
+            summary_path,
         ],
     )
     assert result.exit_code == 0
     assert "Using float32 for MACECalculator" in result.stdout
 
 
-def test_singlepoint_log(tmp_path, caplog):
+def test_log(tmp_path, caplog):
     """Test log correctly written for singlepoint."""
     results_path = tmp_path / "NaCl-results.xyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+
     with caplog.at_level("INFO", logger="janus_core.single_point"):
         result = runner.invoke(
             app,
@@ -144,13 +163,53 @@ def test_singlepoint_log(tmp_path, caplog):
                 "singlepoint",
                 "--struct",
                 DATA_PATH / "NaCl.cif",
-                "--property",
-                "energy",
                 "--out",
                 results_path,
+                "--property",
+                "energy",
                 "--log",
-                f"{tmp_path}/test.log",
+                log_path,
+                "--summary",
+                summary_path,
             ],
         )
         assert "Starting single point calculation" in caplog.text
         assert result.exit_code == 0
+
+
+def test_summary(tmp_path):
+    """Test summary file can be read correctly."""
+    results_path = tmp_path / "benzene-traj-results.xyz"
+    summary_path = tmp_path / "summary.yml"
+
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--struct",
+            DATA_PATH / "benzene-traj.xyz",
+            "--read-kwargs",
+            "{'index': ':'}",
+            "--out",
+            results_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    # Read singlepoint summary file
+    with open(summary_path, encoding="utf8") as file:
+        sp_summary = yaml.safe_load(file)
+
+    assert "command" in sp_summary[0]
+    assert "janus singlepoint" in sp_summary[0]["command"]
+    assert "start_time" in sp_summary[1]
+    assert "inputs" in sp_summary[2]
+    assert "end_time" in sp_summary[3]
+
+    assert "traj" in sp_summary[2]["inputs"]
+    assert "length" in sp_summary[2]["inputs"]["traj"]
+    assert "struct" in sp_summary[2]["inputs"]["traj"]
+    assert "n_atoms" in sp_summary[2]["inputs"]["traj"]["struct"]

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli import app
-from tests.utils import check_log_contents, read_atoms
+from tests.utils import assert_log_contains, read_atoms
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -192,7 +192,7 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, includes=["Starting single point calculation"])
+    assert_log_contains(log_path, includes=["Starting single point calculation"])
 
 
 def test_summary(tmp_path):

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -168,31 +168,39 @@ def test_calc_kwargs(tmp_path):
     assert "Using float32 for MACECalculator" in result.stdout
 
 
-def test_log(tmp_path, caplog):
+def test_log(tmp_path):
     """Test log correctly written for singlepoint."""
     results_path = tmp_path / "NaCl-results.xyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
-    with caplog.at_level("INFO", logger="janus_core.single_point"):
-        result = runner.invoke(
-            app,
-            [
-                "singlepoint",
-                "--struct",
-                DATA_PATH / "NaCl.cif",
-                "--out",
-                results_path,
-                "--property",
-                "energy",
-                "--log",
-                log_path,
-                "--summary",
-                summary_path,
-            ],
-        )
-        assert "Starting single point calculation" in caplog.text
-        assert result.exit_code == 0
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--out",
+            results_path,
+            "--property",
+            "energy",
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+
+    # Read log file
+    with open(log_path, encoding="utf8") as log_file:
+        logs = yaml.safe_load(log_file)
+
+    # Check for correct messages anywhere in logs
+    messages = ""
+    for log in logs:
+        messages += log["message"]
+    assert "Starting single point calculation" in messages
 
 
 def test_summary(tmp_path):

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -192,7 +192,7 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    check_log_contents(log_path, contains=["Starting single point calculation"])
+    check_log_contents(log_path, includes=["Starting single point calculation"])
 
 
 def test_summary(tmp_path):

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli import app
-from tests.utils import read_atoms
+from tests.utils import check_log_contents, read_atoms
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -192,15 +192,7 @@ def test_log(tmp_path):
     )
     assert result.exit_code == 0
 
-    # Read log file
-    with open(log_path, encoding="utf8") as log_file:
-        logs = yaml.safe_load(log_file)
-
-    # Check for correct messages anywhere in logs
-    messages = ""
-    for log in logs:
-        messages += log["message"]
-    assert "Starting single point calculation" in messages
+    check_log_contents(log_path, contains=["Starting single point calculation"])
 
 
 def test_summary(tmp_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,13 @@
 """Utility functions for tests."""
 
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from ase import Atoms
 from ase.io import read
+import yaml
+
+from janus_core.janus_types import MaybeSequence, PathLike
 
 
 def read_atoms(path: Path) -> Union[Atoms, None]:
@@ -30,3 +33,37 @@ def read_atoms(path: Path) -> Union[Atoms, None]:
         path.unlink()
 
     return atoms if atoms else None
+
+
+def check_log_contents(
+    log_path: PathLike,
+    contains: Optional[MaybeSequence[str]] = None,
+    excludes: Optional[MaybeSequence[str]] = None,
+) -> None:
+    """
+    Check messages are present or not within a yaml-formatted log file.
+
+    Parameters
+    ----------
+    log_path : PathLike
+        Path to log file to check messsages of.
+    contains : MaybeSequence[str]
+        Messages that must appear in the log file. Default is None.
+    excludes : MaybeSequence[str]
+        Messages that must not appear in the log file. Default is None.
+    """
+    # Convert single strings to iterable
+    contains = [contains] if isinstance(contains, str) else contains
+    excludes = [excludes] if isinstance(excludes, str) else excludes
+
+    # Read log file
+    with open(log_path, encoding="utf8") as log_file:
+        logs = yaml.safe_load(log_file)
+    messages = "".join(log["message"] for log in logs)
+
+    if contains:
+        for msg in contains:
+            assert msg in messages
+    if excludes:
+        for msg in excludes:
+            assert msg not in messages

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,7 +37,7 @@ def read_atoms(path: Path) -> Union[Atoms, None]:
 
 def check_log_contents(
     log_path: PathLike,
-    contains: Optional[MaybeSequence[str]] = None,
+    includes: Optional[MaybeSequence[str]] = None,
     excludes: Optional[MaybeSequence[str]] = None,
 ) -> None:
     """
@@ -47,22 +47,23 @@ def check_log_contents(
     ----------
     log_path : PathLike
         Path to log file to check messsages of.
-    contains : MaybeSequence[str]
+    includes : MaybeSequence[str]
         Messages that must appear in the log file. Default is None.
     excludes : MaybeSequence[str]
         Messages that must not appear in the log file. Default is None.
     """
     # Convert single strings to iterable
-    contains = [contains] if isinstance(contains, str) else contains
+    includes = [includes] if isinstance(includes, str) else includes
     excludes = [excludes] if isinstance(excludes, str) else excludes
 
     # Read log file
     with open(log_path, encoding="utf8") as log_file:
         logs = yaml.safe_load(log_file)
-    messages = "".join(log["message"] for log in logs)
+    # Nested join as log["message"] may be a list
+    messages = "".join("".join(log["message"]) for log in logs)
 
-    if contains:
-        for msg in contains:
+    if includes:
+        for msg in includes:
             assert msg in messages
     if excludes:
         for msg in excludes:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,9 +36,9 @@ def read_atoms(path: Path) -> Union[Atoms, None]:
 
 
 def check_log_contents(
-    log_path: PathLike,
-    includes: Optional[MaybeSequence[str]] = None,
-    excludes: Optional[MaybeSequence[str]] = None,
+    log_path: PathLike, *,
+    includes: MaybeSequence[str] = (),
+    excludes: MaybeSequence[str] = (),
 ) -> None:
     """
     Check messages are present or not within a yaml-formatted log file.
@@ -62,9 +62,5 @@ def check_log_contents(
     # Nested join as log["message"] may be a list
     messages = "".join("".join(log["message"]) for log in logs)
 
-    if includes:
-        for msg in includes:
-            assert msg in messages
-    if excludes:
-        for msg in excludes:
-            assert msg not in messages
+    assert all(inc in messages for inc in includes)
+    assert all(exc not in messages for exc in excludes)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 """Utility functions for tests."""
 
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 from ase import Atoms
 from ase.io import read
@@ -35,8 +35,9 @@ def read_atoms(path: Path) -> Union[Atoms, None]:
     return atoms if atoms else None
 
 
-def check_log_contents(
-    log_path: PathLike, *,
+def assert_log_contains(
+    log_path: PathLike,
+    *,
     includes: MaybeSequence[str] = (),
     excludes: MaybeSequence[str] = (),
 ) -> None:


### PR DESCRIPTION
Resolves #64

Initial part of possible solution to extending logging. When using the CLI (MD, since the kwargs were already prepared), this outputs something like:

```
- command: janus md
- start_time: 27/03/2024, 12:38:24
- inputs:
    barostat_time: 75.0
    bulk_modulus: 2.0
    ensemble: nve
    equil_steps: 0
    file_prefix: null
    friction: 0.005
    log_kwargs:
      filemode: a
      filename: md.log
    minimize: true
    minimize_every: 1
    minimize_kwargs: {}
    pressure: 0.0
    remove_rot: false
    rescale_every: 10
    rescale_velocities: false
    restart: false
    restart_every: 1000
    restart_stem: null
    restarts_to_keep: 4
    rotate_restart: false
    seed: null
    stats_every: 100
    stats_file: null
    steps: 2
    struct:
      formula: Cl4Na4
      n_atoms: 8
      struct_path: tests/data/NaCl.cif
    struct_name: NaCl
    temp: 300.0
    thermostat_time: 50.0
    timestep: 1.0
    traj_append: false
    traj_every: 100
    traj_file: null
    traj_start: 0
- end_time: 27/03/2024, 12:38:27
```


Currently this is only for MD, and this is implemented via the CLI, rather than the Python interface.