### PR TITLE
Fix setting devices

### DIFF
--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -91,7 +91,7 @@ EoSNames = Literal[
 
 # Janus specific
 Architectures = Literal["mace", "mace_mp", "mace_off", "m3gnet", "chgnet"]
-Devices = Literal["cpu", "cuda", "mps"]
+Devices = Literal["cpu", "cuda", "mps", "xpu"]
 Ensembles = Literal["nph", "npt", "nve", "nvt", "nvt-nh"]
 
 

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -6,6 +6,8 @@ Similar in spirit to matcalc and quacc approaches
 - https://github.com/Quantum-Accelerators/quacc.git
 """
 
+from typing import get_args
+
 from ase.calculators.calculator import Calculator
 import torch
 
@@ -46,6 +48,9 @@ def choose_calculator(
     # but the error message is clear if imports are missing.
     if "model" in kwargs and "model_paths" in kwargs:
         raise ValueError("Please specify either `model` or `model_paths`")
+
+    if not device in get_args(Devices):
+        raise ValueError(f"`device` must be one of: {get_args(Devices)}")
 
     if architecture == "mace":
         from mace import __version__

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -66,7 +66,7 @@ def choose_calculator(
         # Otherwise, take `model_paths` if specified, then default to "small"
         kwargs.setdefault("model", kwargs.pop("model_paths", "small"))
         kwargs.setdefault("default_dtype", "float64")
-        calculator = mace_mp(**kwargs)
+        calculator = mace_mp(device=device, **kwargs)
 
     elif architecture == "mace_off":
         from mace import __version__
@@ -76,7 +76,7 @@ def choose_calculator(
         # Otherwise, take `model_paths` if specified, then default to "small"
         kwargs.setdefault("model", kwargs.pop("model_paths", "small"))
         kwargs.setdefault("default_dtype", "float64")
-        calculator = mace_off(**kwargs)
+        calculator = mace_off(device=device, **kwargs)
 
     elif architecture == "m3gnet":
         from matgl import __version__, load_model

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -57,7 +57,7 @@ def test_no_optimize(tmp_path):
     )
 
 
-test_data_potentials = [("m3gnet", "cpu"), ("chgnet", "")]
+test_data_potentials = [("m3gnet", "cpu"), ("chgnet", "cpu")]
 
 
 @pytest.mark.parametrize("arch, device", test_data_potentials)

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -51,3 +51,10 @@ def test_model_model_paths():
             model=MODEL_PATH,
             model_paths=MODEL_PATH,
         )
+
+
+@pytest.mark.parametrize("architecture", ["mace_mp", "mace_off"])
+def test_invalid_device(architecture):
+    """Test error raised for invalid device is specified."""
+    with pytest.raises(ValueError):
+        choose_calculator(architecture=architecture, device="invalid")

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -17,7 +17,7 @@ test_data_mace = [
     ("mace_off", "cpu", {"model": "small"}),
 ]
 
-test_data_extras = [("m3gnet", "cpu"), ("chgnet", "")]
+test_data_extras = [("m3gnet", "cpu"), ("chgnet", "cpu")]
 
 
 @pytest.mark.parametrize("architecture, device, kwargs", test_data_mace)

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -255,7 +255,7 @@ def test_no_atoms_or_path():
 
 test_data_potentials = [
     ("m3gnet", "cpu", -26.729949951171875),
-    ("chgnet", "", -29.331436157226562),
+    ("chgnet", "cpu", -29.331436157226562),
 ]
 
 


### PR DESCRIPTION
Resolves #95

It's not in the main branch of MACE yet, but as mentioned in #95, there's no reason not to allow `xpu` in theory, so I've added it.

More importantly, in the process of extending the allowed devices, I realised that `device` was not passed to MACE-MP, or MACE-OFF, so this should now be fixed.

Also adds a test that the chosen `device` is valid, as the PyTorch error isn't particularly clear:

```
RuntimeError: don't know how to restore data location of torch.storage.UntypedStorage (tagged with invalid)
```

This should perhaps be three PRs, but they're interconnected and otherwise very minor...