### PR TITLE
Change pressure from bar to GPa

### DIFF
--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Union
 import warnings
 
-from ase import Atoms, filters
+from ase import Atoms, filters, units
 from ase.filters import FrechetCellFilter
 from ase.io import read, write
 import ase.optimize
@@ -103,7 +103,8 @@ def set_optimizer(
             if "constant_volume" in filter_kwargs:
                 logger.info("constant_volume: %s", filter_kwargs["constant_volume"])
             if "scalar_pressure" in filter_kwargs:
-                logger.info("scalar_pressure: %s", filter_kwargs["scalar_pressure"])
+                logger.info("scalar_pressure: %s GPa", filter_kwargs["scalar_pressure"])
+                filter_kwargs["scalar_pressure"] *= units.GPa
     else:
         dyn = optimizer(struct, **opt_kwargs)
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -454,8 +454,8 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         """
         log_header = (
             "# Step | Real Time [s] | Time [fs] | Epot/N [eV] | Ekin/N [eV] | "
-            "T [K] | Etot/N [eV] | Density [g/cm^3] | Volume [A^3] | P [bar] | "
-            "Pxx [bar] | Pyy [bar] | Pzz [bar] | Pyz [bar] | Pxz [bar] | Pxy [bar]"
+            "T [K] | Etot/N [eV] | Density [g/cm^3] | Volume [A^3] | P [GPa] | "
+            "Pxx [GPa] | Pyy [GPa] | Pzz [GPa] | Pyz [GPa] | Pxz [GPa] | Pxy [GPa]"
         )
 
         return log_header
@@ -495,11 +495,11 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
                     self.dyn.atoms.get_stress(include_ideal_gas=True, voigt=False)
                 )
                 / 3
-                / units.bar
+                / units.GPa
             )
             pressure_tensor = (
                 -self.dyn.atoms.get_stress(include_ideal_gas=True, voigt=True)
-                / units.bar
+                / units.GPa
             )
         except ValueError:
             volume = 0.0
@@ -762,7 +762,7 @@ class NPT(MolecularDynamics):
     bulk_modulus : float
         Bulk modulus, in GPa. Default is 2.0.
     pressure : float
-        Pressure, in bar. Default is 0.0.
+        Pressure, in GPa. Default is 0.0.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "npt".
     file_prefix : Optional[PathLike]
@@ -805,7 +805,7 @@ class NPT(MolecularDynamics):
         bulk_modulus : float
             Bulk modulus, in GPa. Default is 2.0.
         pressure : float
-            Pressure, in bar. Default is 0.0.
+            Pressure, in GPa. Default is 0.0.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "npt".
         file_prefix : Optional[PathLike]
@@ -838,7 +838,7 @@ class NPT(MolecularDynamics):
             ttime=self.ttime,
             pfactor=pfactor,
             append_trajectory=self.traj_append,
-            externalstress=self.pressure * units.bar,
+            externalstress=self.pressure * units.GPa,
             **ensemble_kwargs,
         )
 
@@ -914,7 +914,7 @@ class NPT(MolecularDynamics):
             Header for molecular dynamics log.
         """
         log_header = MolecularDynamics.get_log_header()
-        return log_header + " | Target P [bar] | Target T [K]"
+        return log_header + " | Target P [GPa] | Target T [K]"
 
 
 class NVT(MolecularDynamics):
@@ -1146,7 +1146,7 @@ class NPH(NPT):
     bulk_modulus : float
         Bulk modulus, in GPa. Default is 2.0.
     pressure : float
-        Pressure, in bar. Default is 0.0.
+        Pressure, in GPa. Default is 0.0.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is "nph".
     file_prefix : Optional[PathLike]
@@ -1186,7 +1186,7 @@ class NPH(NPT):
         bulk_modulus : float
             Bulk modulus, in GPa. Default is 2.0.
         pressure : float
-            Pressure, in bar. Default is 0.0.
+            Pressure, in GPa. Default is 0.0.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is "nph".
         file_prefix : Optional[PathLike]

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 from typing import Annotated, Any, Optional
 
-from ase import units
 from typer import Context, Option, Typer
 from typer_config import use_config
 
@@ -52,7 +51,7 @@ def _set_minimize_kwargs(
         Whether to optimize cell vectors, as well as atomic positions, by setting
         `hydrostatic_strain` in the filter function.
     pressure : float
-        Scalar pressure when optimizing cell geometry, in bar. Passed to the filter
+        Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
         function if either `vectors_only` or `fully_opt` is True.
     """
     if "opt_kwargs" in minimize_kwargs:
@@ -85,7 +84,7 @@ def _set_minimize_kwargs(
 
     # Set hydrostatic_strain and scalar pressure
     minimize_kwargs["filter_kwargs"]["hydrostatic_strain"] = vectors_only
-    minimize_kwargs["filter_kwargs"]["scalar_pressure"] = pressure * units.bar
+    minimize_kwargs["filter_kwargs"]["scalar_pressure"] = pressure
 
 
 @app.command(
@@ -128,7 +127,7 @@ def geomopt(
         ),
     ] = None,
     pressure: Annotated[
-        float, Option(help="Scalar pressure when optimizing cell geometry, in bar.")
+        float, Option(help="Scalar pressure when optimizing cell geometry, in GPa.")
     ] = 0.0,
     out: Annotated[
         Path,
@@ -181,7 +180,7 @@ def geomopt(
         constraints to atoms. If using --vectors only or --fully-opt, defaults to
         `FrechetCellFilter` if available, otherwise `ExpCellFilter`.
     pressure : float
-        Scalar pressure when optimizing cell geometry, in bar. Passed to the filter
+        Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
         function if either `vectors_only` or `fully_opt` is True. Default is 0.0.
     out : Optional[Path]
         Path to save optimized structure, or last structure if optimization did not

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -71,7 +71,7 @@ def md(
         float, Option(help="Bulk modulus for NPT or NPH simulation, in GPa.")
     ] = 2.0,
     pressure: Annotated[
-        float, Option(help="Pressure fpr NPT or NPH simulation, in bar.")
+        float, Option(help="Pressure fpr NPT or NPH simulation, in GPa.")
     ] = 0.0,
     friction: Annotated[
         float, Option(help="Friction coefficient for NVT simulation, in fs^-1.")
@@ -206,7 +206,7 @@ def md(
     bulk_modulus : float
         Bulk modulus, in GPa. Default is 2.0.
     pressure : float
-        Pressure, in bar. Default is 0.0.
+        Pressure, in GPa. Default is 0.0.
     friction : float
         Friction coefficient in fs^-1. Default is 0.005.
     ensemble_kwargs : Optional[dict[str, Any]]

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -231,7 +231,7 @@ def test_scalar_pressure(option, tmp_path):
             results_path,
             option,
             "--pressure",
-            "100",
+            "0.01",
             "--log",
             log_path,
             "--summary",
@@ -239,7 +239,7 @@ def test_scalar_pressure(option, tmp_path):
         ],
     )
     assert result.exit_code == 0
-    assert_log_contains(log_path, includes=["scalar_pressure: 6.24"])
+    assert_log_contains(log_path, includes=["scalar_pressure: 0.01 GPa"])
 
 
 def test_duplicate_traj(tmp_path):

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -82,7 +82,7 @@ def test_npt():
 
         with open(stats_path, encoding="utf8") as stats_file:
             lines = stats_file.readlines()
-            assert "Target P [bar] | Target T [K]" in lines[0]
+            assert "Target P [GPa] | Target T [K]" in lines[0]
             assert len(lines) == 5
     finally:
         restart_path_1.unlink(missing_ok=True)


### PR DESCRIPTION
Resolves #186

1. Changes units from bar to GPa in MD and geomopt (CLI)
2. Moves setting units for `scalar_pressure` when carrying out geometry optimization into calculation module. Previously this was only set for the geomopt CLI command, but this way it's set for anything that calls geomopt e.g. phonons, MD, EoS etc. and for the Python interface, so it's more consistent.

Is there a good way of signposting this? As I mention in #186, for any arbitrary `kwargs` passed to functions, ASE units should be assumed, so this is an exception.

When it's an explicit variable we make it clear, but is there an obvious way when it's passed via (potentially quite convoluted) kwargs e.g. `--minimize-kwargs "{'filter_kwargs': {'scalar_pressure' : x}}"`?

Also worth checking if I've missed obvious cases for other inconsistencies.

 