### PR TITLE
Add janus CLI version option

### DIFF
--- a/.github/scripts/check_version.py
+++ b/.github/scripts/check_version.py
@@ -1,0 +1,5 @@
+"""Print current version of janus_core."""
+
+from janus_core import __version__
+
+print(__version__)

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -28,10 +28,28 @@ jobs:
         poetry env use 3.11
         poetry build
 
-    - name: Check Version
-      id: check-version
+    - name: Check prerelease
+      id: check-prerelease
       run: |
         [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || echo prerelease=true >> $GITHUB_OUTPUT
+
+    - name: Get versions from __init__ and pyproject.toml
+      run: |
+        export PYTHONPATH=$(pwd)
+        echo "VERSION=$(python .github/scripts/check_version.py)" >> $GITHUB_ENV
+        echo "POETRYVERSION=$(poetry version --short)" >> $GITHUB_ENV
+
+    - name: Check __init__ matches pyproject.toml
+      if: ${{ env.VERSION != env.POETRYVERSION }}
+      run: |
+        echo "Version in __init__.py and pyproject.toml do not match"
+        exit 1
+
+    - name: Check versions match tag
+      if: ${{ ! contains(github.ref, env.VERSION) }}
+      run: |
+        echo "Git tag does not match version in __init__.py"
+        exit 1
 
     - name: Create Release
       uses: ncipollo/release-action@v1
@@ -39,7 +57,7 @@ jobs:
         artifacts: "dist/*"
         token: ${{ secrets.GITHUB_TOKEN }}
         draft: false
-        prerelease: steps.check-version.outputs.prerelease == 'true'
+        prerelease: steps.check-prerelease.outputs.prerelease == 'true'
         skipIfReleaseExists: true
 
     - name: Publish to PyPI

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -11,12 +11,13 @@ import typer
 from typer_config import use_yaml_config
 import yaml
 
+from janus_core import __version__
 from janus_core.geom_opt import optimize
 from janus_core.janus_types import ASEReadArgs, Ensembles
 from janus_core.md import NPH, NPT, NVE, NVT, NVT_NH
 from janus_core.single_point import SinglePoint
 
-app = typer.Typer()
+app = typer.Typer(name="janus", no_args_is_help=True)
 
 
 class TyperDict:  #  pylint: disable=too-few-public-methods
@@ -167,6 +168,25 @@ LogPath = Annotated[Path, typer.Option(help="Path to save logs to.")]
 Summary = Annotated[
     Path, typer.Option(help="Path to save summary of inputs and start/end time.")
 ]
+
+
+@app.callback(invoke_without_command=True, help="")
+def print_version(
+    version: Annotated[
+        bool, typer.Option("--version", help="Print janus version and exit.")
+    ] = None,
+) -> False:
+    """
+    Print current janus-core version and exit.
+
+    Parameters
+    ----------
+    version : bool
+        Whether to print the current janus-core version.
+    """
+    if version:
+        print(f"janus-core version: {__version__}")
+        raise typer.Exit()
 
 
 @app.command(help="Perform single point calculations and save to file.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,28 @@
+"""Test commandline interface with no sub-commands."""
+
+from typer.testing import CliRunner
+
+from janus_core.cli import app
+
+runner = CliRunner()
+
+
+def test_no_args():
+    """Test calling `janus` with no arguments/options."""
+    result = runner.invoke(app)
+    assert result.exit_code == 0
+    assert "Usage: janus [OPTIONS] COMMAND [ARGS]..." in result.stdout
+
+
+def test_help():
+    """Test calling `janus --help`."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Usage: janus [OPTIONS] COMMAND [ARGS]..." in result.stdout
+
+
+def test_version():
+    """Test calling `janus --version`."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "janus-core version:" in result.stdout

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -23,8 +23,7 @@ def test_help():
     """Test calling `janus geomopt --help`."""
     result = runner.invoke(app, ["geomopt", "--help"])
     assert result.exit_code == 0
-    # Command is returned as "root"
-    assert "Usage: root geomopt [OPTIONS]" in result.stdout
+    assert "Usage: janus geomopt [OPTIONS]" in result.stdout
 
 
 def test_geomopt(tmp_path):

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -24,8 +24,7 @@ def test_md_help():
     """Test calling `janus md --help`."""
     result = runner.invoke(app, ["md", "--help"])
     assert result.exit_code == 0
-    # Command is returned as "root"
-    assert "Usage: root md [OPTIONS]" in result.stdout
+    assert "Usage: janus md [OPTIONS]" in result.stdout
 
 
 test_data = [

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -18,20 +18,11 @@ runner = CliRunner()
 # pylint: disable=duplicate-code
 
 
-def test_janus_help():
-    """Test calling `janus --help`."""
-    result = runner.invoke(app, ["--help"])
-    assert result.exit_code == 0
-    # Command is returned as "root"
-    assert "Usage: root [OPTIONS] COMMAND [ARGS]..." in result.stdout
-
-
 def test_singlepoint_help():
     """Test calling `janus singlepoint --help`."""
     result = runner.invoke(app, ["singlepoint", "--help"])
     assert result.exit_code == 0
-    # Command is returned as "root"
-    assert "Usage: root singlepoint [OPTIONS]" in result.stdout
+    assert "Usage: janus singlepoint [OPTIONS]" in result.stdout
 
 
 def test_singlepoint(tmp_path):


### PR DESCRIPTION
Resolves #77 and #78

- Adds `--version` option for CLI, which outputs `__version__` from `janus_core/__init__`
- Includes minor change in behaviour so that the `--help` output is produced when running only `janus`, rather than `Error: Missing command`.
  - This is partly because with the version callback, it's not straightforward to produce the same output as previously, but it also seems like a reasonable output to me
- Adds check that the version in `__init__.py` matches the version in `pyproject.toml` and the git tag, when running the `publish-on-pypi` workflow
  - Initially considered using `janus --version`, which is why it became part of this change, but that requires installing janus, which seemed unnecessary.
  - Could be split into a different PR if there's anything controversial 