### PR TITLE
Add final restart files, and fixed heating file stems

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ janus md --ensemble npt --struct tests/data/NaCl.cif --arch mace_mp --calc-kwarg
 
 This will generate several output files:
 
-- Thermodynamical statistics every 100 steps, written to `NaCl-npt-T300.0-p1.0-stats.dat`
-- The structure trajectory every 100 steps, written to `NaCl-npt-T300.0-p1.0-traj.xyz`
-- The structure to be able to restart the dynamics every 1000 steps, written to `NaCl-npt-T300.0-p1.0-res-1000.xyz`
+- Thermodynamical statistics every 100 steps, written to `NaCl-npt-p1.0-T300.0-stats.dat`
+- The structure trajectory every 100 steps, written to `NaCl-npt-p1.0-T300.0-traj.xyz`
+- The structure to be able to restart the dynamics every 1000 steps, written to `NaCl-npt-p1.0-T300.0-res-1000.xyz`
+- The final structure written to `NaCl-npt-p1.0-T300.0-final.xyz`
 - A log of the processes carried out, written to `md.log`
 - A summary of the inputs and start/end time, written to `md_summary.yml`.
 
@@ -150,7 +151,14 @@ Run an NVT heating simultation from 20K to 300K in steps of 20K, with 10fs at ea
 janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 300 --temp-step 20 --temp-time 10
 ```
 
-This produces the same output files as an MD simulation.
+The produced statistics and trajectory files will indicate the heating range `NaCl-nvt-T20.0-T300.0-stats.dat`, `NaCl-nvt-T20.0-T300.0-traj.xyz`. There will also be final structure files at each temperature point:
+
+```
+NaCl-nvt-T20.0-final.xyz
+NaCl-nvt-T40.0-final.xyz
+...
+NaCl-nvt-T300.0-final.xyz
+```
 
 MD can also be carried out after heating using the same options as described in [Molecular dynamics](#molecular-dynamics). For example:
 
@@ -159,6 +167,8 @@ janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 
 ```
 
 This performs the same initial heating, before running a further 1000 steps (1 ps) at 300K.
+
+When MD is run with heating the trajectory ```NaCl-nvt-T20.0-T300.0-T300.0-traj.xyz``` and statistics ```NaCl-nvt-T20.0-T300.0-T300.0-stats.dat``` files will indicate the heating range and MD temperature (which may be different). With heating and MD trajectories/statistics within the same files.
 
 
 ### Using configuration files

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ janus md --ensemble npt --struct tests/data/NaCl.cif --arch mace_mp --calc-kwarg
 
 This will generate several output files:
 
-- Thermodynamical statistics every 100 steps, written to `NaCl-npt-p1.0-T300.0-stats.dat`
-- The structure trajectory every 100 steps, written to `NaCl-npt-p1.0-T300.0-traj.xyz`
-- The structure to be able to restart the dynamics every 1000 steps, written to `NaCl-npt-p1.0-T300.0-res-1000.xyz`
-- The final structure written to `NaCl-npt-p1.0-T300.0-final.xyz`
+- Thermodynamical statistics every 100 steps, written to `NaCl-npt-T300.0-p1.0-stats.dat`
+- The structure trajectory every 100 steps, written to `NaCl-npt-T300.0-p1.0-traj.xyz`
+- The structure to be able to restart the dynamics every 1000 steps, written to `NaCl-npt-T300.0-p1.0-res-1000.xyz`
+- The final structure written to `NaCl-npt-T300.0-p1.0-final.xyz`
 - A log of the processes carried out, written to `md.log`
 - A summary of the inputs and start/end time, written to `md_summary.yml`.
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -377,7 +377,7 @@ class MolecularDynamics:  # pylint: disable=too-many-instance-attributes
             temperature_prefix = f"-T{self.temp_start}-T{self.temp_end}"
 
         if self.steps > 0:
-            temperature_prefix = f"{temperature_prefix}-T{self.temp}"
+            temperature_prefix += f"-T{self.temp}"
 
         return temperature_prefix
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -523,7 +523,6 @@ class MolecularDynamics:  # pylint: disable=too-many-instance-attributes
         self.dyn.attach(self._write_stats_file, interval=self.stats_every)
         self.dyn.attach(self._write_traj, interval=self.traj_every)
         self.dyn.attach(self._write_restart, interval=self.restart_every)
