### PR TITLE
Fix writing structures for phonons and EoS

### DIFF
--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -17,7 +17,7 @@ from janus_core.helpers.log import config_logger, config_tracker
 from janus_core.helpers.utils import none_to_dict
 
 
-def _calc_volumes_energies(
+def _calc_volumes_energies(  # pylint: disable=too-many-locals
     struct: Atoms,
     *,
     min_volume: float = 0.95,
@@ -174,6 +174,15 @@ def calc_eos(
     file_prefix = file_prefix if file_prefix else struct_name
 
     write_kwargs.setdefault("filename", f"{file_prefix}-generated.xyz")
+
+    if (
+        (minimize or minimize_all)
+        and "write_results" in minimize_kwargs
+        and minimize_kwargs["write_results"]
+    ):
+        raise ValueError(
+            "Optimized structures can be saved by setting `write_structures`"
+        )
 
     if not struct.calc:
         raise ValueError("Please attach a calculator to `struct`.")

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -23,7 +23,7 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
     struct : Atoms
         Structrure to calculate phonons for.
     struct_name : Optional[str]
-        Name of structure. Default is inferred from chemical formula if `struct`.
+        Name of structure. Default is inferred from chemical formula of `struct`.
     supercell : MaybeList[int]
         Size of supercell for calculation. Default is 2.
     displacement : float
@@ -185,6 +185,14 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
                     "name": self.logger.name,
                     "filemode": "a",
                 }
+            # If not specified otherwise, save optimized structure consistently with
+            # phonon output files
+            opt_file = self._build_filename("opt.xyz")
+            if "write_kwargs" in self.minimize_kwargs:
+                self.minimize_kwargs["write_kwargs"].setdefault("filename", opt_file)
+            else:
+                self.minimize_kwargs["write_kwargs"] = {"filename": opt_file}
+
             optimize(self.struct, **self.minimize_kwargs)
 
         if self.logger:

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -17,6 +17,7 @@ from janus_core.cli.types import (
     ReadKwargs,
     StructPath,
     Summary,
+    WriteKwargs,
 )
 from janus_core.cli.utils import (
     check_config,
@@ -60,6 +61,11 @@ def eos(
         float, Option(help="Maximum force for optimization convergence.")
     ] = 0.1,
     minimize_kwargs: MinimizeKwargs = None,
+    write_structures: Annotated[
+        bool,
+        Option(help="Whether to write out all genereated structures."),
+    ] = False,
+    write_kwargs: WriteKwargs = None,
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     read_kwargs: ReadKwargs = None,
@@ -107,6 +113,11 @@ def eos(
         Default is 0.1.
     minimize_kwargs : Optional[dict[str, Any]]
         Other keyword arguments to pass to geometry optimizer. Default is {}.
+    write_structures : bool
+        True to write out all genereated structures. Default is False.
+    write_kwargs : Optional[ASEWriteArgs],
+        Keyword arguments to pass to ase.io.write to save generated structures.
+        Default is {}.
     arch : Optional[str]
         MLIP architecture to use for geometry optimization.
         Default is "mace_mp".
@@ -129,8 +140,8 @@ def eos(
     # Check options from configuration file are all valid
     check_config(ctx)
 
-    [read_kwargs, calc_kwargs, minimize_kwargs] = parse_typer_dicts(
-        [read_kwargs, calc_kwargs, minimize_kwargs]
+    [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs] = parse_typer_dicts(
+        [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs]
     )
 
     if not eos_type in get_args(EoSNames):
@@ -165,6 +176,8 @@ def eos(
         "minimize": minimize,
         "minimize_all": minimize_all,
         "minimize_kwargs": minimize_kwargs,
+        "write_structures": write_structures,
+        "write_kwargs": write_kwargs,
         "file_prefix": file_prefix,
         "log_kwargs": log_kwargs,
     }

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from ase.io import read
 import pytest
 from typer.testing import CliRunner
 
@@ -167,3 +168,33 @@ def test_minimising_all(tmp_path):
             "constant_volume: True",
         ],
     )
+
+
+def test_writing_structs(tmp_path):
+    """Test writing out generated structures."""
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "example"
+    generated_path = tmp_path / "example-generated.xyz"
+
+    result = runner.invoke(
+        app,
+        [
+            "eos",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--n-volumes",
+            4,
+            "--file-prefix",
+            file_prefix,
+            "--write-structures",
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+    assert generated_path.exists()
+    atoms = read(generated_path, index=":")
+    assert len(atoms) == 5

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -198,3 +198,34 @@ def test_writing_structs(tmp_path):
     assert generated_path.exists()
     atoms = read(generated_path, index=":")
     assert len(atoms) == 5
+
+
+def test_error_write_geomopt(tmp_path):
+    """Test an error is raised if trying to write via geomopt."""
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "example"
+
+    minimize_kwargs = "{'write_results': True}"
+
+    result = runner.invoke(
+        app,
+        [
+            "eos",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--n-volumes",
+            4,
+            "--file-prefix",
+            file_prefix,
+            "--minimize",
+            "--minimize-kwargs",
+            minimize_kwargs,
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 1
+    assert isinstance(result.exception, ValueError)

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -278,11 +278,13 @@ def test_invalid_supercell(supercell, tmp_path):
 
 
 def test_minimize_kwargs(tmp_path):
-    """Test setting optimizer function."""
+    """Test setting optimizer function and writing optimized structure."""
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "test"
+    opt_path = tmp_path / "test-opt.xyz"
 
-    minimize_kwargs = "{'optimizer': 'FIRE'}"
+    minimize_kwargs = "{'optimizer': 'FIRE', 'write_results': True}"
 
     result = runner.invoke(
         app,
@@ -294,7 +296,7 @@ def test_minimize_kwargs(tmp_path):
             "--minimize-kwargs",
             minimize_kwargs,
             "--file-prefix",
-            tmp_path / "NaCl",
+            file_prefix,
             "--log",
             log_path,
             "--summary",
@@ -307,3 +309,37 @@ def test_minimize_kwargs(tmp_path):
         log_path,
         includes=["Starting geometry optimization", "Using optimizer: FIRE"],
     )
+    assert opt_path.exists()
+
+
+def test_minimize_filename(tmp_path):
+    """Test minimize filename overwrites default."""
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "test"
+    opt_path = tmp_path / "geomopt-opt.xyz"
+
+    minimize_kwargs = (
+        "{'write_results': 'True', "
+        f"'write_kwargs': {{'filename': '{str(opt_path)}'}}}}"
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "phonons",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--minimize",
+            "--minimize-kwargs",
+            minimize_kwargs,
+            "--file-prefix",
+            file_prefix,
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+    assert opt_path.exists()


### PR DESCRIPTION
Resolves #187 & #188

- Passes file prefix from `phonons` to `geom_opt` by default, so the file names for structures written consistent unless overwritten
- Adds option to save generated structures (and initial, potentially optimized structure) when running `eos` in a single file
  - Prevents writing via `geom_opt`, as the same structures can be saved more safely within `eos`
  - If we also tried to save the optimization trajectory, this would still be overwritten by each structure in turn, but at that point I think it's probably better to recommend dealing with them as separate steps