### PR TITLE
Add integrator kwargs to MD

### DIFF
--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -669,7 +669,7 @@ class NPT(MolecularDynamics):
     file_prefix : Optional[PathLike]
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
-    integrator_kwargs : Optional[dict[str, Any]]
+    ensemble_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -689,7 +689,7 @@ class NPT(MolecularDynamics):
         pressure: float = 0.0,
         ensemble: Ensembles = "npt",
         file_prefix: Optional[PathLike] = None,
-        integrator_kwargs: Optional[dict[str, Any]] = None,
+        ensemble_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -712,7 +712,7 @@ class NPT(MolecularDynamics):
         file_prefix : Optional[PathLike]
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
-        integrator_kwargs : Optional[dict[str, Any]]
+        ensemble_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
@@ -720,7 +720,7 @@ class NPT(MolecularDynamics):
         self.pressure = pressure
         super().__init__(ensemble=ensemble, file_prefix=file_prefix, *args, **kwargs)
 
-        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
+        ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
         self.ttime = thermostat_time * units.fs
 
         if barostat_time:
@@ -740,7 +740,7 @@ class NPT(MolecularDynamics):
             pfactor=pfactor,
             append_trajectory=self.traj_append,
             externalstress=self.pressure * units.bar,
-            **integrator_kwargs,
+            **ensemble_kwargs,
         )
 
     @property
@@ -830,7 +830,7 @@ class NVT(MolecularDynamics):
         Friction coefficient in fs^-1. Default is 0.005.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nvt".
-    integrator_kwargs : Optional[dict[str, Any]]
+    ensemble_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -846,7 +846,7 @@ class NVT(MolecularDynamics):
         *args,
         friction: float = 0.005,
         ensemble: Ensembles = "nvt",
-        integrator_kwargs: Optional[dict[str, Any]] = None,
+        ensemble_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -860,21 +860,21 @@ class NVT(MolecularDynamics):
             Friction coefficient in fs^-1. Default is 0.005.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nvt".
-        integrator_kwargs : Optional[dict[str, Any]]
+        ensemble_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
         super().__init__(ensemble=ensemble, *args, **kwargs)
 
-        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
+        ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
         self.dyn = Langevin(
             self.struct,
             timestep=self.timestep,
             temperature_K=self.temp,
             friction=friction / units.fs,
             append_trajectory=self.traj_append,
-            **integrator_kwargs,
+            **ensemble_kwargs,
         )
 
     def get_log_stats(self) -> str:
@@ -913,7 +913,7 @@ class NVE(MolecularDynamics):
         Additional arguments.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nve".
-    integrator_kwargs : Optional[dict[str, Any]]
+    ensemble_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -928,7 +928,7 @@ class NVE(MolecularDynamics):
         self,
         *args,
         ensemble: Ensembles = "nve",
-        integrator_kwargs: Optional[dict[str, Any]] = None,
+        ensemble_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -940,19 +940,19 @@ class NVE(MolecularDynamics):
             Additional arguments.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nve".
-        integrator_kwargs : Optional[dict[str, Any]]
+        ensemble_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
         super().__init__(ensemble=ensemble, *args, **kwargs)
-        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
+        ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
 
         self.dyn = VelocityVerlet(
             self.struct,
             timestep=self.timestep,
             append_trajectory=self.traj_append,
-            **integrator_kwargs,
+            **ensemble_kwargs,
         )
 
 
@@ -968,7 +968,7 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
         Thermostat time, in fs. Default is 50.0.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nvt-nh".
-    integrator_kwargs : Optional[dict[str, Any]]
+    ensemble_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -979,7 +979,7 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
         *args,
         thermostat_time: float = 50.0,
         ensemble: Ensembles = "nvt-nh",
-        integrator_kwargs: Optional[dict[str, Any]] = None,
+        ensemble_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -993,17 +993,17 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
             Thermostat time, in fs. Default is 50.0.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nvt-nh".
-        integrator_kwargs : Optional[dict[str, Any]]
+        ensemble_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
-        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
+        ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
         super().__init__(
             ensemble=ensemble,
             thermostat_time=thermostat_time,
             barostat_time=None,
-            integrator_kwargs=integrator_kwargs,
+            ensemble_kwargs=ensemble_kwargs,
             *args,
             **kwargs,
         )
@@ -1053,7 +1053,7 @@ class NPH(NPT):
     file_prefix : Optional[PathLike]
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
-    integrator_kwargs : Optional[dict[str, Any]]
+    ensemble_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -1072,7 +1072,7 @@ class NPH(NPT):
         pressure: float = 0.0,
         ensemble: Ensembles = "nph",
         file_prefix: Optional[PathLike] = None,
