### PR TITLE
Update ASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ pre-commit install  # install pre-commit hooks
 pytest -v  # discover and run all tests
 ```
 
-Manually updating ASE via https://gitlab.com/ase/ase is strongly recommended, as tags are no longer regularly published. For example:
-
-```shell
-pip install git+https://gitlab.com/ase/ase.git@b31569210d739bd12c8ad2b6ec0290108e049eea
-```
+> [!NOTE]
+> Manually updating ASE via https://gitlab.com/ase/ase is strongly recommended, as tags may not regularly be published. For example:
+> ```shell
+> pip install git+https://gitlab.com/ase/ase.git@b31569210d739bd12c8ad2b6ec0290108e049eea
+> ```
 
 To prevent poetry downgrading ASE when installing in future, add the commit to pyproject.toml:
 

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ pytest -v  # discover and run all tests
 > [!NOTE]
 > Manually updating ASE via https://gitlab.com/ase/ase is strongly recommended, as tags may not regularly be published. For example:
 > ```shell
-> pip install git+https://gitlab.com/ase/ase.git@b31569210d739bd12c8ad2b6ec0290108e049eea
+> pip install git+https://gitlab.com/ase/ase.git@master
 > ```
-
-To prevent poetry downgrading ASE when installing in future, add the commit to pyproject.toml:
-
-```shell
-poetry add git+https://gitlab.com:ase/ase.git#b31569210d739bd12c8ad2b6ec0290108e049eea
-```
+>
+> To prevent poetry downgrading ASE when installing in future, add the repository to pyproject.toml:
+>
+> ```shell
+> poetry add git+https://gitlab.com:ase/ase.git#master
+> ```
 
 ## Examples
 

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -5,19 +5,12 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Union
 import warnings
 
-from ase import Atoms
+from ase import Atoms, filters
+from ase.filters import FrechetCellFilter
 from ase.io import read, write
 import ase.optimize
 from ase.optimize import LBFGS
 from ase.optimize.optimize import Optimizer
-
-try:
-    from ase import filters
-    from ase.filters import FrechetCellFilter as DefaultFilter
-except ImportError:
-    import ase.constraints as filters
-    from ase.constraints import ExpCellFilter as DefaultFilter
-
 from numpy import linalg
 
 from janus_core.helpers.janus_types import ASEOptArgs, ASEWriteArgs
@@ -36,8 +29,7 @@ def _set_functions(
     optimizer : Union[Callable, str]
         Optimization function, or name of function from ase.optimize.
     filter_func : Optional[Union[Callable], str]]
-        ASE filter function, or name of function from ase.filters or ase.constraints.
-        Default is None.
+        ASE filter function, or name of function from ase.filters. Default is None.
 
     Returns
     -------
@@ -61,7 +53,7 @@ def _set_functions(
 
 def set_optimizer(
     struct: Atoms,
-    filter_func: Optional[Union[Callable, str]] = DefaultFilter,
+    filter_func: Optional[Union[Callable, str]] = FrechetCellFilter,
     filter_kwargs: Optional[dict[str, Any]] = None,
     optimizer: Union[Callable, str] = LBFGS,
     opt_kwargs: Optional[ASEOptArgs] = None,
@@ -75,9 +67,8 @@ def set_optimizer(
     struct : Atoms
         Atoms object to optimize geometry for.
     filter_func : Optional[Union[Callable, str]]
-        Filter function, or name of function from ase.filters or ase.constraints, to
-        apply constraints to atoms. Default is `FrechetCellFilter` if available
-        otherwise `ExpCellFilter`.
+        Filter function, or name of function from ase.filters to apply constraints to
+        atoms. Default is `FrechetCellFilter`.
     filter_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to filter_func. Default is {}.
     optimizer : Union[Callable, str]
@@ -125,7 +116,7 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
     steps: int = 1000,
     symmetry_tolerance: float = 0.001,
     angle_tolerance: float = -1.0,
-    filter_func: Optional[Callable] = DefaultFilter,
+    filter_func: Optional[Callable] = FrechetCellFilter,
     filter_kwargs: Optional[dict[str, Any]] = None,
     optimizer: Callable = LBFGS,
     opt_kwargs: Optional[ASEOptArgs] = None,
@@ -153,9 +144,8 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
         Angle precision for spglib symmetry determination, in degrees. Default is -1.0,
         which means an internally optimized routine is used to judge symmetry.
     filter_func : Optional[Union[Callable, str]]
-        Filter function, or name of function from ase.filters or ase.constraints, to
-        apply constraints to atoms. Default is `FrechetCellFilter` if available
-        otherwise `ExpCellFilter`.
+        Filter function, or name of function from ase.filters to apply constraints to
+        atoms. Default is `FrechetCellFilter`.
     filter_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to filter_func. Default is {}.
     optimizer : Union[Callable, str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ janus = "janus_core.cli.janus:app"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-ase = "3.22.1"
+ase = "^3.23"
 mace-torch = "^0.3.4"
 pyyaml = "^6.0.1"
 typer = "^0.9.0"

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -52,7 +52,7 @@ def test_eos(tmp_path):
     assert lines[0] == "#Lattice Scalar | Energy [eV] | Volume [Å^3] \n"
     assert lines[4].split()[0] == "1.0"
     assert float(lines[4].split()[1]) == pytest.approx(-27.046359959669214)
-    assert float(lines[4].split()[2]) == pytest.approx(184.28932483484286)
+    assert float(lines[4].split()[2]) == pytest.approx(184.05884033013012)
 
     # Check contents of fitted data file
     with open(eos_fit_path, encoding="utf8") as eos_fit_file:

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -140,8 +140,22 @@ def test_hydrostatic_strain():
         single_point_2.struct, filter_kwargs={"hydrostatic_strain": False}
     )
 
-    expected_1 = [5.69139709, 5.69139709, 5.69139709, 89.0, 90.0, 90.0]
-    expected_2 = [5.68834069, 5.68893345, 5.68932555, 89.75938298, 90.0, 90.0]
+    expected_1 = [
+        5.687545288920282,
+        5.687545288920282,
+        5.687545288920282,
+        89.0,
+        90.0,
+        90.0,
+    ]
+    expected_2 = [
+        5.688268799219085,
+        5.688750772505896,
+        5.688822747326383,
+        89.26002493790229,
+        90.0,
+        90.0,
+    ]
     assert struct_1.cell.cellpar() == pytest.approx(expected_1)
     assert struct_2.cell.cellpar() == pytest.approx(expected_2)
 
@@ -175,16 +189,23 @@ def test_restart(tmp_path):
 
     init_energy = single_point.run("energy")["energy"]
 
+    # Check unconverged warning
     with pytest.warns(UserWarning):
         optimize(
-            single_point.struct, steps=2, opt_kwargs={"restart": tmp_path / "NaCl.pkl"}
+            single_point.struct,
+            steps=2,
+            opt_kwargs={"restart": tmp_path / "NaCl.pkl"},
+            fmax=0.0001,
         )
 
     intermediate_energy = single_point.run("energy")["energy"]
     assert intermediate_energy < init_energy
 
     optimize(
-        single_point.struct, steps=2, opt_kwargs={"restart": tmp_path / "NaCl.pkl"}
+        single_point.struct,
+        steps=2,
+        opt_kwargs={"restart": tmp_path / "NaCl.pkl"},
+        fmax=0.0001,
     )
     final_energy = single_point.run("energy")["energy"]
     assert final_energy < intermediate_energy

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -104,7 +104,7 @@ def test_traj(tmp_path):
     )
     assert result.exit_code == 0
     atoms = read(traj_path)
-    assert "forces" in atoms.arrays
+    assert "forces" in atoms.calc.results
 
 
 def test_fully_opt(tmp_path):
@@ -136,7 +136,14 @@ def test_fully_opt(tmp_path):
     )
 
     atoms = read(results_path)
-    expected = [5.68834069, 5.68893345, 5.68932555, 89.75938298, 90.0, 90.0]
+    expected = [
+        5.688268799219085,
+        5.688750772505896,
+        5.688822747326383,
+        89.26002493790229,
+        90.0,
+        90.0,
+    ]
     assert atoms.cell.cellpar() == pytest.approx(expected)
 
 
@@ -167,7 +174,14 @@ def test_fully_opt_and_vectors(tmp_path):
     assert_log_contains(log_path, includes=["Using filter", "hydrostatic_strain: True"])
 
     atoms = read(results_path)
-    expected = [5.69139709, 5.69139709, 5.69139709, 89.0, 90.0, 90.0]
+    expected = [
+        5.687545288920282,
+        5.687545288920282,
+        5.687545288920282,
+        89.0,
+        90.0,
+        90.0,
+    ]
     assert atoms.cell.cellpar() == pytest.approx(expected)
 
 

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -104,13 +104,13 @@ def test_single_point_write():
         architecture="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
-    assert "forces" not in single_point.struct.arrays
+    assert "forces" not in single_point.struct.calc.results
 
     single_point.run(write_results=True)
 
     atoms = read_atoms(results_path)
     assert atoms.get_potential_energy() is not None
-    assert "forces" in atoms.arrays
+    assert "forces" in atoms.calc.results
 
 
 def test_single_point_write_kwargs(tmp_path):
@@ -123,12 +123,12 @@ def test_single_point_write_kwargs(tmp_path):
         architecture="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
-    assert "forces" not in single_point.struct.arrays
+    assert "forces" not in single_point.struct.calc.results
 
     single_point.run(write_results=True, write_kwargs={"filename": results_path})
     atoms = read(results_path)
     assert atoms.get_potential_energy() is not None
-    assert "forces" in atoms.arrays
+    assert "forces" in atoms.calc.results
 
 
 def test_single_point_write_nan(tmp_path):

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -48,7 +48,7 @@ def test_singlepoint(tmp_path):
     atoms = read_atoms(results_path)
     assert result.exit_code == 0
     assert atoms.get_potential_energy() is not None
-    assert "forces" in atoms.arrays
+    assert "forces" in atoms.calc.results
 
 
 def test_properties(tmp_path):


### PR DESCRIPTION
Resolves #178

Changes required are:

- Access to the `FrechetCellFilter`, which is used by default, which changes a few numerical values slightly compared to the `ExpCellFilter`.
- `Atoms.arrays` no longer appears to be populated when `get_potential_energy` is run. This would be changed anyway via #176 (note: further conflicts will be added, as we'll need to change `calc.results` for `info`)

~Minor conflicts will also need to be resolved with #179 where we import filters.~ (rebased)
