### PR TITLE
Track carbon usage for calculations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "ase": ("https://wiki.fysik.dtu.dk/ase/", None),
     "phonopy": ("https://phonopy.github.io/phonopy/", None),
+    "codecarbon": ("https://mlco2.github.io/codecarbon/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -201,4 +202,5 @@ nitpick_ignore = [
     ("py:class", "janus_core.helpers.stats.T"),
     ("py:class", "phonopy.structure.atoms.PhonopyAtoms"),
     ("py:class", "ase.optimize.optimize.Optimizer"),
+    ("py:class", "codecarbon.emissions_tracker.OfflineEmissionsTracker"),
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ phonopy = "^2.23.1"
 seekpath = "^1.9.7"
 spglib = "^2.3.0"
 torch-dftd = "^0.4.0"
+codecarbon = "^2.5.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^7.4.1"}


### PR DESCRIPTION
Resolves #68

See https://codecarbon.io/ and https://mlco2.github.io/codecarbon/index.html

There are quite a few alternative implementations, but this is one option, which adds a section to the log, based on the [documentation](https://mlco2.github.io/codecarbon/to_logger.html) e.g.:

```
- timestamp: 2024-07-10 17:20:53,779
  level: INFO
  message:
    timestamp: 2024-07-10T17:20:53
    project_name: janus-core
    run_id: cfd5626c-92bd-400d-bac6-bf2e599d34a0
    duration: 0.5009441375732422
    emissions: 4.837736120304575e-07
    emissions_rate: 9.657236720526065e-07
    cpu_power: 7.5
    gpu_power: 0.0
    ram_power: 5.823497772216797
    cpu_energy: 1.0434945424397786e-06
    gpu_energy: 0
    ram_energy: 8.089440937358934e-07
    energy_consumed: 1.8524386361756719e-06
    country_name: United Kingdom
    country_iso_code: GBR
    region: None
    cloud_provider:
    cloud_region:
    os: Linux-5.15.153.1-microsoft-standard-WSL2-x86_64-with-glibc2.31
    python_version: 3.11.9
    codecarbon_version: 2.5.0
    cpu_count: 8
    cpu_model: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz
    gpu_count: None
    gpu_model: None
    longitude: None
    latitude: None
    ram_total_size: 15.529327392578125
    tracking_mode: machine
    on_cloud: N
    pue: 1.0
  trace: logger
  line: 22
```

Alternatives include:

- Overwriting the `"codecarbon"` logger handler with ours, which is closer to [their example](https://github.com/mlco2/codecarbon/blob/master/examples/logging_to_file.py). This would require either setting the tracker at the same time as our logger, or accessing the root logger, and also returns fewer details:
```
2024-07-10 17:23:48,206 - codecarbon  : INFO     Energy consumed for RAM : 0.000005 kWh. RAM Power : 5.823497772216797 W
2024-07-10 17:23:48,206 - codecarbon  : INFO     Energy consumed for all CPUs : 0.000006 kWh. Total CPU Power : 7.5 W
2024-07-10 17:23:48,206 - codecarbon  : INFO     0.000011 kWh of electricity used since the beginning.
```

- Use the `@track_emissions` decorator, which would either require a global `logger` object to pass correctly, or we use other output options e.g. the csv file, which would probably be the simplest implementation.