-        self.dyn.attach(lambda : self._write_restart("final.xyz"), interval=self.steps)
 
         if self.rescale_velocities:
             self.dyn.attach(self._reset_velocities, interval=self.rescale_every)

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -393,7 +393,7 @@ class MolecularDynamics:  # pylint: disable=too-many-instance-attributes
         """
 
         if not self.restart_stem:
-            return f"{self.struct_name}-{self.ensemble}-T{self.temp}-final.xyz"
+            return f"{self.file_prefix}-T{self.temp}-final.xyz"
         # respect the users choice
         return f"{self.restart_stem}-T{self.temp}-final.xyz"
 
@@ -409,25 +409,25 @@ class MolecularDynamics:  # pylint: disable=too-many-instance-attributes
         """
         step = self.offset + self.dyn.nsteps
         if not self.restart_stem:
-            return f"{self.struct_name}-{self.ensemble}-T{self.temp}-res-{step}.xyz"
+            return f"{self.file_prefix}-T{self.temp}-res-{step}.xyz"
         return f"{self.restart_stem}-T{self.temp}-res-{step}.xyz"
 
     def configure_filenames(self) -> None:
         """Setup filenames for output files."""
 
         if not self.file_prefix:
-            self.file_prefix = (
-                f"{self.struct_name}-{self.ensemble}{self._parameter_prefix}"
-            )
+            self.file_prefix = f"{self.struct_name}-{self.ensemble}"
+            data_prefix = f"{self.file_prefix}{self._parameter_prefix}"
         else:
+            data_prefix = f"{self.file_prefix}"
             if not self.restart_stem:
                 self.restart_stem = f"{self.file_prefix}"
 
         if not self.stats_file:
-            self.stats_file = f"{self.file_prefix}-stats.dat"
+            self.stats_file = f"{data_prefix}-stats.dat"
 
         if not self.traj_file:
-            self.traj_file = f"{self.file_prefix}-traj.xyz"
+            self.traj_file = f"{data_prefix}-traj.xyz"
 
     @staticmethod
     def get_log_header() -> str:
@@ -735,9 +735,7 @@ class NPT(MolecularDynamics):
 
         pressure = f"-p{self.pressure}" if not isinstance(self, NVT_NH) else ""
         if not self.restart_stem:
-            return (
-                f"{self.struct_name}-{self.ensemble}-T{self.temp}{pressure}-final.xyz"
-            )
+            return f"{self.file_prefix}-T{self.temp}{pressure}-final.xyz"
         return f"{self.restart_stem}-T{self.temp}{pressure}-final.xyz"
 
     @property
@@ -752,10 +750,9 @@ class NPT(MolecularDynamics):
         """
         step = self.offset + self.dyn.nsteps
         pressure = f"-p{self.pressure}" if not isinstance(self, NVT_NH) else ""
-        ending = f"-T{self.temp}{pressure}-res-{step}.xyz"
         if not self.restart_stem:
-            return f"{self.struct_name}-{self.ensemble}{ending}"
-        return f"{self.restart_stem}{ending}"
+            return f"{self.file_prefix}-T{self.temp}{pressure}-res-{step}.xyz"
+        return f"{self.restart_stem}-T{self.temp}{pressure}-res-{step}.xyz"
 
     def get_log_stats(self) -> str:
         """

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -719,15 +719,8 @@ class NPT(MolecularDynamics):
            Formatted temperature range if heating and target temp if running md.
         """
 
-        temperature_prefix = ""
-        if self.temp_start and self.temp_end:
-            temperature_prefix = f"-T{self.temp_start}-T{self.temp_end}"
-
-        if self.steps > 0:
-            temperature_prefix = f"{temperature_prefix}-T{self.temp}"
-
         pressure = f"-p{self.pressure}" if not isinstance(self, NVT_NH) else ""
-        return f"{pressure}{temperature_prefix}"
+        return f"{super()._parameter_prefix}{pressure}"
 
     @property
     def _final_file(self) -> str:
@@ -743,9 +736,9 @@ class NPT(MolecularDynamics):
         pressure = f"-p{self.pressure}" if not isinstance(self, NVT_NH) else ""
         if not self.restart_stem:
             return (
-                f"{self.struct_name}-{self.ensemble}{pressure}-T{self.temp}-final.xyz"
+                f"{self.struct_name}-{self.ensemble}-T{self.temp}{pressure}-final.xyz"
             )
-        return f"{self.restart_stem}{pressure}-T{self.temp}-final.xyz"
+        return f"{self.restart_stem}-T{self.temp}{pressure}-final.xyz"
 
     @property
     def _restart_file(self) -> str:
@@ -759,10 +752,10 @@ class NPT(MolecularDynamics):
         """
         step = self.offset + self.dyn.nsteps
         pressure = f"-p{self.pressure}" if not isinstance(self, NVT_NH) else ""
