### PR TITLE
Change CLI summary to dict from list

### DIFF
--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -261,6 +261,7 @@ def singlepoint(
 
     # Store only filename as filemode is not set by user
     del inputs["log_kwargs"]
+    del inputs["struct_path"]
     inputs["log"] = log
 
     if isinstance(s_point.struct, Atoms):

--- a/janus_core/cli.py
+++ b/janus_core/cli.py
@@ -290,11 +290,11 @@ def singlepoint(
     _dict_paths_to_strs(inputs)
 
     # Save summary information before singlepoint calculation begins
-    save_info = [
-        {"command": "janus singlepoint"},
-        {"start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")},
-        {"inputs": inputs},
-    ]
+    save_info = {
+        "command": "janus singlepoint",
+        "start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S"),
+        "inputs": inputs,
+    }
     with open(summary, "w", encoding="utf8") as outfile:
         yaml.dump(save_info, outfile, default_flow_style=False)
 
@@ -304,7 +304,7 @@ def singlepoint(
     # Save time after simulation has finished
     with open(summary, "a", encoding="utf8") as outfile:
         yaml.dump(
-            [{"end_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")}],
+            {"end_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")},
             outfile,
             default_flow_style=False,
         )
@@ -491,11 +491,11 @@ def geomopt(
     _dict_paths_to_strs(inputs)
 
     # Save summary information before optimization begins
-    save_info = [
-        {"command": "janus geomopt"},
-        {"start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")},
-        {"inputs": inputs},
-    ]
+    save_info = {
+        "command": "janus geomopt",
+        "start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S"),
+        "inputs": inputs,
+    }
     with open(summary, "w", encoding="utf8") as outfile:
         yaml.dump(save_info, outfile, default_flow_style=False)
 
@@ -505,7 +505,7 @@ def geomopt(
     # Time after optimization has finished
     with open(summary, "a", encoding="utf8") as outfile:
         yaml.dump(
-            [{"end_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")}],
+            {"end_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")},
             outfile,
             default_flow_style=False,
         )
@@ -847,11 +847,11 @@ def md(
     _dict_paths_to_strs(inputs)
 
     # Save summary information before simulation begins
-    save_info = [
-        {"command": "janus md"},
-        {"start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")},
-        {"inputs": inputs},
-    ]
+    save_info = {
+        "command": "janus md",
+        "start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S"),
+        "inputs": inputs,
+    }
     with open(summary, "w", encoding="utf8") as outfile:
         yaml.dump(save_info, outfile, default_flow_style=False)
 
