### PR TITLE
Add correlator with stress correlations

### DIFF
--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -175,7 +175,7 @@ janus\_core.helpers.post_process module
    :show-inheritance:
 
 janus\_core.helpers.correlator module
----------------------------------------
+-------------------------------------
 
 .. automodule:: janus_core.helpers.correlator
    :members:
@@ -185,7 +185,7 @@ janus\_core.helpers.correlator module
    :show-inheritance:
 
 janus\_core.helpers.observables module
----------------------------------------
+--------------------------------------
 
 .. automodule:: janus_core.helpers.observables
    :members:

--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -214,7 +214,7 @@ janus\_core.helpers.janus\_types module
    :undoc-members:
    :show-inheritance:
    :exclude-members: clear,copy,setdefault,items,keys,get,pop,popitem,fromkeys,update,values
-
+   :special-members:
 
 janus\_core.helpers.utils module
 --------------------------------

--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -174,6 +174,16 @@ janus\_core.helpers.post_process module
    :undoc-members:
    :show-inheritance:
 
+janus\_core.helpers.correlator module
+---------------------------------------
+
+.. automodule:: janus_core.helpers.correlator
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
 janus\_core.helpers.train module
 --------------------------------
 

--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -184,6 +184,17 @@ janus\_core.helpers.correlator module
    :undoc-members:
    :show-inheritance:
 
+janus\_core.helpers.observables module
+---------------------------------------
+
+.. automodule:: janus_core.helpers.observables
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
+
 janus\_core.helpers.train module
 --------------------------------
 

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -162,7 +162,9 @@ Built-in observables are collected within the ``janus_core.helpers.observables``
 
     Stress("xy", False)
 
-A new built-in observables can be implemented by a class with the method::
+A new built-in observables can be implemented by a class with the method:
+
+.. code-block:: python
 
    def __call__(self, atoms: Atoms, *args, **kwargs) -> float
 

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -150,3 +150,20 @@ Running these tests requires an additional flag to be passed to ``pytest``::
 Alternatively, using ``tox``::
 
     tox -e extra-mlips
+
+Adding a new Observable
+=======================
+
+Additional built-in observable quantities may be added for use within the ``janus_core.helpers.correlator.Correlation``s. These should conform to the ``__call__`` signature of ``janus_core.helpers.janus_types.Observable``. For a user this can be accomplished by writing a function, or class also implementing a commensurate ``__call__``.
+
+Built-in observables are collected within ``janus_core.helpers.observables``. For example the ``janus_core.helpers.observables.Stress`` observable allows a user to quickly setup a given correlation of stress tensor components (with and without the ideal gas constribution). An observable for the ``xy`` component is obtained without the ideal gas contribution as::
+
+    Stress("xy", False)
+
+A new built-in observables can be implemented by a class with the method::
+
+   def __call__(self, atoms: Atoms, *args, **kwargs) -> float
+
+The ``__call__`` should contain all the logic for obtaining some ``float`` value from an ``Atoms`` object, alongside optional positional arguments and kwargs. The args and kwargs are set by a user when specifying correlations for a ``janus_core.calculations.md.MolecularDynamics`` run. See also ``janus_core.helpers.janus_types.CorrelationKwargs``. These are set at the instantiation of the ``janus_core.calculations.md.MolecularDynamics`` object and are not modified. These could be used e.g. to specify an observable calculated only from one atom's data.
+
+``janus_core.helpers.observables.Stress`` includes a constructor to take a symbolic component, e.g. ``"xx"`` or ``"yz"``, and determine the index required from ``ase.Atoms.get_stress`` on instantiation for ease of use.

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -156,7 +156,9 @@ Adding a new Observable
 
 Additional built-in observable quantities may be added for use by the ``janus_core.helpers.correlator.Correlation`` class. These should conform to the ``__call__`` signature of ``janus_core.helpers.janus_types.Observable``. For a user this can be accomplished by writing a function, or class also implementing a commensurate ``__call__``.
 
-Built-in observables are collected within the ``janus_core.helpers.observables`` module. For example the ``janus_core.helpers.observables.Stress`` observable allows a user to quickly setup a given correlation of stress tensor components (with and without the ideal gas contribution). An observable for the ``xy`` component is obtained without the ideal gas contribution as::
+Built-in observables are collected within the ``janus_core.helpers.observables`` module. For example the ``janus_core.helpers.observables.Stress`` observable allows a user to quickly setup a given correlation of stress tensor components (with and without the ideal gas contribution). An observable for the ``xy`` component is obtained without the ideal gas contribution as:
+
+.. code-block:: python
 
     Stress("xy", False)
 

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -156,7 +156,7 @@ Adding a new Observable
 
 Additional built-in observable quantities may be added for use by the ``janus_core.helpers.correlator.Correlation`` class. These should conform to the ``__call__`` signature of ``janus_core.helpers.janus_types.Observable``. For a user this can be accomplished by writing a function, or class also implementing a commensurate ``__call__``.
 
-Built-in observables are collected within ``janus_core.helpers.observables``. For example the ``janus_core.helpers.observables.Stress`` observable allows a user to quickly setup a given correlation of stress tensor components (with and without the ideal gas constribution). An observable for the ``xy`` component is obtained without the ideal gas contribution as::
+Built-in observables are collected within the ``janus_core.helpers.observables`` module. For example the ``janus_core.helpers.observables.Stress`` observable allows a user to quickly setup a given correlation of stress tensor components (with and without the ideal gas contribution). An observable for the ``xy`` component is obtained without the ideal gas contribution as::
 
     Stress("xy", False)
 

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -154,7 +154,7 @@ Alternatively, using ``tox``::
 Adding a new Observable
 =======================
 
