### PR TITLE
Add pressure option for geomopt

### DIFF
--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -20,7 +20,8 @@ from janus_core.helpers.log import config_logger
 from janus_core.helpers.utils import none_to_dict
 
 
-def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
+def optimize(
+    # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
     struct: Atoms,
     fmax: float = 0.1,
     steps: int = 1000,

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -105,6 +105,8 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
                 )
             if "constant_volume" in filter_kwargs:
                 logger.info("constant_volume: %s", filter_kwargs["constant_volume"])
+            if "scalar_pressure" in filter_kwargs:
+                logger.info("scalar_pressure: %s", filter_kwargs["scalar_pressure"])
 
     else:
         dyn = optimizer(struct, **opt_kwargs)

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -105,7 +105,7 @@ def geomopt(
         Whether to fully optimize the cell vectors, angles, and atomic positions.
         Default is False.
     pressure : float
-        Scalar pressure when optimizing cell vectors, in bar. Passed to the filter
+        Scalar pressure when optimizing cell geometry, in bar. Passed to the filter
         function if either `vectors_only` or `fully_opt` is True. Default is 0.0.
     out : Optional[Path]
         Path to save optimized structure, or last structure if optimization did not

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Annotated
 
+from ase import units
 from typer import Context, Option, Typer
 from typer_config import use_config
 
@@ -40,7 +41,9 @@ def geomopt(
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,
-    fmax: Annotated[float, Option(help="Maximum force for convergence.")] = 0.1,
+    fmax: Annotated[
+        float, Option(help="Maximum force for convergence, in eV/Å.")
+    ] = 0.1,
     steps: Annotated[int, Option(help="Maximum number of optimization steps.")] = 1000,
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
@@ -54,6 +57,9 @@ def geomopt(
             help="Fully optimize the cell vectors, angles, and atomic positions.",
         ),
     ] = False,
+    pressure: Annotated[
+        float, Option(help="Scalar pressure when optimizing cell vectors, in bar.")
+    ] = 0.0,
     out: Annotated[
         Path,
         Option(
@@ -84,8 +90,7 @@ def geomopt(
     struct : Path
         Path of structure to simulate.
     fmax : float
-        Set force convergence criteria for optimizer in units eV/Å.
-        Default is 0.1.
+        Set force convergence criteria for optimizer, in eV/Å. Default is 0.1.
     steps : int
         Set maximum number of optimization steps to run. Default is 1000.
     arch : Optional[str]
@@ -99,6 +104,9 @@ def geomopt(
     fully_opt : bool
         Whether to fully optimize the cell vectors, angles, and atomic positions.
         Default is False.
+    pressure : float
+        Scalar pressure when optimizing cell vectors, in bar. Passed to the filter
+        function if either `vectors_only` or `fully_opt` is True. Default is 0.0.
     out : Optional[Path]
         Path to save optimized structure, or last structure if optimization did not
         converge. Default is inferred from name of structure file.
@@ -159,6 +167,7 @@ def geomopt(
     # Set hydrostatic_strain
     # If not passed --fully-opt or --vectors-only, will be unused
     filter_kwargs = {"hydrostatic_strain": vectors_only}
+    filter_kwargs["scalar_pressure"] = pressure * units.bar
 
     # Use default filter if passed --fully-opt or --vectors-only
     # Otherwise override with None

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -58,7 +58,7 @@ def geomopt(
         ),
     ] = False,
     pressure: Annotated[
-        float, Option(help="Scalar pressure when optimizing cell vectors, in bar.")
+        float, Option(help="Scalar pressure when optimizing cell geometry, in bar.")
     ] = 0.0,
     out: Annotated[
         Path,

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -131,7 +131,8 @@ def test_fully_opt(tmp_path):
     assert result.exit_code == 0
 
     assert_log_contains(
-        log_path, includes=["Using filter", "hydrostatic_strain: False"]
+        log_path,
+        includes=["Using filter", "hydrostatic_strain: False", "scalar_pressure: 0.0"],
     )
 
     atoms = read(results_path)
@@ -194,6 +195,37 @@ def test_vectors_not_fully_opt(tmp_path):
     assert result.exit_code == 0
 
     assert_log_contains(log_path, includes=["Using filter", "hydrostatic_strain: True"])
+
+
+test_data = ["--vectors-only", "--fully-opt"]
+
+
+@pytest.mark.parametrize("option", test_data)
+def test_scalar_pressure(option, tmp_path):
+    """Test passing --pressure with --vectors-only."""
+    results_path = tmp_path / "NaCl-opt.xyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl-deformed.cif",
+            "--out",
+            results_path,
+            option,
+            "--pressure",
+            "100",
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+    assert_log_contains(log_path, includes=["scalar_pressure: 6.24"])
 
 
 def test_duplicate_traj(tmp_path):


### PR DESCRIPTION
Resolves #152

As discussed in the issue, we may want a more general kwargs (filter-kwargs, or even more generally minimize-kwargs) to allow further options to be set e.g. `constant_volume` (happy to address that in this PR, or open a new issue).