### PR TITLE
Read all structures in trajectory by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ janus singlepoint --struct tests/data/NaCl.cif --arch mace --calc-kwargs "{'mode
 
 This calculates both forces and energies, defines the MLIP architecture and path to your locally saved model, and changes where the log and results files are saved.
 
-> [!NOTE]                                                                                                                            > The MACE calculator currently returns energy, forces and stress together, so in this case the choice of property will not change the output.
+> [!NOTE]
+> The MACE calculator currently returns energy, forces and stress together, so in this case the choice of property will not change the output.
 
 By default, all structures in a trajectory file will be read, but specific structures can be selected using --read-kwargs:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ janus singlepoint --struct tests/data/NaCl.cif --arch mace --calc-kwargs "{'mode
 
 This calculates both forces and energies, defines the MLIP architecture and path to your locally saved model, and changes where the log and results files are saved.
 
-Note: the MACE calculator currently returns energy, forces and stress together, so in this case the choice of property will not change the output.
+> [!NOTE]                                                                                                                            > The MACE calculator currently returns energy, forces and stress together, so in this case the choice of property will not change the output.
+
+By default, all structures in a trajectory file will be read, but specific structures can be selected using --read-kwargs:
+
+```shell
+janus singlepoint --struct tests/data/benzene-traj.xyz --read-kwargs "{'index': 0}"
+```
 
 For all options, run `janus singlepoint --help`.
 

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -44,7 +44,7 @@ class SinglePoint:
         Device to run model on. Default is "cpu".
     read_kwargs : ASEReadArgs
         Keyword arguments to pass to ase.io.read. By default,
-        read_kwargs["index"] = ":".
+        read_kwargs["index"] is ":".
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
     log_kwargs : Optional[dict[str, Any]]
@@ -107,7 +107,7 @@ class SinglePoint:
             Device to run MLIP model on. Default is "cpu".
         read_kwargs : Optional[ASEReadArgs]
             Keyword arguments to pass to ase.io.read. By default,
-            read_kwargs["index"] = ":".
+            read_kwargs["index"] is ":".
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
         log_kwargs : Optional[dict[str, Any]]

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -43,7 +43,8 @@ class SinglePoint:
     device : Devices
         Device to run model on. Default is "cpu".
     read_kwargs : ASEReadArgs
-        Keyword arguments to pass to ase.io.read. Default is {}.
+        Keyword arguments to pass to ase.io.read. By default,
+        read_kwargs["index"] = ":".
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
     log_kwargs : Optional[dict[str, Any]]
@@ -105,7 +106,8 @@ class SinglePoint:
         device : Devices
             Device to run MLIP model on. Default is "cpu".
         read_kwargs : Optional[ASEReadArgs]
-            Keyword arguments to pass to ase.io.read. Default is {}.
+            Keyword arguments to pass to ase.io.read. By default,
+            read_kwargs["index"] = ":".
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
         log_kwargs : Optional[dict[str, Any]]
@@ -137,6 +139,9 @@ class SinglePoint:
         self.device = device
         self.struct_path = struct_path
         self.struct_name = struct_name
+
+        # Read full trajectory by default
+        read_kwargs.setdefault("index", ":")
 
         # Read structure if given as path
         if self.struct_path:
@@ -196,6 +201,9 @@ class SinglePoint:
         if isinstance(self.struct, list):
             for struct in self.struct:
                 struct.calc = calculator
+            # Return single Atoms object if only one image in list
+            if len(self.struct) == 1:
+                self.struct = self.struct[0]
         else:
             self.struct.calc = calculator
 

--- a/tests/data/singlepoint_config.yml
+++ b/tests/data/singlepoint_config.yml
@@ -5,4 +5,4 @@ out: "NaCl-results.xyz"
 calc-kwargs:
   model: "small"
 read-kwargs:
-  index: ":"
+  index: 0

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -84,7 +84,6 @@ def test_single_point_traj():
     single_point = SinglePoint(
         struct_path=DATA_PATH / "benzene-traj.xyz",
         architecture="mace",
-        read_kwargs={"index": ":"},
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -250,14 +250,14 @@ def test_config(tmp_path):
     )
     assert result.exit_code == 0
     atoms = read(results_path, index=":")
-    assert len(atoms) == 2
+    assert len(atoms) == 1
 
     # Read singlepoint summary file
     with open(summary_path, encoding="utf8") as file:
         sp_summary = yaml.safe_load(file)
 
     assert "index" in sp_summary["inputs"]["calc"]["read_kwargs"]
-    assert sp_summary["inputs"]["calc"]["read_kwargs"]["index"] == ":"
+    assert sp_summary["inputs"]["calc"]["read_kwargs"]["index"] == 0
 
 
 def test_invalid_config():


### PR DESCRIPTION
Resolves #114

Tests are modified so that where previously we had to specify `index=":"` via read_kwargs, the same result is obtained by default, while specifying the index is instead tested by choosing a single structure from a trajectory.