-Additional built-in observable quantities may be added for use within the ``janus_core.helpers.correlator.Correlation``s. These should conform to the ``__call__`` signature of ``janus_core.helpers.janus_types.Observable``. For a user this can be accomplished by writing a function, or class also implementing a commensurate ``__call__``.
+Additional built-in observable quantities may be added for use by the ``janus_core.helpers.correlator.Correlation`` class. These should conform to the ``__call__`` signature of ``janus_core.helpers.janus_types.Observable``. For a user this can be accomplished by writing a function, or class also implementing a commensurate ``__call__``.
 
 Built-in observables are collected within ``janus_core.helpers.observables``. For example the ``janus_core.helpers.observables.Stress`` observable allows a user to quickly setup a given correlation of stress tensor components (with and without the ideal gas constribution). An observable for the ``xy`` component is obtained without the ideal gas contribution as::
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -474,23 +474,18 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
 
     def _parse_correlations(self):
         """Parse correlation kwargs into Correlations."""
-        if not self.correlation_kwargs:
-            self._correlations = None
-        elif len(self.correlation_kwargs) > 0:
-            self._correlations = []
-            for cor in self.correlation_kwargs:
-                self._correlations.append(Correlation(**cor))
+        if self.correlation_kwargs:
+            self._correlations = [Correlation(**cor) for cor in self.correlation_kwargs]
         else:
-            self._correlations = None
+            self._correlations = ()
 
     def _attach_correlations(self):
         """Attach all correlations to self.dyn."""
-        if self._correlations:
-            for i, _ in enumerate(self._correlations):
-                self.dyn.attach(
-                    partial(lambda i: self._correlations[i].update(self.dyn.atoms), i),
-                    self._correlations[i].update_frequency,
-                )
+        for i, _ in enumerate(self._correlations):
+            self.dyn.attach(
+                partial(lambda i: self._correlations[i].update(self.dyn.atoms), i),
+                self._correlations[i].update_frequency,
+            )
 
     def _write_correlations(self):
         """Write out the correlations."""

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -491,7 +491,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
 
     def _attach_correlations(self):
         """Attach all correlations to self.dyn."""
-        # pylint: disable=W0640
+        # pylint: disable=cell-var-from-loop
         if self._correlations:
             for i, _ in enumerate(self._correlations):
                 self.dyn.attach(

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -761,8 +761,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         if self.post_process_kwargs:
             self._post_process()
 
-        if self.correlation_kwargs:
-            self._write_correlations()
+        self._write_correlations()
 
     def _run_dynamics(self) -> None:
         """Run dynamics and/or temperature ramp."""

--- a/janus_core/helpers/correlator.py
+++ b/janus_core/helpers/correlator.py
@@ -4,12 +4,9 @@ Module to correlate scalar data on-the-fly.
 
 from abc import abstractmethod
 from collections.abc import Iterable
-from typing import Union
 
 from ase import units
-from ase.md.langevin import Langevin
-from ase.md.npt import NPT as ASE_NPT
-from ase.md.verlet import VelocityVerlet
+from ase.md import md as MD
 import numpy as np
 
 
@@ -219,7 +216,7 @@ class Observable:
 
     @abstractmethod
     # pylint: disable=C0103
-    def get(self, md: Union[Langevin, VelocityVerlet, ASE_NPT]) -> float:
+    def get(self, md: MD) -> float:
         """
         Get an observable component from md.
 
@@ -302,7 +299,7 @@ class Correlation:
         return self._update_frequency
 
     # pylint: disable=C0103
-    def update(self, md: Union[Langevin, VelocityVerlet, ASE_NPT]):
+    def update(self, md: MD):
         """
         Update a correlation.
 
@@ -358,7 +355,7 @@ class Stress(Observable):
         self.component = component
         self._index = self._component_to_index(component, voigt=False)
 
-    def get(self, md: Union[Langevin, VelocityVerlet, ASE_NPT]) -> float:
+    def get(self, md: MD) -> float:
         """
         Get an observable component from md.
 

--- a/janus_core/helpers/correlator.py
+++ b/janus_core/helpers/correlator.py
@@ -47,12 +47,12 @@ class Correlator:
         self._min_dist = self._points / self._averaging
 
         self._accumulator = np.zeros((self._blocks, 2))
-        self._count_accumulated = np.zeros(self._blocks).astype(int)
-        self._shift_index = np.zeros(self._blocks).astype(int)
+        self._count_accumulated = np.zeros(self._blocks, dtype=int)
+        self._shift_index = np.zeros(self._blocks, dtype=int)
         self._shift = np.zeros((self._blocks, self._points, 2))
-        self._shift_not_null = np.zeros((self._blocks, self._points)).astype(bool)
+        self._shift_not_null = np.zeros((self._blocks, self._points), dtype=bool)
         self._correlation = np.zeros((self._blocks, self._points))
-        self._count_correlated = np.zeros((self._blocks, self._points)).astype(int)
+        self._count_correlated = np.zeros((self._blocks, self._points), dtype=int)
 
     # pylint: disable=invalid-name
     def update(self, a: float, b: float):
@@ -151,8 +151,10 @@ class Correlator:
 
         Returns
         -------
-        tuple[Iterable[float], Iterable[float]]
-            The correlation and lags.
+        correlation : Iterable[float]
+            The correlation values <a(t)b(t+t')>.
+        lags : Iterable[float]]
+            The correlation lag times t'.
         """
         correlation = np.zeros(self._points * self._blocks)
         lags = np.zeros(self._points * self._blocks)
@@ -277,8 +279,10 @@ class Correlation:
 
         Returns
         -------
-        tuple[Iterable[float], Iterable[float]]
-            Correlation value and lags.
+        correlation : Iterable[float]
+            The correlation values <a(t)b(t+t')>.
+        lags : Iterable[float]]
+            The correlation lag times t'.
         """
         return self._correlator.get()
 

--- a/janus_core/helpers/correlator.py
+++ b/janus_core/helpers/correlator.py
@@ -173,7 +173,7 @@ class Correlator:
         return (correlation[0:lag], lags[0:lag])
 
 
-# pylint: disable=R0903
+# pylint: disable=too-few-public-methods
 class Observable:
     """An abstract observable quantity."""
 
@@ -215,7 +215,7 @@ class Observable:
         return matrix[component]
 
     @abstractmethod
-    # pylint: disable=C0103
+    # pylint: disable=invalid-name
     def get(self, md: MD) -> float:
         """
         Get an observable component from md.
@@ -298,7 +298,7 @@ class Correlation:
 
         return self._update_frequency
 
-    # pylint: disable=C0103
+    # pylint: disable=invalid-name
     def update(self, md: MD):
         """
         Update a correlation.

--- a/janus_core/helpers/correlator.py
+++ b/janus_core/helpers/correlator.py
@@ -2,17 +2,18 @@
 Module to correlate scalar data on-the-fly.
 """
 
-from abc import abstractmethod
 from collections.abc import Iterable
+from typing import Union
 
-from ase import units
-from ase.md import md as MD
+from ase import Atoms
 import numpy as np
+
+from janus_core.helpers.janus_types import Observable
 
 
 class Correlator:
     """
-    Correlate scalar real values.
+    Correlate scalar real values, <ab>.
 
     Parameters
     ----------
@@ -20,13 +21,13 @@ class Correlator:
         Number of correlation blocks.
     points : int
         Number of points per block.
-    window : int
+    averaging : int
         Averaging window per block level.
     """
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, *, blocks: int, points: int, window: int):
+    def __init__(self, *, blocks: int, points: int, averaging: int):
         """
         Initialise an empty Correlator.
 
@@ -36,14 +37,14 @@ class Correlator:
             Number of correlation blocks.
         points : int
             Number of points per block.
-        window : int
+        averaging : int
             Averaging window per block level.
         """
         self._blocks = blocks
         self._points = points
