### PR TITLE
Downgrade seekpath for aiida-quantumespresso compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pyyaml = "^6.0.1"
 typer = "^0.9.0"
 typer-config = "^1.4.0"
 phonopy = "^2.23.1"
-seekpath = "^2.1.0"
+seekpath = "^1.9.7"
 spglib = "^2.3.0"
 torch-dftd = "^0.4.0"
 


### PR DESCRIPTION
Resolves #196

This doesn't seem to affect any phonopy functionality from initial testing e.g. from the [phonopy documentation](https://phonopy.github.io/phonopy/phonopy-module.html):

> Automatic selection of band paths using [SeeK-path](https://seekpath.readthedocs.io/en/latest/) is invoked by

>
>```
>phonon.auto_band_structure()
>```

Running 
```
janus phonons --struct tests/data/NaCl.cif --band --plot-to-file
```

still correctly generates `NaCl-auto_bands.svg` via `plot_band_structure`, and running

```
poetry add aiida-quantumespresso
```

also installs aiida-quantumespresso successfully.