### PR TITLE
Add ALIGNN as optional MLIP

### DIFF
--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -1,3 +1,83 @@
 ========
 Tutorial
 ========
+
+Adding a new MLIP
+=================
+
+Integration of new MLIPs currently requires a corresponding `ASE calculator <https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html>`_.
+
+The following steps can then be taken, using `ALIGNN-FF <https://github.com/usnistgov/alignn>`_ as an example:
+
+1. Add required dependencies
+----------------------------
+
+Dependencies for ``janus-core`` are specified through a ``pyproject.toml`` file, with syntax defined by `poetry's dependency specification <https://python-poetry.org/docs/dependency-specification/>`_.
+
+Required dependencies are listed under ``[tool.poetry.dependencies]``, but new MLIPs should initially be added as optional dependencies under ``[tool.poetry.group.extra-mlips.dependencies]``::
+
+    [tool.poetry.group.extra-mlips]
+    optional = true
+    [tool.poetry.group.extra-mlips.dependencies]
+    alignn = "^2024.5.27"
+
+Poetry will automatically resolve dependencies of the MLIP, if present, to ensure consistency with existing dependencies.
+
+These dependencies can then be installed by running:
+
+.. code-block:: bash
+
+    poetry lock
+    poetry install --with extra-mlips
+
+
+2. Register MLIP architecture
+-----------------------------
+
+In order to be able to select the appropriate MLIP when running calculations, it is first necessary to add a label for the architecture to ``Architectures`` in ``janus_core.helpers.janus_types``.
+
+In this case, we choose the label ``"alignn"``::
+
+    Architectures = Literal["mace", "mace_mp", "mace_off", "m3gnet", "chgnet", "alignn"]
+
+
+3. Add MLIP calculator
+----------------------
+
+Next, we need to allow the ASE calculator corresponding to the MLIP label to be set.
+
+This is done within the ``janus_core.helpers.mlip_calculators`` module, if ``architecture`` matches the label defined above::
+
+    elif architecture == "alignn":
+        from alignn import __version__
+        from alignn.ff.ff import AlignnAtomwiseCalculator, default_path
+
+        # Set default path for config and model location
+        kwargs.setdefault("path", default_path())
+        calculator = AlignnAtomwiseCalculator(device=device, **kwargs)
+
+Note, unlike in other ``janus-core`` modules, any imports required should be contained within the ``elif`` branch, as these dependencies are optional.
+
+As ``device`` is a parameter of ``choose_calculator``, it must either be passed explicitly, or added to the ``kwargs``, with the appropriate keyword expected by the calculator. When using CHGNet, for example, we instead set ``use_device=device``.
+
+All other parameters are passed through ``kwargs`` specific to the calculator, although extra handling of common parameters, such as the model (path), may be useful.
+
+In this case, we define a default ``"path"``, setting both the model and configuration, unless either is explicitly overridden.
+
+In addition to setting the calculator, ``__version__`` must also imported here, providing a check on the package independent of the calculator itself.
+
+
+4. Add tests
+------------
+
+Tests must be added to ensure that, at a minimum, the new calculator allows an MLIP to be loaded correctly, and that an energy can be calculated.
+
+This can be done by adding the appropriate data as tuples to the ``test_extra_mlips_data`` lists in the ``tests.test_mlip_calculators`` and ``tests.test_single_point`` modules.
+
+For ``tests.test_mlip_calculators``, ``architecture`` and ``device`` should be defined, ensuring that the calculator and its version are correctly set::
+
+    test_extra_mlips_data = [("alignn", "cpu")]
+
+For ``tests.test_single_point``, ``architecture``, ``device``, and the predicted potential energy of NaCl should be defined, ensuring that calculations can be performed::
+
+    test_extra_mlips_data = [("alignn", "cpu", -11.148092269897461)]

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -81,3 +81,11 @@ For ``tests.test_mlip_calculators``, ``architecture`` and ``device`` should be d
 For ``tests.test_single_point``, ``architecture``, ``device``, and the predicted potential energy of NaCl should be defined, ensuring that calculations can be performed::
 
     test_extra_mlips_data = [("alignn", "cpu", -11.148092269897461)]
