### PR TITLE
Add structure name option to MD CLI

### DIFF
--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -41,6 +41,7 @@ def md(
     ctx: Context,
     ensemble: Annotated[str, Option(help="Name of thermodynamic ensemble.")],
     struct: StructPath,
+    struct_name: Annotated[str, Option(help="Name of structure to simulate.")] = None,
     steps: Annotated[int, Option(help="Number of steps in simulation.")] = 0,
     timestep: Annotated[float, Option(help="Timestep for integrator, in fs.")] = 1.0,
     temp: Annotated[float, Option(help="Temperature, in K.")] = 300.0,
@@ -174,6 +175,8 @@ def md(
         Name of thermodynamic ensemble.
     struct : Path
         Path of structure to simulate.
+    struct_name : str
+        Name of structure to simulate. Default is None.
     steps : int
         Number of steps in simulation. Default is 0.
     timestep : float
@@ -275,6 +278,7 @@ def md(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
+        struct_name=struct_name,
         architecture=arch,
         device=device,
         read_kwargs=read_kwargs,

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -41,7 +41,17 @@ def md(
     ctx: Context,
     ensemble: Annotated[str, Option(help="Name of thermodynamic ensemble.")],
     struct: StructPath,
-    struct_name: Annotated[str, Option(help="Name of structure to simulate.")] = None,
+    struct_name: Annotated[
+        str,
+        Option(
+            help=(
+                """
+                Name of structure to simulate. Default is inferred from filepath or
+                chemical formula.
+                """
+            )
+        ),
+    ] = None,
     steps: Annotated[int, Option(help="Number of steps in simulation.")] = 0,
     timestep: Annotated[float, Option(help="Timestep for integrator, in fs.")] = 1.0,
     temp: Annotated[float, Option(help="Temperature, in K.")] = 300.0,
@@ -176,7 +186,8 @@ def md(
     struct : Path
         Path of structure to simulate.
     struct_name : str
-        Name of structure to simulate. Default is None.
+        Name of structure to simulate. Default is inferred from filepath or chemical
+        formula.
     steps : int
         Number of steps in simulation. Default is 0.
     timestep : float

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -346,10 +346,11 @@ def test_invalid_config():
 
 def test_struct_name(tmp_path):
     """ "Test specifying the structure name."""
-    stats_path = tmp_path / "EXAMPLE-nvt-T10.0-stats.dat"
-    traj_path = tmp_path / "EXAMPLE-nvt-T10.0-traj.xyz"
-    final_path = tmp_path / "EXAMPLE-nvt-T10.0-final.xyz"
-    struct_name = tmp_path / "EXAMPLE"
+    struct_name = "EXAMPLE"
+    struct_path = tmp_path / struct_name
+    stats_path = tmp_path / f"{struct_name}-nvt-T10.0-stats.dat"
+    traj_path = tmp_path / f"{struct_name}-nvt-T10.0-traj.xyz"
+    final_path = tmp_path / f"{struct_name}-nvt-T10.0-final.xyz"
     result = runner.invoke(
         app,
         [

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -342,3 +342,31 @@ def test_invalid_config():
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, ValueError)
+
+
+def test_struct_name(tmp_path):
+    """ "Test specifying the structure name."""
+    stats_path = tmp_path / "EXAMPLE-nvt-T10.0-stats.dat"
+    traj_path = tmp_path / "EXAMPLE-nvt-T10.0-traj.xyz"
+    final_path = tmp_path / "EXAMPLE-nvt-T10.0-final.xyz"
+    struct_name = tmp_path / "EXAMPLE"
+    result = runner.invoke(
+        app,
+        [
+            "md",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--ensemble",
+            "nvt",
+            "--steps",
+            "2",
+            "--temp",
+            "10",
+            "--struct-name",
+            str(struct_name),
+        ],
+    )
+    assert result.exit_code == 0
+    assert stats_path.exists()
+    assert traj_path.exists()
+    assert final_path.exists()

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -364,7 +364,7 @@ def test_struct_name(tmp_path):
             "--temp",
             "10",
             "--struct-name",
-            str(struct_name),
+            str(struct_path),
         ],
     )
     assert result.exit_code == 0


### PR DESCRIPTION
This doesn't resolve #129, but I think it addresses setting the structure name more straightforwardly than #136.

I would suggest we either remove `file_prefix`, or (preferably, in my opinion) fix the results/final files that no longer respect use it in the way other files do.