-        self._window = window
+        self._averaging = averaging
         self._max_block_used = 0
-        self._min_dist = self._points / self._window
+        self._min_dist = self._points / self._averaging
 
         self._accumulator = np.zeros((self._blocks, 2))
         self._count_accumulated = np.zeros(self._blocks).astype(int)
@@ -53,28 +54,30 @@ class Correlator:
         self._correlation = np.zeros((self._blocks, self._points))
         self._count_correlated = np.zeros((self._blocks, self._points)).astype(int)
 
-    def update(self, observable_a: float, observable_b: float):
+    # pylint: disable=invalid-name
+    def update(self, a: float, b: float):
         """
-        Update the correlation with new values a and b.
+        Update the correlation, <ab>, with new values a and b.
 
         Parameters
         ----------
-        observable_a : float
+        a : float
             Newly observed value of left correland.
-        observable_b : float
+        b : float
             Newly observed value of right correland.
         """
-        self._add(observable_a, observable_b, 0)
+        self._add(a, b, 0)
 
-    def _add(self, observable_a: float, observable_b: float, block: int):
+    # pylint: disable=invalid-name
+    def _add(self, a: float, b: float, block: int):
         """
         Propagate update down block hierarchy.
 
         Parameters
         ----------
-        observable_a : float
+        a : float
             Newly observed value of left correland/average.
-        observable_b : float
+        b : float
             Newly observed value of right correland/average.
         block : int
             Block in the hierachy being updated.
@@ -84,15 +87,15 @@ class Correlator:
 
         shift = self._shift_index[block]
         self._max_block_used = max(self._max_block_used, block)
-        self._shift[block, shift, :] = observable_a, observable_b
-        self._accumulator[block, :] += observable_a, observable_b
+        self._shift[block, shift, :] = a, b
+        self._accumulator[block, :] += a, b
         self._shift_not_null[block, shift] = True
         self._count_accumulated[block] += 1
 
-        if self._count_accumulated[block] == self._window:
+        if self._count_accumulated[block] == self._averaging:
             self._add(
-                self._accumulator[block, 0] / self._window,
-                self._accumulator[block, 1] / self._window,
+                self._accumulator[block, 0] / self._averaging,
+                self._accumulator[block, 1] / self._averaging,
                 block + 1,
             )
             self._accumulator[block, :] = 0.0
@@ -168,98 +171,42 @@ class Correlator:
                     correlation[lag] = (
                         self._correlation[k, i] / self._count_correlated[k, i]
                     )
-                    lags[lag] = float(i) * float(self._window) ** k
+                    lags[lag] = float(i) * float(self._averaging) ** k
                     lag += 1
         return (correlation[0:lag], lags[0:lag])
 
 
-# pylint: disable=too-few-public-methods
-class Observable:
-    """An abstract observable quantity."""
-
-    @staticmethod
-    def _component_to_index(component: str, *, voigt: bool = False) -> int:
-        """
-        Convert a component code to an index.
-
-        Parameters
-        ----------
-        component : str
-            The component code, x, y, z, ....
-        voigt : bool
-            Use voigt indexing for matrices.
-
-        Returns
-        -------
-        int
-            An index used internally to access the component.
-        """
-        vector = {"x": 0, "y": 1, "z": 2}
-        matrix = {
-            "xx": 0,
-            "xy": 1,
-            "xz": 2,
-            "yx": 3,
-            "yy": 4,
-            "yz": 5,
-            "zx": 6,
-            "zy": 7,
-            "zz": 8,
-        }
-        matrix_voigt = {"xx": 0, "yy": 1, "zz": 2, "yz": 3, "xz": 4, "xy": 5}
-
-        if voigt:
-            return matrix_voigt[component]
-        if component in vector:
-            return vector[component]
-        return matrix[component]
-
-    @abstractmethod
-    # pylint: disable=invalid-name
-    def get(self, md: MD) -> float:
-        """
-        Get an observable component from md.
-
-        Parameters
-        ----------
-        md : Union[Langevin, VelocityVerlet, ASE_NPT]
-            A MolecularDynamics object.
-
-        Returns
-        -------
-        float
-            A scalar value of the observable (component).
-        """
-        return
-
-
 class Correlation:
     """
