### PR TITLE
Ensure config options are valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,6 @@ This will run a singlepoint energy calculation on `KCl.cif` using the [MACE-MP](
 > [!NOTE]
 > `properties` must be passed as a Yaml list, as above, not as a string.
 
-> [!WARNING]
-> If an option in the configuration file does not match any variable names, an error will **not** be raised.
-> Please check the summary file to ensure the configuration has been read correctly.
-
 
 ## License
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -192,4 +192,5 @@ html_search_language = "en"
 nitpick_ignore = [
     ("py:class", "Logger"),
     ("py:class", "numpy.float64"),
+    ("py:class", "typer.models.Context"),
 ]

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Annotated
 
-from typer import Option, Typer
+from typer import Context, Option, Typer
 from typer_config import use_config
 
 from janus_core.calculations.geom_opt import optimize
@@ -20,6 +20,7 @@ from janus_core.cli.types import (
     WriteKwargs,
 )
 from janus_core.cli.utils import (
+    check_config,
     end_summary,
     parse_typer_dicts,
     start_summary,
@@ -37,6 +38,7 @@ app = Typer()
 def geomopt(
     # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
     # numpydoc ignore=PR02
+    ctx: Context,
     struct: StructPath,
     fmax: Annotated[float, Option(help="Maximum force for convergence.")] = 0.1,
     steps: Annotated[int, Option(help="Maximum number of optimization steps.")] = 1000,
@@ -77,6 +79,8 @@ def geomopt(
 
     Parameters
     ----------
+    ctx : Context
+        Typer (Click) Context. Automatically set.
     struct : Path
         Path of structure to simulate.
     fmax : float
@@ -117,6 +121,9 @@ def geomopt(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    # Check options from configuration file are all valid
+    check_config(ctx)
+
     [read_kwargs, calc_kwargs, opt_kwargs, write_kwargs] = parse_typer_dicts(
         [read_kwargs, calc_kwargs, opt_kwargs, write_kwargs]
     )

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Annotated, Optional, get_args
 
-from typer import Option, Typer
+from typer import Context, Option, Typer
 from typer_config import use_config
 
 from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_NH
@@ -19,6 +19,7 @@ from janus_core.cli.types import (
     Summary,
 )
 from janus_core.cli.utils import (
+    check_config,
     end_summary,
     parse_typer_dicts,
     start_summary,
@@ -37,6 +38,7 @@ app = Typer()
 def md(
     # pylint: disable=too-many-arguments,too-many-locals,invalid-name,duplicate-code
     # numpydoc ignore=PR02
+    ctx: Context,
     ensemble: Annotated[str, Option(help="Name of thermodynamic ensemble.")],
     struct: StructPath,
     steps: Annotated[int, Option(help="Number of steps in simulation.")] = 0,
@@ -166,6 +168,8 @@ def md(
 
     Parameters
     ----------
+    ctx : Context
+        Typer (Click) Context. Automatically set.
     ensemble : str
         Name of thermodynamic ensemble.
     struct : Path
@@ -258,6 +262,9 @@ def md(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    # Check options from configuration file are all valid
+    check_config(ctx)
+
     [read_kwargs, calc_kwargs, minimize_kwargs] = parse_typer_dicts(
         [read_kwargs, calc_kwargs, minimize_kwargs]
     )

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Annotated
 
 from ase import Atoms
-from typer import Option, Typer
+from typer import Context, Option, Typer
 from typer_config import use_config
 
 from janus_core.calculations.single_point import SinglePoint
@@ -19,6 +19,7 @@ from janus_core.cli.types import (
     WriteKwargs,
 )
 from janus_core.cli.utils import (
+    check_config,
     end_summary,
     parse_typer_dicts,
     start_summary,
@@ -32,8 +33,9 @@ app = Typer()
 @app.command(help="Perform single point calculations and save to file.")
 @use_config(yaml_converter_callback)
 def singlepoint(
-    # pylint: disable=too-many-locals,duplicate-code
+    # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
     # numpydoc ignore=PR02
+    ctx: Context,
     struct: StructPath,
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
@@ -66,6 +68,8 @@ def singlepoint(
 
     Parameters
     ----------
+    ctx : Context
+        Typer (Click) Context. Automatically set.
     struct : Path
         Path of structure to simulate.
     arch : Optional[str]
@@ -92,6 +96,9 @@ def singlepoint(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    # Check options from configuration file are all valid
+    check_config(ctx)
+
     [read_kwargs, calc_kwargs, write_kwargs] = parse_typer_dicts(
         [read_kwargs, calc_kwargs, write_kwargs]
     )

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from typer import Context
 from typer_config import conf_callback_factory, yaml_loader
 import yaml
 
@@ -104,3 +105,19 @@ def end_summary(summary: Path) -> None:
             default_flow_style=False,
         )
     logging.shutdown()
+
+
+def check_config(ctx: Context) -> None:
+    """
+    Check options in configuration file are valid options for CLI command.
+
+    Parameters
+    ----------
+    ctx : Context
+        Typer (Click) Context within command.
+    """
+    # Compare options from config file (default_map) to function definition (params)
+    for option in ctx.default_map:
+        # Check options individually so can inform user of specific issue
+        if option not in ctx.params:
+            raise ValueError(f"'{option}' in configuration file is not a valid option")

--- a/tests/data/invalid.yml
+++ b/tests/data/invalid.yml
@@ -1,0 +1,1 @@
+test: "value"

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -341,3 +341,19 @@ def test_config(tmp_path):
 
     assert "alpha" in geomopt_summary["inputs"]["opt_kwargs"]
     assert geomopt_summary["inputs"]["opt_kwargs"]["alpha"] == 100
+
+
+def test_invalid_config():
+    """Test passing a config file with an invalid option name."""
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--config",
+            DATA_PATH / "invalid.yml",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValueError)

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -324,3 +324,21 @@ def test_heating(tmp_path):
         ],
     )
     assert result.exit_code == 0
+
+
+def test_invalid_config():
+    """Test passing a config file with an invalid option name."""
+    result = runner.invoke(
+        app,
+        [
+            "md",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--ensemble",
+            "nvt",
+            "--config",
+            DATA_PATH / "invalid.yml",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValueError)

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -258,3 +258,19 @@ def test_config(tmp_path):
 
     assert "index" in sp_summary["inputs"]["read_kwargs"]
     assert sp_summary["inputs"]["read_kwargs"]["index"] == ":"
+
+
+def test_invalid_config():
+    """Test passing a config file with an invalid option name."""
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--struct",
+            DATA_PATH / "benzene-traj.xyz",
+            "--config",
+            DATA_PATH / "invalid.yml",
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValueError)


### PR DESCRIPTION
Resolves #103

Compares the options defined in configuration file to CLI function options to ensure only valid options are defined.

Also restructures code, as the CLI module was getting a bit unwieldy. This is entirely done within the first commit, so happy to separate out into two PRs if preferable.