-        ending = f"-T{self.temp}-res-{step}.xyz"
+        ending = f"-T{self.temp}{pressure}-res-{step}.xyz"
         if not self.restart_stem:
-            return f"{self.struct_name}-{self.ensemble}{pressure}{ending}"
-        return f"{self.restart_stem}{pressure}{ending}"
+            return f"{self.struct_name}-{self.ensemble}{ending}"
+        return f"{self.restart_stem}{ending}"
 
     def get_log_stats(self) -> str:
         """

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -43,11 +43,13 @@ def test_npt():
     """Test NPT molecular dynamics."""
     restart_path_1 = Path("Cl4Na4-npt-p1.0-T300.0-res-2.xyz")
     restart_path_2 = Path("Cl4Na4-npt-p1.0-T300.0-res-4.xyz")
+    restart_final = Path("Cl4Na4-npt-p1.0-T300.0-final.xyz")
     traj_path = Path("Cl4Na4-npt-p1.0-T300.0-traj.xyz")
     stats_path = Path("Cl4Na4-npt-p1.0-T300.0-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
+    assert not restart_final.exists()
     assert not traj_path.exists()
     assert not stats_path.exists()
 
@@ -73,7 +75,8 @@ def test_npt():
         assert isinstance(restart_atoms_1, Atoms)
         restart_atoms_2 = read(restart_path_2)
         assert isinstance(restart_atoms_2, Atoms)
-
+        restart_atoms_final = read(restart_final)
+        assert isinstance(restart_atoms_final, Atoms)
         traj = read(traj_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
         assert len(traj) == 4
@@ -85,6 +88,7 @@ def test_npt():
     finally:
         restart_path_1.unlink(missing_ok=True)
         restart_path_2.unlink(missing_ok=True)
+        restart_final.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
 
@@ -92,12 +96,15 @@ def test_npt():
 def test_nvt_nh():
     """Test NVT-Nosé–Hoover  molecular dynamics."""
     restart_path = Path("Cl4Na4-nvt-nh-T300.0-res-3.xyz")
+    restart_final_path = Path("Cl4Na4-nvt-nh-T300.0-final.xyz")
     traj_path = Path("Cl4Na4-nvt-nh-T300.0-traj.xyz")
     stats_path = Path("Cl4Na4-nvt-nh-T300.0-stats.dat")
 
     assert not restart_path.exists()
+    assert not restart_final_path.exists()
     assert not traj_path.exists()
     assert not stats_path.exists()
+   
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
@@ -119,6 +126,9 @@ def test_nvt_nh():
         restart_atoms = read(restart_path)
         assert isinstance(restart_atoms, Atoms)
 
+        restart_final_atoms = read(restart_final_path)
+        assert isinstance(restart_final_atoms, Atoms)
+ 
         traj = read(traj_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
         assert len(traj) == 3
@@ -129,6 +139,7 @@ def test_nvt_nh():
             assert len(lines) == 4
     finally:
         restart_path.unlink(missing_ok=True)
+        restart_final_path.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
 
@@ -168,10 +179,12 @@ def test_nve(tmp_path):
 def test_nph():
     """Test NPH molecular dynamics."""
     restart_path = Path("Cl4Na4-nph-p0.0-T300.0-res-2.xyz")
+    restart_final_path = Path("Cl4Na4-nph-p0.0-T300.0-final.xyz")
     traj_path = Path("Cl4Na4-nph-p0.0-T300.0-traj.xyz")
     stats_path = Path("Cl4Na4-nph-p0.0-T300.0-stats.dat")
 
     assert not restart_path.exists()
+    assert not restart_final_path.exists()
     assert not traj_path.exists()
     assert not stats_path.exists()
 
@@ -195,6 +208,9 @@ def test_nph():
         with pytest.raises(FileNotFoundError):
             read(restart_path)
 
+        restart_final_atoms = read(restart_final_path)
+        assert isinstance(restart_final_atoms, Atoms)
+        
         traj = read(traj_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
         assert len(traj) == 1
@@ -205,6 +221,7 @@ def test_nph():
             assert len(lines) == 2
     finally:
         restart_path.unlink(missing_ok=True)
+        restart_final_path.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -104,7 +104,6 @@ def test_nvt_nh():
     assert not restart_final_path.exists()
     assert not traj_path.exists()
     assert not stats_path.exists()
-   
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
@@ -128,7 +127,7 @@ def test_nvt_nh():
 
         restart_final_atoms = read(restart_final_path)
         assert isinstance(restart_final_atoms, Atoms)
- 
+
         traj = read(traj_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
         assert len(traj) == 3
@@ -210,7 +209,7 @@ def test_nph():
 
         restart_final_atoms = read(restart_final_path)
         assert isinstance(restart_final_atoms, Atoms)
-        
+
         traj = read(traj_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
         assert len(traj) == 1
@@ -648,18 +647,21 @@ def test_heating_md(tmp_path):
     assert stat_data.units[16] == "K"
     assert stat_data.labels[16] == "Target T"
 
+
 def test_heating_file_stems():
     """Test default heating file stems."""
-    
-    traj_path = Path("Cl4Na4-nvt-T10-T20-traj.xyz")
-    stats_path = Path("Cl4Na4-nvt-T10-T20-stats.dat")
+
+    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-traj.xyz")
+    stats_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
     final_10_path = Path("Cl4Na4-nvt-T10-final.xyz")
-    final_20_path = Path("Cl4Na4-nvt-T20-final.xyz") 
-    
-    assert not traj_path.exists()
-    assert not stats_path.exists()
+    final_20_path = Path("Cl4Na4-nvt-T20-final.xyz")
+    final_path = Path("Cl4Na4-nvt-T25.0-final.xyz")
+
+    assert not traj_heating_path.exists()
+    assert not stats_heating_path.exists()
     assert not final_10_path.exists()
     assert not final_20_path.exists()
+    assert not final_path.exists()
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
@@ -669,13 +671,13 @@ def test_heating_file_stems():
     nvt = NVT(
         struct=single_point.struct,
         temp=25.0,
-        steps=0,
+        steps=100,
         traj_every=100,
         stats_every=2,
         temp_start=10,
         temp_end=20,
         temp_step=10,
-        temp_time=2
+        temp_time=2,
     )
     try:
         nvt.run()
@@ -684,19 +686,21 @@ def test_heating_file_stems():
         final_20_atoms = read(final_20_path)
         assert isinstance(final_20_atoms, Atoms)
 
-        traj = read(traj_path, index=":")
+        traj = read(traj_heating_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
-        assert len(traj) == 1
+        assert len(traj) == 2
 
-        with open(stats_path, encoding="utf8") as stats_file:
+        with open(stats_heating_path, encoding="utf8") as stats_file:
             lines = stats_file.readlines()
             assert "Target T [K]" in lines[0]
-            assert len(lines) == 4
+            assert len(lines) == 54
+
+        final = read(final_path)
+        assert isinstance(final, Atoms)
 
     finally:
-        traj_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
+        traj_heating_path.unlink(missing_ok=True)
+        stats_heating_path.unlink(missing_ok=True)
         final_10_path.unlink(missing_ok=True)
         final_20_path.unlink(missing_ok=True)
-
-
+        final_path.unlink(missing_ok=True)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -649,7 +649,7 @@ def test_heating_md(tmp_path):
 
 
 def test_heating_files():
-    "Test default heating file names" ""
+    """Test default heating file names."""
     traj_heating_path = Path("Cl4Na4-nvt-T10-T20-traj.xyz")
     stats_heating_path = Path("Cl4Na4-nvt-T10-T20-stats.dat")
     final_10_path = Path("Cl4Na4-nvt-T10-final.xyz")

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -41,11 +41,11 @@ def test_init(ensemble, expected):
 
 def test_npt():
     """Test NPT molecular dynamics."""
-    restart_path_1 = Path("Cl4Na4-npt-p1.0-T300.0-res-2.xyz")
-    restart_path_2 = Path("Cl4Na4-npt-p1.0-T300.0-res-4.xyz")
-    restart_final = Path("Cl4Na4-npt-p1.0-T300.0-final.xyz")
-    traj_path = Path("Cl4Na4-npt-p1.0-T300.0-traj.xyz")
-    stats_path = Path("Cl4Na4-npt-p1.0-T300.0-stats.dat")
+    restart_path_1 = Path("Cl4Na4-npt-T300.0-p1.0-res-2.xyz")
+    restart_path_2 = Path("Cl4Na4-npt-T300.0-p1.0-res-4.xyz")
+    restart_final = Path("Cl4Na4-npt-T300.0-p1.0-final.xyz")
+    traj_path = Path("Cl4Na4-npt-T300.0-p1.0-traj.xyz")
+    stats_path = Path("Cl4Na4-npt-T300.0-p1.0-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -177,10 +177,10 @@ def test_nve(tmp_path):
 
 def test_nph():
     """Test NPH molecular dynamics."""
-    restart_path = Path("Cl4Na4-nph-p0.0-T300.0-res-2.xyz")
-    restart_final_path = Path("Cl4Na4-nph-p0.0-T300.0-final.xyz")
-    traj_path = Path("Cl4Na4-nph-p0.0-T300.0-traj.xyz")
-    stats_path = Path("Cl4Na4-nph-p0.0-T300.0-stats.dat")
+    restart_path = Path("Cl4Na4-nph-T300.0-p0.0-res-2.xyz")
+    restart_final_path = Path("Cl4Na4-nph-T300.0-p0.0-final.xyz")
+    traj_path = Path("Cl4Na4-nph-T300.0-p0.0-traj.xyz")
+    stats_path = Path("Cl4Na4-nph-T300.0-p0.0-stats.dat")
 
     assert not restart_path.exists()
     assert not restart_final_path.exists()
@@ -648,8 +648,60 @@ def test_heating_md(tmp_path):
     assert stat_data.labels[16] == "Target T"
 
 
-def test_heating_file_stems():
-    """Test default heating file stems."""
+def test_heating_files():
+    "Test default heating file names" ""
+    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-traj.xyz")
+    stats_heating_path = Path("Cl4Na4-nvt-T10-T20-stats.dat")
+    final_10_path = Path("Cl4Na4-nvt-T10-final.xyz")
+    final_20_path = Path("Cl4Na4-nvt-T20-final.xyz")
+
+    assert not traj_heating_path.exists()
+    assert not stats_heating_path.exists()
+    assert not final_10_path.exists()
+    assert not final_20_path.exists()
+
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+    nvt = NVT(
+        struct=single_point.struct,
+        temp=25.0,
+        steps=0,
+        traj_every=2,
+        stats_every=2,
+        temp_start=10,
+        temp_end=20,
+        temp_step=10,
+        temp_time=2,
+    )
+    try:
+        nvt.run()
+        final_10_atoms = read(final_10_path)
+        assert isinstance(final_10_atoms, Atoms)
+        final_20_atoms = read(final_20_path)
+        assert isinstance(final_20_atoms, Atoms)
+
+        traj = read(traj_heating_path, index=":")
+        assert all(isinstance(image, Atoms) for image in traj)
+        assert len(traj) == 3
+
+        stats = Stats(source=stats_heating_path)
+        assert stats.rows == 3
+        assert stats.data[0, 16] == 10.0
+        assert stats.data[1, 16] == 10.0
+        assert stats.data[2, 16] == 20.0
+
+    finally:
+        traj_heating_path.unlink(missing_ok=True)
+        stats_heating_path.unlink(missing_ok=True)
+        final_10_path.unlink(missing_ok=True)
+        final_20_path.unlink(missing_ok=True)
+
+
+def test_heating_md_files():
+    """Test default heating files when also running md"""
 
     traj_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-traj.xyz")
     stats_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
@@ -690,10 +742,11 @@ def test_heating_file_stems():
         assert all(isinstance(image, Atoms) for image in traj)
         assert len(traj) == 2
 
-        with open(stats_heating_path, encoding="utf8") as stats_file:
-            lines = stats_file.readlines()
-            assert "Target T [K]" in lines[0]
-            assert len(lines) == 54
+        stats = Stats(source=stats_heating_path)
+        assert stats.rows == 54
+        assert stats.data[0, 16] == 10
+        assert stats.data[2, 16] == 20
+        assert stats.data[53, 16] == 25
 
         final = read(final_path)
         assert isinstance(final, Atoms)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -723,7 +723,7 @@ def test_heating_md_files():
     nvt = NVT(
         struct=single_point.struct,
         temp=25.0,
-        steps=100,
+        steps=2,
         traj_every=100,
         stats_every=2,
         temp_start=10,
@@ -740,13 +740,13 @@ def test_heating_md_files():
 
         traj = read(traj_heating_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
-        assert len(traj) == 2
+        assert len(traj) == 1
 
         stats = Stats(source=stats_heating_path)
-        assert stats.rows == 53
+        assert stats.rows == 4
         assert stats.data[0, 16] == 10
         assert stats.data[2, 16] == 20
-        assert stats.data[52, 16] == 25
+        assert stats.data[3, 16] == 25
 
         final = read(final_path)
         assert isinstance(final, Atoms)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -743,10 +743,10 @@ def test_heating_md_files():
         assert len(traj) == 2
 
         stats = Stats(source=stats_heating_path)
-        assert stats.rows == 54
+        assert stats.rows == 53
         assert stats.data[0, 16] == 10
         assert stats.data[2, 16] == 20
-        assert stats.data[53, 16] == 25
+        assert stats.data[52, 16] == 25
 
         final = read(final_path)
         assert isinstance(final, Atoms)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -41,10 +41,10 @@ def test_init(ensemble, expected):
 
 def test_npt():
     """Test NPT molecular dynamics."""
-    restart_path_1 = Path("Cl4Na4-npt-T300.0-p1.0-res-2.xyz")
-    restart_path_2 = Path("Cl4Na4-npt-T300.0-p1.0-res-4.xyz")
-    traj_path = Path("Cl4Na4-npt-T300.0-p1.0-traj.xyz")
-    stats_path = Path("Cl4Na4-npt-T300.0-p1.0-stats.dat")
+    restart_path_1 = Path("Cl4Na4-npt-p1.0-T300.0-res-2.xyz")
+    restart_path_2 = Path("Cl4Na4-npt-p1.0-T300.0-res-4.xyz")
+    traj_path = Path("Cl4Na4-npt-p1.0-T300.0-traj.xyz")
+    stats_path = Path("Cl4Na4-npt-p1.0-T300.0-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -167,9 +167,9 @@ def test_nve(tmp_path):
 
 def test_nph():
     """Test NPH molecular dynamics."""
-    restart_path = Path("Cl4Na4-nph-T300.0-p0.0-res-2.xyz")
-    traj_path = Path("Cl4Na4-nph-T300.0-p0.0-traj.xyz")
-    stats_path = Path("Cl4Na4-nph-T300.0-p0.0-stats.dat")
+    restart_path = Path("Cl4Na4-nph-p0.0-T300.0-res-2.xyz")
+    traj_path = Path("Cl4Na4-nph-p0.0-T300.0-traj.xyz")
+    stats_path = Path("Cl4Na4-nph-p0.0-T300.0-stats.dat")
 
     assert not restart_path.exists()
     assert not traj_path.exists()
@@ -475,7 +475,7 @@ def test_rescale_every(tmp_path):
 
 def test_rotate_restart(tmp_path):
     """Test setting rotate_restart."""
-    file_prefix = tmp_path / "Cl4Na4-nvt-T300.0"
+    file_prefix = tmp_path / "Cl4Na4-nvt"
     restart_path_1 = tmp_path / "Cl4Na4-nvt-T300.0-res-1.xyz"
     restart_path_2 = tmp_path / "Cl4Na4-nvt-T300.0-res-2.xyz"
     restart_path_3 = tmp_path / "Cl4Na4-nvt-T300.0-res-3.xyz"


### PR DESCRIPTION
The desired behaviour introduced is to produce a restart file (```.xyz```) at the end of a heating cycle or md run. As discussed in #108 the user specified restart frequency may not align with the final time step, and this results in a predictable file name for use in automated meta-workflows.

Schematically the file stems will be (NPT is currently no working in this PR),

```
# NVT/NVE, not heating
[ENSEMBLE]-[TEMPERATURE]-[STEP]-res
[ENSEMBLE]-[TEMPERATURE]-final
# heating, where TEMPERATURE is dynamically updated as heating progresses
[ENSEMBLE]-[TEMPERATURE]-[STEP]-res
[ENSEMBLE]-[TEMPERATURE]-final
[ENSEMBLE]-[TEMPERATURE_START]-[TEMPERATURE_END]-stats
[ENSEMBLE]-[TEMPERATURE_START]-[TEMPERATURE_END]-traj
# NPT also has pressure, after termperature, e.g.
[ENSEMBLE]-[TEMPERATURE]-[PRESSURE]-final
[ENSEMBLE]-[TEMPERATURE_START]-[TEMPERATURE_END]-[PRESSURE]-stats
```

@ElliottKasoar One point that definitely needs addressing is what is desired when we do a heating run and md run, in the same janus run? Does there need to be some indication the md run is post heating for example?

This PR Closes #115 