### PR TITLE
Tidy code

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 
 
 This produces the same output files as an MD simulation.
 
-MD can also be carried out after heating using the same options as described in #molecular-dynamics. For example:
+MD can also be carried out after heating using the same options as described in [Molecular dynamics](#molecular-dynamics). For example:
 
 ```shell
 janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 300 --temp-step 20 --temp-time 10 --steps 1000 --temp 300

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ janus = "janus_core.cli:app"
 python = "^3.9"
 ase = "^3.22.1"
 mace-torch = "^0.3.4"
-pyaml = "^23.12.0"
+pyyaml = "^6.0.1"
 typer = "^0.9.0"
 typer-config = "^1.4.0"
 


### PR DESCRIPTION
- Fixes dependency
  - I don't think this changes anything functionally (other than removing the unnecessary/unwanted dependency), as pyaml depends on pyYAML, and everywhere within the code we use pyYAML itself via `import yaml`
- Fixes broken README link