@@ -861,7 +861,7 @@ def md(
     # Save time after simulation has finished
     with open(summary, "a", encoding="utf8") as outfile:
         yaml.dump(
-            [{"end_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")}],
+            {"end_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")},
             outfile,
             default_flow_style=False,
         )

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -301,15 +301,15 @@ def test_summary(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         geomopt_summary = yaml.safe_load(file)
 
-    assert "command" in geomopt_summary[0]
-    assert "janus geomopt" in geomopt_summary[0]["command"]
-    assert "start_time" in geomopt_summary[1]
-    assert "end_time" in geomopt_summary[3]
+    assert "command" in geomopt_summary
+    assert "janus geomopt" in geomopt_summary["command"]
+    assert "start_time" in geomopt_summary
+    assert "end_time" in geomopt_summary
 
-    assert "inputs" in geomopt_summary[2]
-    assert "opt_kwargs" in geomopt_summary[2]["inputs"]
-    assert "struct" in geomopt_summary[2]["inputs"]
-    assert "n_atoms" in geomopt_summary[2]["inputs"]["struct"]
+    assert "inputs" in geomopt_summary
+    assert "opt_kwargs" in geomopt_summary["inputs"]
+    assert "struct" in geomopt_summary["inputs"]
+    assert "n_atoms" in geomopt_summary["inputs"]["struct"]
 
 
 def test_config(tmp_path):
@@ -340,5 +340,5 @@ def test_config(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         geomopt_summary = yaml.safe_load(file)
 
-    assert "alpha" in geomopt_summary[2]["inputs"]["opt_kwargs"]
-    assert geomopt_summary[2]["inputs"]["opt_kwargs"]["alpha"] == 100
+    assert "alpha" in geomopt_summary["inputs"]["opt_kwargs"]
+    assert geomopt_summary["inputs"]["opt_kwargs"]["alpha"] == 100

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -232,15 +232,15 @@ def test_summary(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         summary = yaml.safe_load(file)
 
-    assert "command" in summary[0]
-    assert "janus md" in summary[0]["command"]
-    assert "start_time" in summary[1]
-    assert "inputs" in summary[2]
-    assert "end_time" in summary[3]
+    assert "command" in summary
+    assert "janus md" in summary["command"]
+    assert "start_time" in summary
+    assert "inputs" in summary
+    assert "end_time" in summary
 
-    assert "ensemble" in summary[2]["inputs"]
-    assert "struct" in summary[2]["inputs"]
-    assert "n_atoms" in summary[2]["inputs"]["struct"]
+    assert "ensemble" in summary["inputs"]
+    assert "struct" in summary["inputs"]
+    assert "n_atoms" in summary["inputs"]["struct"]
 
 
 def test_config(tmp_path):
@@ -276,6 +276,6 @@ def test_config(tmp_path):
         md_summary = yaml.safe_load(file)
 
     # Check temperature is passed correctly
-    assert md_summary[2]["inputs"]["temp"] == 200
+    assert md_summary["inputs"]["temp"] == 200
     # Check explicit option overwrites config
-    assert md_summary[2]["inputs"]["ensemble"] == "nve"
+    assert md_summary["inputs"]["ensemble"] == "nve"

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -224,16 +224,16 @@ def test_summary(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         sp_summary = yaml.safe_load(file)
 
-    assert "command" in sp_summary[0]
-    assert "janus singlepoint" in sp_summary[0]["command"]
-    assert "start_time" in sp_summary[1]
-    assert "inputs" in sp_summary[2]
-    assert "end_time" in sp_summary[3]
+    assert "command" in sp_summary
+    assert "janus singlepoint" in sp_summary["command"]
+    assert "start_time" in sp_summary
+    assert "inputs" in sp_summary
+    assert "end_time" in sp_summary
 
-    assert "traj" in sp_summary[2]["inputs"]
-    assert "length" in sp_summary[2]["inputs"]["traj"]
-    assert "struct" in sp_summary[2]["inputs"]["traj"]
-    assert "n_atoms" in sp_summary[2]["inputs"]["traj"]["struct"]
+    assert "traj" in sp_summary["inputs"]
+    assert "length" in sp_summary["inputs"]["traj"]
+    assert "struct" in sp_summary["inputs"]["traj"]
+    assert "n_atoms" in sp_summary["inputs"]["traj"]["struct"]
 
 
 def test_config(tmp_path):
@@ -265,5 +265,5 @@ def test_config(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         sp_summary = yaml.safe_load(file)
 
-    assert "index" in sp_summary[2]["inputs"]["read_kwargs"]
-    assert sp_summary[2]["inputs"]["read_kwargs"]["index"] == ":"
+    assert "index" in sp_summary["inputs"]["read_kwargs"]
+    assert sp_summary["inputs"]["read_kwargs"]["index"] == ":"


### PR DESCRIPTION
Resolves #101

Also removes the duplicate `struct_path` for singlepoint summary, which isn't present in geomopt/md since the singlepoint options are instead explicitly captured under `inputs["calc"]`

E.g. singlepoint_summary is now:

```yaml
command: janus singlepoint
inputs:
  architecture: mace_mp
  calc_kwargs: {}
  device: cpu
  log: singlepoint.log
  read_kwargs: {}
  run:
    properties: []
    write_kwargs: {}
  struct:
    formula: Cl4Na4
    n_atoms: 8
    struct_name: NaCl
    struct_path: tests/data/NaCl.cif
  start_time: 08/04/2024, 18:27:48
end_time: 08/04/2024, 18:27:49
```

Previously:

```yaml
- command: janus singlepoint
- start_time: 08/04/2024, 18:34:19
- inputs:
    architecture: mace_mp
    calc_kwargs: {}
    device: cpu
    log: singlepoint.log
    read_kwargs: {}
    run:
      properties: []
      write_kwargs: {}
    struct:
      formula: Cl4Na4
      n_atoms: 8
      struct_name: NaCl
      struct_path: tests/data/NaCl.cif
    struct_path: tests/data/NaCl.cif
- end_time: 08/04/2024, 18:34:20
```