### PR TITLE
Fix MACE model

### DIFF
--- a/janus_core/mlip_calculators.py
+++ b/janus_core/mlip_calculators.py
@@ -51,7 +51,7 @@ def choose_calculator(
         from mace.calculators import MACECalculator
 
         # `model_paths` is keyword for path to model, so take from kwargs if specified
-        # Otherwise, take `model` if specified, then default to `None`, which will
+        # Otherwise, take `model` if specified, then default to `""`, which will
         # raise a ValueError
         kwargs.setdefault("model_paths", kwargs.pop("model", ""))
         kwargs.setdefault("default_dtype", "float64")

--- a/janus_core/mlip_calculators.py
+++ b/janus_core/mlip_calculators.py
@@ -53,7 +53,7 @@ def choose_calculator(
         # `model_paths` is keyword for path to model, so take from kwargs if specified
         # Otherwise, take `model` if specified, then default to `None`, which will
         # raise a ValueError
-        kwargs.setdefault("model_paths", kwargs.pop("model", None))
+        kwargs.setdefault("model_paths", kwargs.pop("model", ""))
         kwargs.setdefault("default_dtype", "float64")
         calculator = MACECalculator(device=device, **kwargs)
 


### PR DESCRIPTION
This will address errors with MACE-OFF due to a change of URL, but currently only fixes a misleading error if no model is specified for "mace" (`TypeError: object of type 'NoneType' has no len()` -> `ValueError: No mace file names supplied`)