-    Represents a user correlation.
+    Represents a user correlation, <ab>.
 
     Parameters
     ----------
-    observable_a : Observable
-        Quantity a correlated.
-    observable_b : Observable
-        Quantity b correlated.
+    a : tuple[Observable, dict]
+        Getter for a and kwargs.
+    b : tuple[Observable, dict]
+        Getter for b and kwargs.
+    name : str
+        Name of correlation.
     blocks : int
         Number of correlation blocks.
     points : int
         Number of points per block.
-    window : int
+    averaging : int
         Averaging window per block level.
     update_frequency : int
         Frequency to update the correlation, md steps.
     """
 
+    # pylint: disable=invalid-name, too-many-instance-attributes
     def __init__(
         self,
-        observable_a: Observable,
-        observable_b: Observable,
+        a: Union[Observable, tuple[Observable, tuple, dict]],
+        b: Union[Observable, tuple[Observable, tuple, dict]],
+        name: str,
         blocks: int,
         points: int,
-        window: int,
+        averaging: int,
         update_frequency: int,
     ):
         """
@@ -267,22 +214,35 @@ class Correlation:
 
         Parameters
         ----------
-        observable_a : Observable
-            Quantity a correlated.
-        observable_b : Observable
-            Quantity b correlated.
+        a : tuple[Observable, tuple, dict]
+            Getter for a and kwargs.
+        b : tuple[Observable, tuple, dict]
+            Getter for b and kwargs.
+        name : str
+            Name of correlation.
         blocks : int
             Number of correlation blocks.
         points : int
             Number of points per block.
-        window : int
+        averaging : int
             Averaging window per block level.
         update_frequency : int
             Frequency to update the correlation, md steps.
         """
-        self.observable_a = observable_a
-        self.observable_b = observable_b
-        self._correlator = Correlator(blocks=blocks, points=points, window=window)
+        self.name = name
+        if isinstance(a, tuple):
+            self._get_a, self._a_args, self._a_kwargs = a
+        else:
+            self._get_a = a
+            self._a_args, self._a_kwargs = (), {}
+
+        if isinstance(b, tuple):
+            self._get_b, self._b_args, self._b_kwargs = b
+        else:
+            self._get_b = b
+            self._b_args, self._b_kwargs = (), {}
+
+        self._correlator = Correlator(blocks=blocks, points=points, averaging=averaging)
         self._update_frequency = update_frequency
 
     @property
@@ -295,20 +255,21 @@ class Correlation:
         int
             Correlation update frequency.
         """
-
         return self._update_frequency
 
-    # pylint: disable=invalid-name
-    def update(self, md: MD):
+    def update(self, atoms: Atoms):
         """
         Update a correlation.
 
         Parameters
         ----------
-        md : Union[Langevin, VelocityVerlet, ASE_NPT]
-            MolecularDynamics object to observe values from.
+        atoms : Atoms
+            Atoms object to observe values from.
         """
-        self._correlator.update(self.observable_a.get(md), self.observable_b.get(md))
+        self._correlator.update(
+            self._get_a(atoms, *self._a_args, **self._a_kwargs),
+            self._get_b(atoms, *self._b_args, **self._b_kwargs),
+        )
 
     def get(self) -> tuple[Iterable[float], Iterable[float]]:
         """
@@ -330,80 +291,4 @@ class Correlation:
         str
             String representation.
         """
-        return f"{str(self.observable_a)}-{str(self.observable_b)}"
-
-
-class Stress(Observable):
-    """
-    A stress observable.
-
-    Parameters
-    ----------
-    component : str
-        Component of the stress tensor.
-    """
-
-    def __init__(self, component: str):
-        """
-        A stress observable.
-
-        Parameters
-        ----------
-        component : str
-            Component of the stress tensor.
-        """
-        self.component = component
-        self._index = self._component_to_index(component, voigt=False)
-
-    def get(self, md: MD) -> float:
-        """
-        Get an observable component from md.
-
-        Parameters
-        ----------
-        md : Union[Langevin, VelocityVerlet, ASE_NPT]
-            The md object to observe.
-
-        Returns
-        -------
-        float
-            The observed stress value.
-        """
-        return (
-            md.atoms.get_stress(include_ideal_gas=True, voigt=False).flatten()[
-                self._index
-            ]
-            / units.bar
-        )
-
-    def __str__(self) -> str:
-        """
-        String representation of Stress observable.
-
-        Returns
-        -------
-        str
-            String representation.
-        """
-        return f"stress_{self.component}"
-
-
-def option_to_observable(option: str) -> Observable:
-    """
-    Convert an option string into an Observable.
-
-    Parameters
-    ----------
-    option : str
-        A user correlation option.
-
-    Returns
-    -------
-    Observable
-        The internal representation.
-    """
-    observable, component = option.split("_")
-    if observable.lower() in ["s", "stress"]:
-        return Stress(component)
-
-    raise ValueError(f"Could not match {option} to correlation observable")
+        return self.name