-        integrator_kwargs: Optional[dict[str, Any]] = None,
+        ensemble_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -1093,12 +1093,12 @@ class NPH(NPT):
         file_prefix : Optional[PathLike]
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
-        integrator_kwargs : Optional[dict[str, Any]]
+        ensemble_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
-        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
+        ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
         super().__init__(
             *args,
             thermostat_time=thermostat_time,
@@ -1107,6 +1107,6 @@ class NPH(NPT):
             pressure=pressure,
             ensemble=ensemble,
             file_prefix=file_prefix,
-            integrator_kwargs=integrator_kwargs,
+            ensemble_kwargs=ensemble_kwargs,
             **kwargs,
         )

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -669,6 +669,8 @@ class NPT(MolecularDynamics):
     file_prefix : Optional[PathLike]
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
+    integrator_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -687,6 +689,7 @@ class NPT(MolecularDynamics):
         pressure: float = 0.0,
         ensemble: Ensembles = "npt",
         file_prefix: Optional[PathLike] = None,
+        integrator_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -709,12 +712,15 @@ class NPT(MolecularDynamics):
         file_prefix : Optional[PathLike]
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
+        integrator_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
         self.pressure = pressure
         super().__init__(ensemble=ensemble, file_prefix=file_prefix, *args, **kwargs)
 
+        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
         self.ttime = thermostat_time * units.fs
 
         if barostat_time:
@@ -734,6 +740,7 @@ class NPT(MolecularDynamics):
             pfactor=pfactor,
             append_trajectory=self.traj_append,
             externalstress=self.pressure * units.bar,
+            **integrator_kwargs,
         )
 
     @property
@@ -823,6 +830,8 @@ class NVT(MolecularDynamics):
         Friction coefficient in fs^-1. Default is 0.005.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nvt".
+    integrator_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -837,6 +846,7 @@ class NVT(MolecularDynamics):
         *args,
         friction: float = 0.005,
         ensemble: Ensembles = "nvt",
+        integrator_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -850,17 +860,21 @@ class NVT(MolecularDynamics):
             Friction coefficient in fs^-1. Default is 0.005.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nvt".
+        integrator_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
         super().__init__(ensemble=ensemble, *args, **kwargs)
 
+        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
         self.dyn = Langevin(
             self.struct,
             timestep=self.timestep,
             temperature_K=self.temp,
             friction=friction / units.fs,
             append_trajectory=self.traj_append,
+            **integrator_kwargs,
         )
 
     def get_log_stats(self) -> str:
@@ -899,6 +913,8 @@ class NVE(MolecularDynamics):
         Additional arguments.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nve".
+    integrator_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -908,7 +924,13 @@ class NVE(MolecularDynamics):
         Configured NVE dynamics.
     """
 
-    def __init__(self, *args, ensemble: Ensembles = "nve", **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        ensemble: Ensembles = "nve",
+        integrator_kwargs: Optional[dict[str, Any]] = None,
+        **kwargs,
+    ) -> None:
         """
         Initialise dynamics for NVE simulation.
 
@@ -918,14 +940,19 @@ class NVE(MolecularDynamics):
             Additional arguments.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nve".
+        integrator_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
         super().__init__(ensemble=ensemble, *args, **kwargs)
+        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
+
         self.dyn = VelocityVerlet(
             self.struct,
             timestep=self.timestep,
             append_trajectory=self.traj_append,
+            **integrator_kwargs,
         )
 
 
@@ -941,6 +968,8 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
         Thermostat time, in fs. Default is 50.0.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nvt-nh".
+    integrator_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
     """
@@ -950,6 +979,7 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
         *args,
         thermostat_time: float = 50.0,
         ensemble: Ensembles = "nvt-nh",
+        integrator_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -963,13 +993,17 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
             Thermostat time, in fs. Default is 50.0.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nvt-nh".
+        integrator_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
+        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
         super().__init__(
             ensemble=ensemble,
             thermostat_time=thermostat_time,
             barostat_time=None,
+            integrator_kwargs=integrator_kwargs,
             *args,
             **kwargs,
         )
@@ -1019,6 +1053,8 @@ class NPH(NPT):
     file_prefix : Optional[PathLike]
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
+    integrator_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to MD integrator. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -1036,6 +1072,7 @@ class NPH(NPT):
         pressure: float = 0.0,
         ensemble: Ensembles = "nph",
         file_prefix: Optional[PathLike] = None,
+        integrator_kwargs: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         """
@@ -1056,9 +1093,12 @@ class NPH(NPT):
         file_prefix : Optional[PathLike]
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
+        integrator_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to MD integrator. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
+        integrator_kwargs = integrator_kwargs if integrator_kwargs else {}
         super().__init__(
             *args,
             thermostat_time=thermostat_time,
@@ -1067,5 +1107,6 @@ class NPH(NPT):
             pressure=pressure,
             ensemble=ensemble,
             file_prefix=file_prefix,
+            integrator_kwargs=integrator_kwargs,
             **kwargs,
         )

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -670,7 +670,7 @@ class NPT(MolecularDynamics):
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
     ensemble_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to MD integrator. Default is {}.
