### PR TITLE
Test Windows and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,21 @@ jobs:
   tests:
     name: ${{ matrix.os }} / ${{ matrix.python-version }}
     runs-on: "${{ matrix.os }}"
+    continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        experimental: [false]
         include:
           - os: macos-latest
             python-version: "3.11"
+            experimental: true
           - os: windows-latest
             python-version: "3.11"
+            experimental: true
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           - os: macos-latest
             python-version: "3.11"
             experimental: true
+          - os: macos-13
+            python-version: "3.11"
+            experimental: true
           - os: windows-latest
             python-version: "3.11"
             experimental: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,19 @@ on: [push, pull_request]
 jobs:
 
   tests:
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} / ${{ matrix.python-version }}
+    runs-on: "${{ matrix.os }}"
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.9','3.10','3.11','3.12']
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        include:
+          - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.11"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       env:
         # show timings of tests
         PYTEST_ADDOPTS: "--durations=0"
+        PYTORCH_MPS_HIGH_WATERMARK_RATIO: "0.0"
       run: poetry run pytest --cov janus_core --cov-append .
 
     - name: Report coverage to Coveralls


### PR DESCRIPTION
I thought we had an issue, but can't find it...

- Adds Windows and MacOS (arm and intel, I think, based on [this list](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories))

These are experimental, as we can't currently guarantee support/functionality, but this makes it easier to see and fix issues, and hopefully we can get to a point where they are all supported fully.

Currently there seem to be at least a couple that we could address soon:

- Installing dgl for windows
- Setting the correct device for `chgnet` (on MacOS or any OS?)

(I don't suggest fixing them as part of this PR)

Unfortunately I think even "allowed" failures lose the green tick, which is annoying.