### PR TITLE
Add final file option for MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,13 @@ Run an NVT heating simultation from 20K to 300K in steps of 20K, with 10fs at ea
 janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 300 --temp-step 20 --temp-time 10
 ```
 
-The produced statistics and trajectory files will indicate the heating range `NaCl-nvt-T20.0-T300.0-stats.dat`, `NaCl-nvt-T20.0-T300.0-traj.xyz`. There will also be final structure files at each temperature point:
+The produced final, statistics, and trajectory files will indicate the heating range:
 
-```
-NaCl-nvt-T20.0-final.xyz
-NaCl-nvt-T40.0-final.xyz
-...
-NaCl-nvt-T300.0-final.xyz
-```
+- `NaCl-nvt-T20.0-T300.0-final.xyz`
+- `NaCl-nvt-T20.0-T300.0-stats.dat`
+- `NaCl-nvt-T20.0-T300.0-traj.xyz`
+
+The final structure file will include the final structure at each temperature point (20K, 40K, ..., 300K).
 
 MD can also be carried out after heating using the same options as described in [Molecular dynamics](#molecular-dynamics). For example:
 
@@ -186,7 +185,7 @@ janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 
 
 This performs the same initial heating, before running a further 1000 steps (1 ps) at 300K.
 
-When MD is run with heating the trajectory ```NaCl-nvt-T20.0-T300.0-T300.0-traj.xyz``` and statistics ```NaCl-nvt-T20.0-T300.0-T300.0-stats.dat``` files will indicate the heating range and MD temperature (which may be different). With heating and MD trajectories/statistics within the same files.
+When MD is run with heating, the final, trajectory, and statistics files (`NaCl-nvt-T20.0-T300.0-T300.0-final.xyz`, `NaCl-nvt-T20.0-T300.0-T300.0-traj.xyz`, and `NaCl-nvt-T20.0-T300.0-T300.0-stats.dat`) indicate the heating range and MD temperature, which can differ. Each file contains data from both the heating and MD parts of the simulation.
 
 Additional settings for geometry optimization, such as enabling optimization of cell vectors by setting `hydrostatic_strain = True` for the ASE filter, can be set using the `--minimize-kwargs` option:
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -136,6 +136,17 @@ def md(
     restarts_to_keep: Annotated[
         int, Option(help="Restart files to keep if rotating.")
     ] = 4,
+    final_file: Annotated[
+        Path,
+        Option(
+            help=(
+                """
+                File to save final configuration at each temperature of similation.
+                Default inferred from `file_prefix`.
+                """
+            )
+        ),
+    ] = None,
     stats_file: Annotated[
         Path,
         Option(
@@ -249,6 +260,9 @@ def md(
         Whether to rotate restart files. Default is False.
     restarts_to_keep : int
         Restart files to keep if rotating. Default is 4.
+    final_file : Optional[PathLike]
+        File to save final configuration at each temperature of similation. Default
+        inferred from `file_prefix`.
     stats_file : Optional[PathLike]
         File to save thermodynamical statistics. Default inferred from `file_prefix`.
     stats_every : int
@@ -344,6 +358,7 @@ def md(
         "restart_every": restart_every,
         "rotate_restart": rotate_restart,
         "restarts_to_keep": restarts_to_keep,
+        "final_file": final_file,
         "stats_file": stats_file,
         "stats_every": stats_every,
         "traj_file": traj_file,

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -550,8 +550,7 @@ def test_heating(tmp_path):
     """Test heating with no MD."""
     # pylint: disable=invalid-name
     file_prefix = tmp_path / "NaCl-heating"
-    final_T0_file = tmp_path / "NaCl-heating-T0.0-final.xyz"
-    final_T20_file = tmp_path / "NaCl-heating-T20.0-final.xyz"
+    final_file = tmp_path / "NaCl-heating-final.xyz"
     log_file = tmp_path / "nvt.log"
 
     single_point = SinglePoint(
@@ -582,8 +581,7 @@ def test_heating(tmp_path):
         ],
         excludes=["Starting molecular dynamics simulation"],
     )
-    assert final_T0_file.exists()
-    assert final_T20_file.exists()
+    assert final_file.exists()
 
 
 def test_noramp_heating(tmp_path):
@@ -656,13 +654,11 @@ def test_heating_files():
     """Test default heating file names."""
     traj_heating_path = Path("Cl4Na4-nvt-T10-T20-traj.xyz")
     stats_heating_path = Path("Cl4Na4-nvt-T10-T20-stats.dat")
-    final_10_path = Path("Cl4Na4-nvt-T10-final.xyz")
-    final_20_path = Path("Cl4Na4-nvt-T20-final.xyz")
+    final_path = Path("Cl4Na4-nvt-T10-T20-final.xyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
-    assert not final_10_path.exists()
-    assert not final_20_path.exists()
+    assert not final_path.exists()
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
@@ -682,10 +678,9 @@ def test_heating_files():
     )
     try:
         nvt.run()
-        final_10_atoms = read(final_10_path)
-        assert isinstance(final_10_atoms, Atoms)
-        final_20_atoms = read(final_20_path)
-        assert isinstance(final_20_atoms, Atoms)
+        final_atoms = read(final_path, index=":")
+        assert isinstance(final_atoms[0], Atoms)
+        assert len(final_atoms) == 2
 
         traj = read(traj_heating_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
@@ -700,8 +695,7 @@ def test_heating_files():
     finally:
         traj_heating_path.unlink(missing_ok=True)
         stats_heating_path.unlink(missing_ok=True)
-        final_10_path.unlink(missing_ok=True)
-        final_20_path.unlink(missing_ok=True)
+        final_path.unlink(missing_ok=True)
 
 
 def test_heating_md_files():
@@ -709,14 +703,10 @@ def test_heating_md_files():
 
     traj_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-traj.xyz")
     stats_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
-    final_10_path = Path("Cl4Na4-nvt-T10-final.xyz")
-    final_20_path = Path("Cl4Na4-nvt-T20-final.xyz")
-    final_path = Path("Cl4Na4-nvt-T25.0-final.xyz")
+    final_path = Path("Cl4Na4-nvt-T10-T20-T25.0-final.xyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
-    assert not final_10_path.exists()
-    assert not final_20_path.exists()
     assert not final_path.exists()
 
     single_point = SinglePoint(
@@ -737,10 +727,9 @@ def test_heating_md_files():
     )
     try:
         nvt.run()
-        final_10_atoms = read(final_10_path)
-        assert isinstance(final_10_atoms, Atoms)
-        final_20_atoms = read(final_20_path)
-        assert isinstance(final_20_atoms, Atoms)
+        final_atoms = read(final_path, index=":")
+        assert len(final_atoms) == 3
+        assert isinstance(final_atoms[0], Atoms)
 
         traj = read(traj_heating_path, index=":")
         assert all(isinstance(image, Atoms) for image in traj)
@@ -752,14 +741,9 @@ def test_heating_md_files():
         assert stats.data[2, 16] == 20
         assert stats.data[3, 16] == 25
 
-        final = read(final_path)
-        assert isinstance(final, Atoms)
-
     finally:
         traj_heating_path.unlink(missing_ok=True)
         stats_heating_path.unlink(missing_ok=True)
-        final_10_path.unlink(missing_ok=True)
-        final_20_path.unlink(missing_ok=True)
         final_path.unlink(missing_ok=True)
 
 
@@ -797,9 +781,7 @@ def test_cooling(tmp_path):
     """Test cooling with no MD."""
     # pylint: disable=invalid-name
     file_prefix = tmp_path / "NaCl-cooling"
-    final_T0_file = tmp_path / "NaCl-cooling-T0.0-final.xyz"
-    final_T10_file = tmp_path / "NaCl-cooling-T10.0-final.xyz"
-    final_T20_file = tmp_path / "NaCl-cooling-T20.0-final.xyz"
+    final_path = tmp_path / "NaCl-cooling-final.xyz"
     stats_cooling_path = tmp_path / "NaCl-cooling-stats.dat"
     log_file = tmp_path / "nvt.log"
 
@@ -831,9 +813,10 @@ def test_cooling(tmp_path):
         ],
         excludes=["Starting molecular dynamics simulation"],
     )
-    assert final_T0_file.exists()
-    assert final_T10_file.exists()
-    assert final_T20_file.exists()
+    assert final_path.exists()
+    final_atoms = read(final_path, index=":")
+    assert isinstance(final_atoms[0], Atoms)
+    assert len(final_atoms) == 3
 
     stats = Stats(source=stats_cooling_path)
     assert stats.rows == 2

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -386,7 +386,7 @@ def test_ensemble_kwargs(tmp_path):
     file_prefix = tmp_path / "md"
     log_path = tmp_path / "md.log"
     summary_path = tmp_path / "summary.yml"
-    final_path = tmp_path / "md-T300.0-p0.0-final.xyz"
+    final_path = tmp_path / "md-final.xyz"
     stats_path = tmp_path / "md-stats.dat"
 
     ensemble_kwargs = "{'mask' : (0, 1, 0)}"

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -346,7 +346,7 @@ def test_invalid_config():
 
 
 def test_struct_name(tmp_path):
-    """ "Test specifying the structure name."""
+    """Test specifying the structure name."""
     struct_name = "EXAMPLE"
     struct_path = tmp_path / struct_name
     stats_path = tmp_path / f"{struct_name}-nvt-T10.0-stats.dat"
@@ -465,3 +465,41 @@ def test_invalid_ensemble_kwargs(tmp_path):
 
     assert result.exit_code == 1
     assert isinstance(result.exception, TypeError)
+
+
+def test_final_name(tmp_path):
+    """Test specifying the final file name."""
+    file_prefix = tmp_path / "npt"
+    stats_path = tmp_path / "npt-stats.dat"
+    traj_path = tmp_path / "npt-traj.xyz"
+    final_path = tmp_path / "example.xyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+    result = runner.invoke(
+        app,
+        [
+            "md",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--ensemble",
+            "nvt",
+            "--steps",
+            "2",
+            "--stats-every",
+            1,
+            "--traj-every",
+            1,
+            "--file-prefix",
+            file_prefix,
+            "--final-file",
+            final_path,
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+    assert traj_path.exists()
+    assert stats_path.exists()
+    assert final_path.exists()


### PR DESCRIPTION
Resolves #198

- Replaces final files for each temperature with a single `-final` file, with the same naming conventions as `-traj` and `-stats` files, as well as an option to define the name of this file similarly via `final_file` (`--final-file`).

What were previously individual `-final` files are accessible through reading a specific index from the combined file.

Each structure has the associated temperature (and pressure) that was previously in the file names stored as `info`.