+        Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -713,7 +713,7 @@ class NPT(MolecularDynamics):
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
         ensemble_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to MD integrator. Default is {}.
+            Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
@@ -831,7 +831,7 @@ class NVT(MolecularDynamics):
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nvt".
     ensemble_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to MD integrator. Default is {}.
+        Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -861,7 +861,7 @@ class NVT(MolecularDynamics):
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nvt".
         ensemble_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to MD integrator. Default is {}.
+            Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
@@ -914,7 +914,7 @@ class NVE(MolecularDynamics):
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nve".
     ensemble_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to MD integrator. Default is {}.
+        Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -941,7 +941,7 @@ class NVE(MolecularDynamics):
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nve".
         ensemble_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to MD integrator. Default is {}.
+            Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
@@ -969,7 +969,7 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nvt-nh".
     ensemble_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to MD integrator. Default is {}.
+        Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
     """
@@ -994,7 +994,7 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nvt-nh".
         ensemble_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to MD integrator. Default is {}.
+            Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
         """
@@ -1054,7 +1054,7 @@ class NPH(NPT):
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
     ensemble_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to MD integrator. Default is {}.
+        Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
 
@@ -1094,7 +1094,7 @@ class NPH(NPT):
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
         ensemble_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to MD integrator. Default is {}.
+            Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
         """

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -208,7 +208,7 @@ def md(
     friction : float
         Friction coefficient in fs^-1. Default is 0.005.
     ensemble_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to the MD integrator. Default is {}.
+        Keyword arguments to pass to ensemble initialization. Default is {}.
     arch : Optional[str]
         MLIP architecture to use for molecular dynamics.
         Default is "mace_mp".

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -12,7 +12,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
-    IntegratorKwargs,
+    EnsembleKwargs,
     LogPath,
     MinimizeKwargs,
     ReadKwargs,
@@ -75,7 +75,7 @@ def md(
     friction: Annotated[
         float, Option(help="Friction coefficient for NVT simulation, in fs^-1.")
     ] = 0.005,
-    integrator_kwargs: IntegratorKwargs = None,
+    ensemble_kwargs: EnsembleKwargs = None,
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     read_kwargs: ReadKwargs = None,
@@ -207,7 +207,7 @@ def md(
         Pressure, in bar. Default is 0.0.
     friction : float
         Friction coefficient in fs^-1. Default is 0.005.
-    integrator_kwargs : Optional[dict[str, Any]]
+    ensemble_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the MD integrator. Default is {}.
     arch : Optional[str]
         MLIP architecture to use for molecular dynamics.
@@ -284,8 +284,8 @@ def md(
     # Check options from configuration file are all valid
     check_config(ctx)
 
-    [read_kwargs, calc_kwargs, minimize_kwargs, integrator_kwargs] = parse_typer_dicts(
-        [read_kwargs, calc_kwargs, minimize_kwargs, integrator_kwargs]
+    [read_kwargs, calc_kwargs, minimize_kwargs, ensemble_kwargs] = parse_typer_dicts(
+        [read_kwargs, calc_kwargs, minimize_kwargs, ensemble_kwargs]
     )
 
     if not ensemble in get_args(Ensembles):
@@ -340,7 +340,7 @@ def md(
         "temp_time": temp_time,
         "log_kwargs": log_kwargs,
         "seed": seed,
-        "integrator_kwargs": integrator_kwargs,
+        "ensemble_kwargs": ensemble_kwargs,
     }
 
     # Instantiate MD ensemble

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -12,6 +12,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    IntegratorKwargs,
     LogPath,
     MinimizeKwargs,
     ReadKwargs,
@@ -74,6 +75,7 @@ def md(
     friction: Annotated[
         float, Option(help="Friction coefficient for NVT simulation, in fs^-1.")
     ] = 0.005,
+    integrator_kwargs: IntegratorKwargs = None,
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     read_kwargs: ReadKwargs = None,
@@ -205,6 +207,8 @@ def md(
         Pressure, in bar. Default is 0.0.
     friction : float
         Friction coefficient in fs^-1. Default is 0.005.
+    integrator_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to the MD integrator. Default is {}.
     arch : Optional[str]
         MLIP architecture to use for molecular dynamics.
         Default is "mace_mp".
@@ -280,8 +284,8 @@ def md(
     # Check options from configuration file are all valid
     check_config(ctx)
 
-    [read_kwargs, calc_kwargs, minimize_kwargs] = parse_typer_dicts(
-        [read_kwargs, calc_kwargs, minimize_kwargs]
+    [read_kwargs, calc_kwargs, minimize_kwargs, integrator_kwargs] = parse_typer_dicts(
+        [read_kwargs, calc_kwargs, minimize_kwargs, integrator_kwargs]
     )
 
     if not ensemble in get_args(Ensembles):
@@ -336,6 +340,7 @@ def md(
         "temp_time": temp_time,
         "log_kwargs": log_kwargs,
         "seed": seed,
+        "integrator_kwargs": integrator_kwargs,
     }
 
     # Instantiate MD ensemble

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -138,6 +138,20 @@ MinimizeKwargs = Annotated[
     ),
 ]
 
+IntegratorKwargs = Annotated[
+    TyperDict,
+    Option(
+        parser=parse_dict_class,
+        help=(
+            """
+            Keyword arguments to pass to the integrator. Must be passed as a
+            dictionary wrapped in quotes, e.g. "{'key' : value}".
+            """
+        ),
+        metavar="DICT",
+    ),
+]
+
 LogPath = Annotated[Path, Option(help="Path to save logs to.")]
 
 Summary = Annotated[

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -144,7 +144,7 @@ EnsembleKwargs = Annotated[
         parser=parse_dict_class,
         help=(
             """