+
+Running these tests requires an additional flag to be passed to ``pytest``::
+
+    pytest -v --run-extra-mlips
+
+Alternatively, using ``tox``::
+
+    tox -e extra-mlips

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -90,7 +90,7 @@ EoSNames = Literal[
 
 
 # Janus specific
-Architectures = Literal["mace", "mace_mp", "mace_off", "m3gnet", "chgnet"]
+Architectures = Literal["mace", "mace_mp", "mace_off", "m3gnet", "chgnet", "alignn"]
 Devices = Literal["cpu", "cuda", "mps", "xpu"]
 Ensembles = Literal["nph", "npt", "nve", "nvt", "nvt-nh"]
 

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -103,6 +103,14 @@ def choose_calculator(
         torch.set_default_dtype(torch.float32)
         calculator = CHGNetCalculator(use_device=device, **kwargs)
 
+    elif architecture == "alignn":
+        from alignn import __version__
+        from alignn.ff.ff import AlignnAtomwiseCalculator, default_path
+
+        # Set default path for config and model location
+        kwargs.setdefault("path", default_path())
+        calculator = AlignnAtomwiseCalculator(device=device, **kwargs)
+
     else:
         raise ValueError(
             f"Unrecognized {architecture=}. Suported architectures "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ spglib = "^2.3.0"
 torch-dftd = "^0.4.0"
 codecarbon = "^2.5.0"
 
+[tool.poetry.group.extra-mlips]
+optional = true
+[tool.poetry.group.extra-mlips.dependencies]
+alignn = "^2024.5.27"
+
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^7.4.1"}
 pgtest = "^1.3.2"

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -8,26 +8,30 @@ from janus_core.helpers.mlip_calculators import choose_calculator
 
 MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"
 
-test_data_mace = [
+test_mlips_data = [
     ("mace", "cpu", {"model": MODEL_PATH}),
     ("mace", "cpu", {"model_paths": MODEL_PATH}),
     ("mace_off", "cpu", {}),
     ("mace_mp", "cpu", {}),
     ("mace_mp", "cpu", {"model": MODEL_PATH}),
     ("mace_off", "cpu", {"model": "small"}),
+    ("m3gnet", "cpu", {}),
+    ("chgnet", "cpu", {}),
 ]
 
-test_data_extras = [("m3gnet", "cpu"), ("chgnet", "cpu")]
 
-
-@pytest.mark.parametrize("architecture, device, kwargs", test_data_mace)
-def test_mace(architecture, device, kwargs):
+@pytest.mark.parametrize("architecture, device, kwargs", test_mlips_data)
+def test_mlips(architecture, device, kwargs):
     """Test mace calculators can be configured."""
     calculator = choose_calculator(architecture=architecture, device=device, **kwargs)
     assert calculator.parameters["version"] is not None
 
 
-@pytest.mark.parametrize("architecture, device", test_data_extras)
+test_extra_mlips_data = [("alignn", "cpu")]
+
+
+@pytest.mark.extra_mlips
+@pytest.mark.parametrize("architecture, device", test_extra_mlips_data)
 def test_extra_mlips(architecture, device):
     """Test m3gnet and chgnet calculators can be configured."""
     calculator = choose_calculator(

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -253,15 +253,31 @@ def test_no_atoms_or_path():
         )
 
 
-test_data_potentials = [
+test_mlips_data = [
     ("m3gnet", "cpu", -26.729949951171875),
     ("chgnet", "cpu", -29.331436157226562),
 ]
 
 
-@pytest.mark.parametrize("arch, device, expected_energy", test_data_potentials)
-def test_extra_mlips(arch, device, expected_energy):
+@pytest.mark.parametrize("arch, device, expected_energy", test_mlips_data)
+def test_mlips(arch, device, expected_energy):
     """Test single point energy using CHGNET and M3GNET calculators."""
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        architecture=arch,
+        device=device,
+    )
+    energy = single_point.run("energy")["energy"]
+    assert energy == pytest.approx(expected_energy)
+
+
+test_extra_mlips_data = [("alignn", "cpu", -11.148092269897461)]
+
+
+@pytest.mark.extra_mlips
+@pytest.mark.parametrize("arch, device, expected_energy", test_extra_mlips_data)
+def test_extra_mlips(arch, device, expected_energy):
+    """Test single point energy using ALIGNN-FF calculator."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         architecture=arch,


### PR DESCRIPTION
Adds optional integration with [ALIGNN](https://github.com/usnistgov/alignn), to be used as worked developer example for how to add a new MLIP to janus-core.

One other thing to consider, which could affect this implementation/the example slightly (although it would be a separate PR), is if we want to standardise the input model.

Currently only `device` is standardised, but if we wanted to do the same for the path to the model (which may be useful/essential for aiida-mlip, @federicazanca?), it would be sensible to do it now, before adding further MLIPs.

To do:

- [x] Add notes to docs explaining steps taken

Depends on #195, so may need a minor rebase.