--- a/janus_core/helpers/correlator.py
+++ b/janus_core/helpers/correlator.py
@@ -66,10 +66,10 @@ class Correlator:
         b : float
             Newly observed value of right correland.
         """
-        self._add(a, b, 0)
+        self._propagate(a, b, 0)
 
     # pylint: disable=invalid-name
-    def _add(self, a: float, b: float, block: int):
+    def _propagate(self, a: float, b: float, block: int):
         """
         Propagate update down block hierarchy.
 
@@ -93,7 +93,7 @@ class Correlator:
         self._count_accumulated[block] += 1
 
         if self._count_accumulated[block] == self._averaging:
-            self._add(
+            self._propagate(
                 self._accumulator[block, 0] / self._averaging,
                 self._accumulator[block, 1] / self._averaging,
                 block + 1,

--- a/janus_core/helpers/correlator.py
+++ b/janus_core/helpers/correlator.py
@@ -1,0 +1,412 @@
+"""
+Module to correlate scalar data on-the-fly.
+"""
+
+from abc import abstractmethod
+from collections.abc import Iterable
+from typing import Union
+
+from ase import units
+from ase.md.langevin import Langevin
+from ase.md.npt import NPT as ASE_NPT
+from ase.md.verlet import VelocityVerlet
+import numpy as np
+
+
+class Correlator:
+    """
+    Correlate scalar real values.
+
+    Parameters
+    ----------
+    blocks : int
+        Number of correlation blocks.
+    points : int
+        Number of points per block.
+    window : int
+        Averaging window per block level.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(self, *, blocks: int, points: int, window: int):
+        """
+        Initialise an empty Correlator.
+
+        Parameters
+        ----------
+        blocks : int
+            Number of correlation blocks.
+        points : int
+            Number of points per block.
+        window : int
+            Averaging window per block level.
+        """
+        self._blocks = blocks
+        self._points = points
+        self._window = window
+        self._max_block_used = 0
+        self._min_dist = self._points / self._window
+
+        self._accumulator = np.zeros((self._blocks, 2))
+        self._count_accumulated = np.zeros(self._blocks).astype(int)
+        self._shift_index = np.zeros(self._blocks).astype(int)
+        self._shift = np.zeros((self._blocks, self._points, 2))
+        self._shift_not_null = np.zeros((self._blocks, self._points)).astype(bool)
+        self._correlation = np.zeros((self._blocks, self._points))
+        self._count_correlated = np.zeros((self._blocks, self._points)).astype(int)
+
+    def update(self, observable_a: float, observable_b: float):
+        """
+        Update the correlation with new values a and b.
+
+        Parameters
+        ----------
+        observable_a : float
+            Newly observed value of left correland.
+        observable_b : float
+            Newly observed value of right correland.
+        """
+        self._add(observable_a, observable_b, 0)
+
+    def _add(self, observable_a: float, observable_b: float, block: int):
+        """
+        Propagate update down block hierarchy.
+
+        Parameters
+        ----------
+        observable_a : float
+            Newly observed value of left correland/average.
+        observable_b : float
+            Newly observed value of right correland/average.
+        block : int
+            Block in the hierachy being updated.
+        """
+        if block == self._blocks:
+            return
+
+        shift = self._shift_index[block]
+        self._max_block_used = max(self._max_block_used, block)
+        self._shift[block, shift, :] = observable_a, observable_b
+        self._accumulator[block, :] += observable_a, observable_b
+        self._shift_not_null[block, shift] = True
+        self._count_accumulated[block] += 1
+
+        if self._count_accumulated[block] == self._window:
+            self._add(
+                self._accumulator[block, 0] / self._window,
+                self._accumulator[block, 1] / self._window,
+                block + 1,
+            )
+            self._accumulator[block, :] = 0.0
+            self._count_accumulated[block] = 0
+
+        i = self._shift_index[block]
+        if block == 0:
+            j = i
+            for point in range(self._points):
+                if self._shifts_valid(block, i, j):
+                    self._correlation[block, point] += (
+                        self._shift[block, i, 0] * self._shift[block, j, 1]
+                    )
+                    self._count_correlated[block, point] += 1
+                j -= 1
+                if j < 0:
+                    j += self._points
+        else:
+            for point in range(self._min_dist, self._points):
+                if j < 0:
+                    j = j + self._points
+                if self._shifts_valid(block, i, j):
+                    self._correlation[block, point] += (
+                        self._shift[block, i, 0] * self._shift[block, j, 1]
+                    )
+                    self._count_correlated[block, point] += 1
+                j = j - 1
+        self._shift_index[block] = (self._shift_index[block] + 1) % self._points
+
+    def _shifts_valid(self, block: int, p_i: int, p_j: int) -> bool:
+        """
+        True if the shift registers have data.
+
+        Parameters
+        ----------
+        block : int
+            Block to check the shift register of.
+        p_i : int
+            Index i in the shift (left correland).
+        p_j : int
+            Index j in the shift (right correland).
+
+        Returns
+        -------
+        bool
+            Whether the shift indices have data.
+        """
+        return self._shift_not_null[block, p_i] and self._shift_not_null[block, p_j]
+
+    def get(self) -> tuple[Iterable[float], Iterable[float]]:
+        """
+        Obtain the correlation and lag times.
+
+        Returns
+        -------
+        tuple[Iterable[float], Iterable[float]]
+            The correlation and lags.
+        """
+        correlation = np.zeros(self._points * self._blocks)
+        lags = np.zeros(self._points * self._blocks)
+
+        lag = 0
+        for i in range(self._points):
+            if self._count_correlated[0, i] > 0:
+                correlation[lag] = (
+                    self._correlation[0, i] / self._count_correlated[0, i]
+                )
+                lags[lag] = i
+                lag += 1
+        for k in range(1, self._max_block_used):
+            for i in range(self._min_dist, self._points):
+                if self._count_correlated[k, i] > 0:
+                    correlation[lag] = (
+                        self._correlation[k, i] / self._count_correlated[k, i]
+                    )
+                    lags[lag] = float(i) * float(self._window) ** k
+                    lag += 1
+        return (correlation[0:lag], lags[0:lag])
+
+
+# pylint: disable=R0903
+class Observable:
+    """An abstract observable quantity."""
+
+    @staticmethod
+    def _component_to_index(component: str, *, voigt: bool = False) -> int:
+        """
+        Convert a component code to an index.
+
+        Parameters
+        ----------
+        component : str
+            The component code, x, y, z, ....
+        voigt : bool
+            Use voigt indexing for matrices.
+
+        Returns
+        -------
+        int
+            An index used internally to access the component.
+        """
+        vector = {"x": 0, "y": 1, "z": 2}
+        matrix = {
+            "xx": 0,
+            "xy": 1,
+            "xz": 2,
+            "yx": 3,
+            "yy": 4,
+            "yz": 5,
+            "zx": 6,
+            "zy": 7,
+            "zz": 8,
+        }
+        matrix_voigt = {"xx": 0, "yy": 1, "zz": 2, "yz": 3, "xz": 4, "xy": 5}
+
+        if voigt:
+            return matrix_voigt[component]
+        if component in vector:
+            return vector[component]
+        return matrix[component]
+
+    @abstractmethod
+    # pylint: disable=C0103
+    def get(self, md: Union[Langevin, VelocityVerlet, ASE_NPT]) -> float:
+        """
+        Get an observable component from md.
+
+        Parameters
+        ----------
+        md : Union[Langevin, VelocityVerlet, ASE_NPT]
+            A MolecularDynamics object.
+
+        Returns
+        -------
+        float
+            A scalar value of the observable (component).
+        """
+        return
+
+
+class Correlation:
+    """
+    Represents a user correlation.
+
+    Parameters
+    ----------
+    observable_a : Observable
+        Quantity a correlated.
+    observable_b : Observable
+        Quantity b correlated.
+    blocks : int
+        Number of correlation blocks.
+    points : int
+        Number of points per block.
+    window : int
+        Averaging window per block level.
+    update_frequency : int
+        Frequency to update the correlation, md steps.
+    """
+
+    def __init__(
+        self,
+        observable_a: Observable,
+        observable_b: Observable,
+        blocks: int,
+        points: int,
+        window: int,
+        update_frequency: int,
+    ):
+        """
+        Initialise a correlation.
+
+        Parameters
+        ----------
+        observable_a : Observable
+            Quantity a correlated.
+        observable_b : Observable
+            Quantity b correlated.
+        blocks : int
+            Number of correlation blocks.
+        points : int
+            Number of points per block.
+        window : int
+            Averaging window per block level.
+        update_frequency : int
+            Frequency to update the correlation, md steps.
+        """
+        self.observable_a = observable_a
+        self.observable_b = observable_b
+        self._correlator = Correlator(blocks=blocks, points=points, window=window)
+        self._update_frequency = update_frequency
+
+    @property
+    def update_frequency(self) -> int:
+        """
+        Get update frequency.
+
+        Returns
+        -------
+        int
+            Correlation update frequency.
+        """
+
+        return self._update_frequency
+
+    # pylint: disable=C0103
+    def update(self, md: Union[Langevin, VelocityVerlet, ASE_NPT]):
+        """
+        Update a correlation.
+
+        Parameters
+        ----------
+        md : Union[Langevin, VelocityVerlet, ASE_NPT]
+            MolecularDynamics object to observe values from.
+        """
+        self._correlator.update(self.observable_a.get(md), self.observable_b.get(md))
+
+    def get(self) -> tuple[Iterable[float], Iterable[float]]:
+        """
+        Get the correlation value and lags.
+
+        Returns
+        -------
+        tuple[Iterable[float], Iterable[float]]
+            Correlation value and lags.
+        """
+        return self._correlator.get()
+
+    def __str__(self) -> str:
+        """
+        String representation of correlation.
+
+        Returns
+        -------
+        str
+            String representation.
+        """
+        return f"{str(self.observable_a)}-{str(self.observable_b)}"
+
+
+class Stress(Observable):
+    """
+    A stress observable.
+
+    Parameters
+    ----------
+    component : str
+        Component of the stress tensor.
+    """
+
+    def __init__(self, component: str):
+        """
+        A stress observable.
+
+        Parameters
+        ----------
+        component : str
+            Component of the stress tensor.
+        """
+        self.component = component
+        self._index = self._component_to_index(component, voigt=False)
+
+    def get(self, md: Union[Langevin, VelocityVerlet, ASE_NPT]) -> float:
+        """
+        Get an observable component from md.
+
+        Parameters
+        ----------
+        md : Union[Langevin, VelocityVerlet, ASE_NPT]
+            The md object to observe.
+
+        Returns
+        -------
+        float
+            The observed stress value.
+        """
+        return (
+            md.atoms.get_stress(include_ideal_gas=True, voigt=False).flatten()[
+                self._index
+            ]
+            / units.bar
+        )
+
+    def __str__(self) -> str:
+        """
+        String representation of Stress observable.
+
+        Returns
+        -------
+        str
+            String representation.
+        """
+        return f"stress_{self.component}"
+
+
+def option_to_observable(option: str) -> Observable:
+    """
+    Convert an option string into an Observable.
+
+    Parameters
+    ----------
+    option : str
+        A user correlation option.
+
+    Returns
+    -------
+    Observable
+        The internal representation.
+    """
+    observable, component = option.split("_")
+    if observable.lower() in ["s", "stress"]:
+        return Stress(component)
+
+    raise ValueError(f"Could not match {option} to correlation observable")

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -75,6 +75,15 @@ class PostProcessKwargs(TypedDict, total=False):
     vaf_output_file: Optional[PathLike]
 
 
+class CorrelationKwargs(TypedDict, total=False):
+    """Arguments for on-the-fly correlations."""
+
+    # Pairs of indexed observables, ('s_xy', 's_xy')
+    correlations: Sequence[tuple[str, str]]
+    # Blocks, points, window, and update frequency
+    correlation_parameters: Sequence[tuple[int, int, int, int]]
+
+
 # eos_names from ase.eos
 EoSNames = Literal[
     "sj",

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -105,14 +105,21 @@ class Observable(Protocol):
 
 
 class CorrelationKwargs(TypedDict, total=True):
-    """Arguments for on-the-fly correlations."""
+    """Arguments for on-the-fly correlations <ab>."""
 
-    a: Union[Observable, tuple[Observable, Optional[tuple], Optional[dict]]]
-    b: Union[Observable, tuple[Observable, Optional[tuple], Optional[dict]]]
+    #: observable a in <ab>, with optional args and kwargs
+    a: Union[Observable, tuple[Observable, tuple, dict]]
+    #: observable b in <ab>, with optional args and kwargs
+    b: Union[Observable, tuple[Observable, tuple, dict]]
+    #: name used for correlation in output
     name: str
+    #: blocks used in multi-tau algorithm
     blocks: int
+    #: points per block
     points: int
+    #: averaging between blocks
     averaging: int
+    #: frequency to update the correlation (steps)
     update_frequency: int
 
 

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -4,7 +4,16 @@ from collections.abc import Sequence
 from enum import Enum
 import logging
 from pathlib import Path, PurePath
-from typing import IO, Literal, Optional, TypedDict, TypeVar, Union
+from typing import (
+    IO,
+    Literal,
+    Optional,
+    Protocol,
+    TypedDict,
+    TypeVar,
+    Union,
+    runtime_checkable,
+)
 
 from ase import Atoms
 from ase.eos import EquationOfState
@@ -75,13 +84,36 @@ class PostProcessKwargs(TypedDict, total=False):
     vaf_output_file: Optional[PathLike]
 
 
-class CorrelationKwargs(TypedDict, total=False):
+# pylint: disable=too-few-public-methods
+@runtime_checkable
+class Observable(Protocol):
+    """Signature for correlation observable getter."""
+
+    def __call__(self, atoms: Atoms, *args, **kwargs) -> float:
+        """
+        Call the getter.
+
+        Parameters
+        ----------
+        atoms : Atoms
+            Atoms object to extract values from.
+        *args : tuple
+            Additional positional arguments passed to getter.
+        **kwargs : dict
+            Additional kwargs passed getter.
+        """
+
+
+class CorrelationKwargs(TypedDict, total=True):
     """Arguments for on-the-fly correlations."""
 
-    # Pairs of indexed observables, ('s_xy', 's_xy')
-    correlations: Sequence[tuple[str, str]]
-    # Blocks, points, window, and update frequency
-    correlation_parameters: Sequence[tuple[int, int, int, int]]
+    a: Union[Observable, tuple[Observable, Optional[tuple], Optional[dict]]]
+    b: Union[Observable, tuple[Observable, Optional[tuple], Optional[dict]]]
+    name: str
+    blocks: int
+    points: int
+    averaging: int
+    update_frequency: int
 
 
 # eos_names from ase.eos

--- a/janus_core/helpers/observables.py
+++ b/janus_core/helpers/observables.py
@@ -1,0 +1,75 @@
+"""
+Module for built-in correlation observables.
+"""
+
+from ase import Atoms, units
+
+
+# pylint: disable=too-few-public-methods
+class Stress:
+    """
+    Observable for stress components.
+
+    Parameters
+    ----------
+    component : str
+        Symbol for tensor components, xx, yy, etc.
+    include_ideal_gas : bool
+        Calculate with the ideal gas contribution.
+    """
+
+    def __init__(self, component: str, include_ideal_gas: bool = True):
+        """
+        Initialise the observables from a symbolic str component.
+
+        Parameters
+        ----------
+        component : str
+            Symbol for tensor components, xx, yy, etc.
+        include_ideal_gas : bool
+            Calculate with the ideal gas contribution.
+        """
+        components = {
+            "xx": 0,
+            "yy": 1,
+            "zz": 2,
+            "yz": 3,
+            "zy": 3,
+            "xz": 4,
+            "zx": 4,
+            "xy": 5,
+            "yx": 5,
+        }
+        if component not in components:
+            raise ValueError(
+                f"'{component}' invalid, must be '{', '.join(list(components.keys()))}'"
+            )
+
+        self.component = component
+        self._index = components[self.component]
+        self.include_ideal_gas = include_ideal_gas
+
+    def __call__(self, atoms: Atoms, *args, **kwargs) -> float:
+        """
+        Get the stress component.
+
+        Parameters
+        ----------
+        atoms : Atoms
+            Atoms object to extract values from.
+        *args : tuple
+            Additional positional arguments passed to getter.
+        **kwargs : dict
+            Additional kwargs passed getter.
+
+        Returns
+        -------
+        float
+            The stress component in GPa units.
+        """
+        return (
+            atoms.get_stress(include_ideal_gas=self.include_ideal_gas, voigt=True)[
+                self._index
+            ]
+            / units.GPa
+        )

--- a/janus_core/helpers/observables.py
+++ b/janus_core/helpers/observables.py
@@ -18,7 +18,7 @@ class Stress:
         Calculate with the ideal gas contribution.
     """
 
-    def __init__(self, component: str, include_ideal_gas: bool = True):
+    def __init__(self, component: str, *, include_ideal_gas: bool = True):
         """
         Initialise the observables from a symbolic str component.
 

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -1,0 +1,113 @@
+"""Test the Correlator"""
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import numpy as np
+from typer.testing import CliRunner
+from yaml import Loader, load
+
+from janus_core.calculations.md import NVE
+from janus_core.calculations.single_point import SinglePoint
+from janus_core.helpers.correlator import Correlator
+from janus_core.helpers.stats import Stats
+
+DATA_PATH = Path(__file__).parent / "data"
+MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"
+runner = CliRunner()
+
+TOLERANCE = 1e-16
+
+
+# pylint: disable=C0103
+def correlate(
+    x: Iterable[float], y: Iterable[float], *, fft: bool = True
+) -> Iterable[float]:
+    """
+    Direct correlation of x and y. If fft uses np.correlate in full mode.
+    """
+    n = min(len(x), len(y))
+    if fft:
+        cor = np.correlate(x, y, "full")
+        cor = cor[len(cor) // 2 :]
+        return cor / n - np.arange(n)
+    cor = np.zeros(n)
+    for j in range(n):
+        for i in range(n - j):
+            cor[j] += x[i] * y[i + j]
+        cor[j] /= n - j
+    return cor
+
+
+def test_setup():
+    """Test initial values"""
+    cor = Correlator(blocks=1, points=100, window=2)
+    correlation, lags = cor.get()
+    assert len(correlation) == len(lags)
+    assert len(correlation) == 0
+
+
+def test_correlation():
+    """Test Correlator against np.correlate"""
+    points = 100
+    cor = Correlator(blocks=1, points=points, window=1)
+    signal = np.exp(-np.linspace(0.0, 1.0, points))
+    for val in signal:
+        cor.update(val, val)
+    correlation, lags = cor.get()
+
+    direct = correlate(signal, signal, fft=False)
+    fft = correlate(signal, signal, fft=True)
+
+    assert len(correlation) == len(lags)
+    assert all(lags == range(points))
+    assert np.mean(direct - correlation) < TOLERANCE
+    assert np.mean(fft - correlation) < TOLERANCE
+
+
+def test_md_correlations(tmp_path):
+    """Test correlations as part of MD cycle."""
+    file_prefix = tmp_path / "Cl4Na4-nve-T300.0"
+    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.xyz"
+    stats_path = tmp_path / "Cl4Na4-nve-T300.0-stats.dat"
+    cor_path = tmp_path / "Cl4Na4-nve-T300.0-cor.dat"
+
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        architecture="mace",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+
+    nve = NVE(
+        struct=single_point.struct,
+        temp=300.0,
+        steps=10,
+        traj_every=2,
+        stats_every=1,
+        file_prefix=file_prefix,
+        correlation_kwargs={
+            "correlations": [("s_xy", "s_xy")],
+            "correlation_parameters": [(1, 10, 1, 1)],
+        },
+    )
+
+    try:
+        nve.run()
+        assert cor_path.exists()
+        with open(cor_path, encoding="utf8") as in_file:
+            cor = load(in_file, Loader=Loader)
+        assert "correlations" in cor
+        assert len(cor["correlations"]) == 1
+        assert "stress_xy-stress_xy" in cor["correlations"][0]
+        stress_cor = cor["correlations"][0]["stress_xy-stress_xy"]
+        value, lags = stress_cor["value"], stress_cor["lags"]
+        assert len(value) == len(lags) == 10
+
+        stats = Stats(stats_path)
+        pxy = stats["Pxy"][1:]
+        direct = correlate(pxy, pxy)
+        assert np.mean(direct - value) < TOLERANCE
+    finally:
+        traj_path.unlink(missing_ok=True)
+        stats_path.unlink(missing_ok=True)
+        cor_path.unlink(missing_ok=True)

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -71,7 +71,7 @@ def test_correlation():
 def test_md_correlations(tmp_path):
     """Test correlations as part of MD cycle."""
     file_prefix = tmp_path / "Cl4Na4-nve-T300.0"
-    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.xyz"
+    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.extxyz"
     stats_path = tmp_path / "Cl4Na4-nve-T300.0-stats.dat"
     cor_path = tmp_path / "Cl4Na4-nve-T300.0-cor.dat"
 


### PR DESCRIPTION
This PR adds an online correlation algorithm (multi-tau), with stress correlations as user observables. The correlations are,

$$C_{ab}(t) = \frac{1}{T-t}\sum_{t'=1}^{T-t}a(t)b(t+t'),$$

for some values $a$ and $b$, and time lags $t$. The lags (and timestep) are implied by the frequency the correlator is updated in ```run``` controled by ```correlation_parameters[.][3]``` (which could probably use being some TypedDict actually...).

A user may ask for a sequence of correlations by,

```python
correlation_kwargs={
            "correlations": [("s_xy", "s_xy")],
            "correlation_parameters": [(1, 10, 1, 1)],
        },
```

where ```s_xy``` is parsed into an ```Observable``` that can poll ```MolecularDynamics::dyn``` with a ```get``` method.

Correlations are written in ```yaml``` format for now a list of correlations (name, value, and lags).

New correlations can be added by providing an extension to ```Observable``` as is done for stress which connects user input to a function to get values from ```Union[Langevin, VelocityVerlet, ASE_NPT]```,

```python
class Stress(Observable):
    def __init__(self, component: str):
        self.component = component
        self._index = self._component_to_index(component, voigt=False)

    def get(self, md: Union[Langevin, VelocityVerlet, ASE_NPT]) -> float:
        return (
            md.atoms.get_stress(include_ideal_gas=True, voigt=False).flatten()[
                self._index
            ]
            / units.bar
        )

    def __str__(self) -> str:
	...
```

any combination of observables is a "valid" correlation.

- ```correlator.py``` could perhaps be split into multiple files 