-            Keyword arguments to pass to the integrator. Must be passed as a
+            Keyword arguments to pass to ensemble initialization. Must be passed as a
             dictionary wrapped in quotes, e.g. "{'key' : value}".
             """
         ),

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -138,7 +138,7 @@ MinimizeKwargs = Annotated[
     ),
 ]
 
-IntegratorKwargs = Annotated[
+EnsembleKwargs = Annotated[
     TyperDict,
     Option(
         parser=parse_dict_class,

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -840,3 +840,23 @@ def test_cooling(tmp_path):
     assert stats.rows == 2
     assert stats.data[0, 16] == 20.0
     assert stats.data[1, 16] == 10.0
+
+
+def test_integrator_kwargs(tmp_path):
+    """Test setting integrator kwargs."""
+    log_file = tmp_path / "nvt.log"
+
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+
+    npt = NPT(
+        struct=single_point.struct,
+        integrator_kwargs={"mask": (0, 1, 0)},
+        log_kwargs={"filename": log_file},
+    )
+
+    expected_mask = [[False, False, False], [False, True, False], [False, False, False]]
+    assert np.array_equal(npt.dyn.mask, expected_mask)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -842,7 +842,7 @@ def test_cooling(tmp_path):
     assert stats.data[1, 16] == 10.0
 
 
-def test_integrator_kwargs(tmp_path):
+def test_ensemble_kwargs(tmp_path):
     """Test setting integrator kwargs."""
     log_file = tmp_path / "nvt.log"
 
@@ -854,7 +854,7 @@ def test_integrator_kwargs(tmp_path):
 
     npt = NPT(
         struct=single_point.struct,
-        integrator_kwargs={"mask": (0, 1, 0)},
+        ensemble_kwargs={"mask": (0, 1, 0)},
         log_kwargs={"filename": log_file},
     )
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -377,3 +377,37 @@ def test_struct_name(tmp_path):
     assert stats_path.exists()
     assert traj_path.exists()
     assert final_path.exists()
+
+
+def test_integrator_kwargs(tmp_path):
+    """Test passing integrator-kwargs to NPT."""
+    file_prefix = tmp_path / "npt-T300"
+    log_path = tmp_path / "md.log"
+    summary_path = tmp_path / "summary.yml"
+
+    integrator_kwargs = "{'mask': (0, 1, 0)}"
+
+    result = runner.invoke(
+        app,
+        [
+            "md",
+            "--ensemble",
+            "npt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--file-prefix",
+            file_prefix,
+            "--steps",
+            2,
+            "--integrator-kwargs",
+            integrator_kwargs,
+            "--traj-every",
+            1,
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+
+    assert result.exit_code == 0


### PR DESCRIPTION
Resolves #172

To do:

- [x] Improve CLI test. Possibly just pick a value for one of the outputs to check it doesn't change, as we can't check the mask itself is set as we do in the Python.