### PR TITLE
Change default output extensions to extxyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Perform a single point calcuation (using the [MACE-MP](https://github.com/ACEsui
 janus singlepoint --struct tests/data/NaCl.cif --arch mace_mp --model-path small
 ```
 
-This will calculate the energy, stress and forces and save this in `NaCl-results.xyz`, in addition to generating a log file, `singlepoint.log`, and summary of inputs, `singlepoint_summary.yml`.
+This will calculate the energy, stress and forces and save this in `NaCl-results.extxyz`, in addition to generating a log file, `singlepoint.log`, and summary of inputs, `singlepoint_summary.yml`.
 
 Additional options may be specified. For example:
 
 ```shell
-janus singlepoint --struct tests/data/NaCl.cif --arch mace --model-path /path/to/your/ml.model --properties energy --properties forces --log ./example.log --out ./example.xyz
+janus singlepoint --struct tests/data/NaCl.cif --arch mace --model-path /path/to/your/ml.model --properties energy --properties forces --log ./example.log --out ./example.extxyz
 ```
 
 This calculates both forces and energies, defines the MLIP architecture and path to your locally saved model, and changes where the log and results files are saved.
@@ -104,12 +104,12 @@ Perform geometry optimization (using the [MACE-MP](https://github.com/ACEsuit/ma
 janus geomopt --struct tests/data/H2O.cif --arch mace_mp --model-path small
 ```
 
-This will optimize the atomic positions and save the resulting structure in `H2O-opt.xyz`, in addition to generating a log file, `geomopt.log`, and summary of inputs, `geomopt_summary.yml`.
+This will optimize the atomic positions and save the resulting structure in `H2O-opt.extxyz`, in addition to generating a log file, `geomopt.log`, and summary of inputs, `geomopt_summary.yml`.
 
 Additional options may be specified. This shares most options with `singlepoint`, as well as a few additional options, such as:
 
 ```shell
-janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --vectors-only --traj 'NaCl-traj.xyz'
+janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --vectors-only --traj 'NaCl-traj.extxyz'
 ```
 
 This allows the cell vectors to be optimised, allowing only hydrostatic deformation, and saves the optimization trajectory in addition to the final structure and log.
@@ -136,9 +136,9 @@ janus md --ensemble npt --struct tests/data/NaCl.cif --arch mace_mp --model-path
 This will generate several output files:
 
 - Thermodynamical statistics every 100 steps, written to `NaCl-npt-T300.0-p1.0-stats.dat`
-- The structure trajectory every 100 steps, written to `NaCl-npt-T300.0-p1.0-traj.xyz`
-- The structure to be able to restart the dynamics every 1000 steps, written to `NaCl-npt-T300.0-p1.0-res-1000.xyz`
-- The final structure written to `NaCl-npt-T300.0-p1.0-final.xyz`
+- The structure trajectory every 100 steps, written to `NaCl-npt-T300.0-p1.0-traj.extxyz`
+- The structure to be able to restart the dynamics every 1000 steps, written to `NaCl-npt-T300.0-p1.0-res-1000.extxyz`
+- The final structure written to `NaCl-npt-T300.0-p1.0-final.extxyz`
 - A log of the processes carried out, written to `md.log`
 - A summary of the inputs and start/end time, written to `md_summary.yml`.
 
@@ -152,7 +152,7 @@ This performs an NVT molecular dynamics simulation at 300K for 1000 steps (0.5 p
 
 
 ```shell
-janus md --ensemble nve --struct tests/data/NaCl.cif --steps 200 --temp 300 --traj-start 100 --traj-every 10 --traj-file "example-trajectory.xyz" --stats-every 10 --stats-file "example-statistics.dat"
+janus md --ensemble nve --struct tests/data/NaCl.cif --steps 200 --temp 300 --traj-start 100 --traj-every 10 --traj-file "example-trajectory.extxyz" --stats-every 10 --stats-file "example-statistics.dat"
 ```
 
 This performs an NVE molecular dynamics simulation at 300K for 200 steps (0.2 ps), saving the trajectory every 10 steps after the first 100, and the thermodynamical statistics every 10 steps, as well as changing the output file names for both.
@@ -171,9 +171,9 @@ janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 
 
 The produced final, statistics, and trajectory files will indicate the heating range:
 
-- `NaCl-nvt-T20.0-T300.0-final.xyz`
+- `NaCl-nvt-T20.0-T300.0-final.extxyz`
 - `NaCl-nvt-T20.0-T300.0-stats.dat`
-- `NaCl-nvt-T20.0-T300.0-traj.xyz`
+- `NaCl-nvt-T20.0-T300.0-traj.extxyz`
 
 The final structure file will include the final structure at each temperature point (20K, 40K, ..., 300K).
 
@@ -185,7 +185,7 @@ janus md --ensemble nvt --struct tests/data/NaCl.cif --temp-start 20 --temp-end 
 
 This performs the same initial heating, before running a further 1000 steps (1 ps) at 300K.
 
-When MD is run with heating, the final, trajectory, and statistics files (`NaCl-nvt-T20.0-T300.0-T300.0-final.xyz`, `NaCl-nvt-T20.0-T300.0-T300.0-traj.xyz`, and `NaCl-nvt-T20.0-T300.0-T300.0-stats.dat`) indicate the heating range and MD temperature, which can differ. Each file contains data from both the heating and MD parts of the simulation.
+When MD is run with heating, the final, trajectory, and statistics files (`NaCl-nvt-T20.0-T300.0-T300.0-final.extxyz`, `NaCl-nvt-T20.0-T300.0-T300.0-traj.extxyz`, and `NaCl-nvt-T20.0-T300.0-T300.0-stats.dat`) indicate the heating range and MD temperature, which can differ. Each file contains data from both the heating and MD parts of the simulation.
 
 Additional settings for geometry optimization, such as enabling optimization of cell vectors by setting `hydrostatic_strain = True` for the ASE filter, can be set using the `--minimize-kwargs` option:
 
@@ -251,7 +251,7 @@ For example, with the following configuration file and command:
 struct: "NaCl.cif"
 properties:
   - "energy"
-out: "NaCl-results.xyz"
+out: "NaCl-results.extxyz"
 arch: mace_mp
 model-path: medium
 calc-kwargs:
@@ -294,7 +294,7 @@ MACE descriptors can be calculated for structures (using the [MACE-MP](https://g
 janus descriptors --struct tests/data/NaCl.cif --arch mace_mp --model-path small
 ```
 
-This will calculate the mean descriptor for this structure and save this as attached information (`descriptors`) in `NaCl-descriptors.xyz`, in addition to generating a log file, `descriptors.log`, and summary of inputs, `descriptors_summary.yml`.
+This will calculate the mean descriptor for this structure and save this as attached information (`descriptors`) in `NaCl-descriptors.extxyz`, in addition to generating a log file, `descriptors.log`, and summary of inputs, `descriptors_summary.yml`.
 
 The mean descriptor per element can also be calculated, and all descriptors, rather than only the invariant part, can be used when calculating the means:
 
@@ -302,7 +302,7 @@ The mean descriptor per element can also be calculated, and all descriptors, rat
 janus descriptors --struct tests/data/NaCl.cif --no-invariants-only --calc-per-element
 ```
 
-This will generate the same output files, but additional labels (`Cl_descriptor` and `Na_descriptor`) will be saved in `NaCl-descriptors.xyz`.
+This will generate the same output files, but additional labels (`Cl_descriptor` and `Na_descriptor`) will be saved in `NaCl-descriptors.extxyz`.
 
 For all options, run `janus descriptors --help`.
 

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -173,7 +173,7 @@ def calc_eos(
     struct_name = struct_name if struct_name else struct.get_chemical_formula()
     file_prefix = file_prefix if file_prefix else struct_name
 
-    write_kwargs.setdefault("filename", f"{file_prefix}-generated.xyz")
+    write_kwargs.setdefault("filename", f"{file_prefix}-generated.extxyz")
 
     if (
         (minimize or minimize_all)

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -183,7 +183,7 @@ def optimize(  # pylint: disable=too-many-arguments,too-many-locals,too-many-bra
 
     write_kwargs.setdefault(
         "filename",
-        Path(f"./{struct.get_chemical_formula()}-opt.xyz").absolute(),
+        Path(f"./{struct.get_chemical_formula()}-opt.extxyz").absolute(),
     )
 
     if traj_kwargs and "filename" not in traj_kwargs:

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -351,7 +351,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         self.n_atoms = len(self.struct)
 
         self.final_file = self._build_filename(
-            "final.xyz",
+            "final.extxyz",
             self._parameter_prefix if file_prefix is None else "",
             filename=self.final_file,
         )
@@ -361,7 +361,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             filename=self.stats_file,
         )
         self.traj_file = self._build_filename(
-            "traj.xyz",
+            "traj.extxyz",
             self._parameter_prefix if file_prefix is None else "",
             filename=self.traj_file,
         )
@@ -451,7 +451,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         """
         step = self.offset + self.dyn.nsteps
         return self._build_filename(
-            f"res-{step}.xyz", f"T{self.temp}", prefix_override=self.restart_stem
+            f"res-{step}.extxyz", f"T{self.temp}", prefix_override=self.restart_stem
         )
 
     @staticmethod
@@ -899,7 +899,7 @@ class NPT(MolecularDynamics):
         step = self.offset + self.dyn.nsteps
         pressure = f"p{self.pressure}" if not isinstance(self, NVT_NH) else ""
         return self._build_filename(
-            f"res-{step}.xyz",
+            f"res-{step}.extxyz",
             f"T{self.temp}",
             pressure,
             prefix_override=self.restart_stem,

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -187,7 +187,7 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
                 }
             # If not specified otherwise, save optimized structure consistently with
             # phonon output files
-            opt_file = self._build_filename("opt.xyz")
+            opt_file = self._build_filename("opt.extxyz")
             if "write_kwargs" in self.minimize_kwargs:
                 self.minimize_kwargs["write_kwargs"].setdefault("filename", opt_file)
             else:

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -395,7 +395,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
 
         write_kwargs.setdefault(
             "filename",
-            self._build_filename("results.xyz").absolute(),
+            self._build_filename("results.extxyz").absolute(),
         )
 
         if self.logger:

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -128,7 +128,7 @@ def descriptors(
     if out:
         write_kwargs["filename"] = out
     else:
-        write_kwargs["filename"] = f"{s_point.struct_name}-descriptors.xyz"
+        write_kwargs["filename"] = f"{s_point.struct_name}-descriptors.extxyz"
 
     # Dictionary of inputs for optimize function
     descriptors_kwargs = {

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -234,7 +234,7 @@ def geomopt(
     if out:
         write_kwargs["filename"] = out
     else:
-        write_kwargs["filename"] = f"{s_point.struct_name}-opt.xyz"
+        write_kwargs["filename"] = f"{s_point.struct_name}-opt.extxyz"
 
     _set_minimize_kwargs(minimize_kwargs, traj, vectors_only, pressure)
 

--- a/janus_core/helpers/descriptors.py
+++ b/janus_core/helpers/descriptors.py
@@ -62,7 +62,7 @@ def calc_descriptors(
 
     write_kwargs.setdefault(
         "filename",
-        Path(f"./{struct_name}-descriptors.xyz").absolute(),
+        Path(f"./{struct_name}-descriptors.extxyz").absolute(),
     )
 
     if isinstance(struct, Sequence):

--- a/tests/data/geomopt_config.yml
+++ b/tests/data/geomopt_config.yml
@@ -1,5 +1,5 @@
 struct: "NaCl.cif"
-out: "NaCl-results.xyz"
+out: "NaCl-results.extxyz"
 minimize-kwargs:
   opt-kwargs:
     alpha: 100

--- a/tests/data/singlepoint_config.yml
+++ b/tests/data/singlepoint_config.yml
@@ -1,7 +1,7 @@
 struct: "NaCl.cif"
 properties:
   - "energy"
-out: "NaCl-results.xyz"
+out: "NaCl-results.extxyz"
 calc-kwargs:
   model: "small"
 read-kwargs:

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -24,7 +24,7 @@ def test_descriptors(tmp_path):
     """Test calculating MLIP descriptors."""
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    out_path = tmp_path / "NaCl-descriptors.xyz"
+    out_path = tmp_path / "NaCl-descriptors.extxyz"
     result = runner.invoke(
         app,
         [
@@ -62,7 +62,7 @@ def test_calc_per_element(tmp_path):
     """Test calculating MLIP descriptors for each element."""
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    out_path = tmp_path / "NaCl-descriptors.xyz"
+    out_path = tmp_path / "NaCl-descriptors.extxyz"
     result = runner.invoke(
         app,
         [
@@ -101,7 +101,7 @@ def test_invariant(tmp_path):
     """Test setting invariant_only to false."""
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    out_path = tmp_path / "NaCl-descriptors.xyz"
+    out_path = tmp_path / "NaCl-descriptors.extxyz"
     result = runner.invoke(
         app,
         [
@@ -140,7 +140,7 @@ def test_traj(tmp_path):
     """Test calculating descriptors for a trajectory."""
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    out_path = tmp_path / "benzene-descriptors.xyz"
+    out_path = tmp_path / "benzene-descriptors.extxyz"
     result = runner.invoke(
         app,
         [

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -175,7 +175,7 @@ def test_writing_structs(tmp_path):
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
     file_prefix = tmp_path / "example"
-    generated_path = tmp_path / "example-generated.xyz"
+    generated_path = tmp_path / "example-generated.extxyz"
 
     result = runner.invoke(
         app,

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -49,7 +49,7 @@ def test_optimize(architecture, struct_path, expected, kwargs):
 
 def test_saving_struct(tmp_path):
     """Test saving optimized structure."""
-    struct_path = tmp_path / "NaCl.xyz"
+    results_path = tmp_path / "NaCl.extxyz"
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
@@ -62,9 +62,9 @@ def test_saving_struct(tmp_path):
     optimize(
         single_point.struct,
         write_results=True,
-        write_kwargs={"filename": struct_path, "format": "extxyz"},
+        write_kwargs={"filename": results_path, "format": "extxyz"},
     )
-    opt_struct = read(struct_path)
+    opt_struct = read(results_path)
 
     assert opt_struct.get_potential_energy() < init_energy
 
@@ -92,14 +92,14 @@ def test_traj_reformat(tmp_path):
     )
 
     traj_path_binary = tmp_path / "NaCl.traj"
-    traj_path_xyz = tmp_path / "NaCl-traj.xyz"
+    traj_path_xyz = tmp_path / "NaCl-traj.extxyz"
 
     optimize(
         single_point.struct,
         opt_kwargs={"trajectory": str(traj_path_binary)},
         traj_kwargs={"filename": traj_path_xyz},
     )
-    traj = read(tmp_path / "NaCl-traj.xyz", index=":")
+    traj = read(traj_path_xyz, index=":")
 
     assert len(traj) == 3
 
@@ -111,7 +111,7 @@ def test_missing_traj_kwarg(tmp_path):
         architecture="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
-    traj_path = tmp_path / "NaCl-traj.xyz"
+    traj_path = tmp_path / "NaCl-traj.extxyz"
     with pytest.raises(ValueError):
         optimize(single_point.struct, traj_kwargs={"filename": traj_path})
 

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -28,7 +28,7 @@ def test_help():
 
 def test_geomopt(tmp_path):
     """Test geomopt calculation."""
-    results_path = Path("./NaCl-opt.xyz").absolute()
+    results_path = Path("./NaCl-opt.extxyz").absolute()
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -54,7 +54,7 @@ def test_geomopt(tmp_path):
 
 def test_log(tmp_path):
     """Test log correctly written for geomopt."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -81,8 +81,8 @@ def test_log(tmp_path):
 
 def test_traj(tmp_path):
     """Test trajectory correctly written for geomopt."""
-    results_path = tmp_path / "NaCl-opt.xyz"
-    traj_path = f"{tmp_path}/test.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
+    traj_path = f"{tmp_path}/test.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -109,7 +109,7 @@ def test_traj(tmp_path):
 
 def test_fully_opt(tmp_path):
     """Test passing --fully-opt without --vectors-only"""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -149,7 +149,7 @@ def test_fully_opt(tmp_path):
 
 def test_fully_opt_and_vectors(tmp_path):
     """Test passing --fully-opt with --vectors-only."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -187,7 +187,7 @@ def test_fully_opt_and_vectors(tmp_path):
 
 def test_vectors_not_fully_opt(tmp_path):
     """Test passing --vectors-only without --fully-opt."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -217,7 +217,7 @@ test_data = ["--vectors-only", "--fully-opt"]
 @pytest.mark.parametrize("option", test_data)
 def test_scalar_pressure(option, tmp_path):
     """Test passing --pressure with --vectors-only."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -244,7 +244,7 @@ def test_scalar_pressure(option, tmp_path):
 
 def test_duplicate_traj(tmp_path):
     """Test trajectory file cannot be not passed via traj_kwargs."""
-    traj_path = tmp_path / "NaCl-traj.xyz"
+    traj_path = tmp_path / "NaCl-traj.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -272,7 +272,7 @@ def test_restart(tmp_path):
     """Test restarting geometry optimization."""
     data_path = DATA_PATH / "NaCl-deformed.cif"
     restart_path = tmp_path / "NaCl-res.pkl"
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -326,7 +326,7 @@ def test_restart(tmp_path):
 
 def test_summary(tmp_path):
     """Test summary file can be read correctly."""
-    results_path = tmp_path / "NaCl-results.xyz"
+    results_path = tmp_path / "NaCl-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -363,7 +363,7 @@ def test_summary(tmp_path):
 
 def test_config(tmp_path):
     """Test passing a config file with opt_kwargs."""
-    results_path = tmp_path / "NaCl-results.xyz"
+    results_path = tmp_path / "NaCl-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -411,7 +411,7 @@ def test_invalid_config():
 
 def test_const_volume(tmp_path):
     """Test setting constant volume with --fully-opt."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -440,7 +440,7 @@ def test_const_volume(tmp_path):
 
 def test_optimizer_str(tmp_path):
     """Test setting optimizer function."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -469,7 +469,7 @@ def test_optimizer_str(tmp_path):
 
 def test_filter_str(tmp_path):
     """Test setting filter function."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -499,7 +499,7 @@ def test_filter_str(tmp_path):
 
 def test_filter_str_error(tmp_path):
     """Test setting filter function without --fully-opt or --vectors-only."""
-    results_path = tmp_path / "NaCl-opt.xyz"
+    results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -41,10 +41,10 @@ def test_init(ensemble, expected):
 
 def test_npt():
     """Test NPT molecular dynamics."""
-    restart_path_1 = Path("Cl4Na4-npt-T300.0-p1.0-res-2.xyz")
-    restart_path_2 = Path("Cl4Na4-npt-T300.0-p1.0-res-4.xyz")
-    restart_final = Path("Cl4Na4-npt-T300.0-p1.0-final.xyz")
-    traj_path = Path("Cl4Na4-npt-T300.0-p1.0-traj.xyz")
+    restart_path_1 = Path("Cl4Na4-npt-T300.0-p1.0-res-2.extxyz")
+    restart_path_2 = Path("Cl4Na4-npt-T300.0-p1.0-res-4.extxyz")
+    restart_final = Path("Cl4Na4-npt-T300.0-p1.0-final.extxyz")
+    traj_path = Path("Cl4Na4-npt-T300.0-p1.0-traj.extxyz")
     stats_path = Path("Cl4Na4-npt-T300.0-p1.0-stats.dat")
 
     assert not restart_path_1.exists()
@@ -94,9 +94,9 @@ def test_npt():
 
 def test_nvt_nh():
     """Test NVT-Nosé–Hoover  molecular dynamics."""
-    restart_path = Path("Cl4Na4-nvt-nh-T300.0-res-3.xyz")
-    restart_final_path = Path("Cl4Na4-nvt-nh-T300.0-final.xyz")
-    traj_path = Path("Cl4Na4-nvt-nh-T300.0-traj.xyz")
+    restart_path = Path("Cl4Na4-nvt-nh-T300.0-res-3.extxyz")
+    restart_final_path = Path("Cl4Na4-nvt-nh-T300.0-final.extxyz")
+    traj_path = Path("Cl4Na4-nvt-nh-T300.0-traj.extxyz")
     stats_path = Path("Cl4Na4-nvt-nh-T300.0-stats.dat")
 
     assert not restart_path.exists()
@@ -145,7 +145,7 @@ def test_nvt_nh():
 def test_nve(tmp_path):
     """Test NVE molecular dynamics."""
     file_prefix = tmp_path / "Cl4Na4-nve-T300.0"
-    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.xyz"
+    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.extxyz"
     stats_path = tmp_path / "Cl4Na4-nve-T300.0-stats.dat"
 
     single_point = SinglePoint(
@@ -176,9 +176,9 @@ def test_nve(tmp_path):
 
 def test_nph():
     """Test NPH molecular dynamics."""
-    restart_path = Path("Cl4Na4-nph-T300.0-p0.0-res-2.xyz")
-    restart_final_path = Path("Cl4Na4-nph-T300.0-p0.0-final.xyz")
-    traj_path = Path("Cl4Na4-nph-T300.0-p0.0-traj.xyz")
+    restart_path = Path("Cl4Na4-nph-T300.0-p0.0-res-2.extxyz")
+    restart_final_path = Path("Cl4Na4-nph-T300.0-p0.0-final.extxyz")
+    traj_path = Path("Cl4Na4-nph-T300.0-p0.0-traj.extxyz")
     stats_path = Path("Cl4Na4-nph-T300.0-p0.0-stats.dat")
 
     assert not restart_path.exists()
@@ -227,7 +227,7 @@ def test_nph():
 def test_restart(tmp_path):
     """Test restarting molecular dynamics simulation."""
     file_prefix = tmp_path / "Cl4Na4-nvt-T300.0"
-    traj_path = tmp_path / "Cl4Na4-nvt-T300.0-traj.xyz"
+    traj_path = tmp_path / "Cl4Na4-nvt-T300.0-traj.extxyz"
     stats_path = tmp_path / "Cl4Na4-nvt-T300.0-stats.dat"
 
     single_point = SinglePoint(
@@ -376,7 +376,7 @@ def test_remove_rot(tmp_path):
 def test_traj_start(tmp_path):
     """Test starting trajectory after n steps."""
     file_prefix = tmp_path / "Cl4Na4-nvt-T300.0"
-    traj_path = tmp_path / "Cl4Na4-nvt-T300.0-traj.xyz"
+    traj_path = tmp_path / "Cl4Na4-nvt-T300.0-traj.extxyz"
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
@@ -491,9 +491,9 @@ def test_rescale_every(tmp_path):
 def test_rotate_restart(tmp_path):
     """Test setting rotate_restart."""
     file_prefix = tmp_path / "Cl4Na4-nvt"
-    restart_path_1 = tmp_path / "Cl4Na4-nvt-T300.0-res-1.xyz"
-    restart_path_2 = tmp_path / "Cl4Na4-nvt-T300.0-res-2.xyz"
-    restart_path_3 = tmp_path / "Cl4Na4-nvt-T300.0-res-3.xyz"
+    restart_path_1 = tmp_path / "Cl4Na4-nvt-T300.0-res-1.extxyz"
+    restart_path_2 = tmp_path / "Cl4Na4-nvt-T300.0-res-2.extxyz"
+    restart_path_3 = tmp_path / "Cl4Na4-nvt-T300.0-res-3.extxyz"
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
@@ -520,7 +520,7 @@ def test_rotate_restart(tmp_path):
 def test_atoms_struct(tmp_path):
     """Test restarting NVT molecular dynamics."""
     file_prefix = tmp_path / "Cl4Na4-nvt-T300.0"
-    traj_path = tmp_path / "Cl4Na4-nvt-T300.0-traj.xyz"
+    traj_path = tmp_path / "Cl4Na4-nvt-T300.0-traj.extxyz"
     stats_path = tmp_path / "Cl4Na4-nvt-T300.0-stats.dat"
 
     struct = read(DATA_PATH / "NaCl.cif")
@@ -550,7 +550,7 @@ def test_heating(tmp_path):
     """Test heating with no MD."""
     # pylint: disable=invalid-name
     file_prefix = tmp_path / "NaCl-heating"
-    final_file = tmp_path / "NaCl-heating-final.xyz"
+    final_file = tmp_path / "NaCl-heating-final.extxyz"
     log_file = tmp_path / "nvt.log"
 
     single_point = SinglePoint(
@@ -652,9 +652,9 @@ def test_heating_md(tmp_path):
 
 def test_heating_files():
     """Test default heating file names."""
-    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-traj.xyz")
+    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-traj.extxyz")
     stats_heating_path = Path("Cl4Na4-nvt-T10-T20-stats.dat")
-    final_path = Path("Cl4Na4-nvt-T10-T20-final.xyz")
+    final_path = Path("Cl4Na4-nvt-T10-T20-final.extxyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
@@ -701,9 +701,9 @@ def test_heating_files():
 def test_heating_md_files():
     """Test default heating files when also running md"""
 
-    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-traj.xyz")
+    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz")
     stats_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
-    final_path = Path("Cl4Na4-nvt-T10-T20-T25.0-final.xyz")
+    final_path = Path("Cl4Na4-nvt-T10-T20-T25.0-final.extxyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
@@ -781,7 +781,7 @@ def test_cooling(tmp_path):
     """Test cooling with no MD."""
     # pylint: disable=invalid-name
     file_prefix = tmp_path / "NaCl-cooling"
-    final_path = tmp_path / "NaCl-cooling-final.xyz"
+    final_path = tmp_path / "NaCl-cooling-final.extxyz"
     stats_cooling_path = tmp_path / "NaCl-cooling-stats.dat"
     log_file = tmp_path / "nvt.log"
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -41,7 +41,7 @@ test_data = [
 def test_md(ensemble, tmp_path):
     """Test all MD simulations are able to run."""
     file_prefix = tmp_path / f"{ensemble}-T300"
-    traj_path = tmp_path / f"{ensemble}-T300-traj.xyz"
+    traj_path = tmp_path / f"{ensemble}-T300-traj.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -350,8 +350,8 @@ def test_struct_name(tmp_path):
     struct_name = "EXAMPLE"
     struct_path = tmp_path / struct_name
     stats_path = tmp_path / f"{struct_name}-nvt-T10.0-stats.dat"
-    traj_path = tmp_path / f"{struct_name}-nvt-T10.0-traj.xyz"
-    final_path = tmp_path / f"{struct_name}-nvt-T10.0-final.xyz"
+    traj_path = tmp_path / f"{struct_name}-nvt-T10.0-traj.extxyz"
+    final_path = tmp_path / f"{struct_name}-nvt-T10.0-final.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
     result = runner.invoke(
@@ -386,7 +386,7 @@ def test_ensemble_kwargs(tmp_path):
     file_prefix = tmp_path / "md"
     log_path = tmp_path / "md.log"
     summary_path = tmp_path / "summary.yml"
-    final_path = tmp_path / "md-final.xyz"
+    final_path = tmp_path / "md-final.extxyz"
     stats_path = tmp_path / "md-stats.dat"
 
     ensemble_kwargs = "{'mask' : (0, 1, 0)}"
@@ -471,8 +471,8 @@ def test_final_name(tmp_path):
     """Test specifying the final file name."""
     file_prefix = tmp_path / "npt"
     stats_path = tmp_path / "npt-stats.dat"
-    traj_path = tmp_path / "npt-traj.xyz"
-    final_path = tmp_path / "example.xyz"
+    traj_path = tmp_path / "npt-traj.extxyz"
+    final_path = tmp_path / "example.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
     result = runner.invoke(

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -282,7 +282,7 @@ def test_minimize_kwargs(tmp_path):
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
     file_prefix = tmp_path / "test"
-    opt_path = tmp_path / "test-opt.xyz"
+    opt_path = tmp_path / "test-opt.extxyz"
 
     minimize_kwargs = "{'optimizer': 'FIRE', 'write_results': True}"
 
@@ -317,7 +317,7 @@ def test_minimize_filename(tmp_path):
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
     file_prefix = tmp_path / "test"
-    opt_path = tmp_path / "geomopt-opt.xyz"
+    opt_path = tmp_path / "geomopt-opt.extxyz"
 
     minimize_kwargs = (
         "{'write_results': 'True', "

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -19,7 +19,7 @@ runner = CliRunner()
 def test_md_pp(tmp_path):
     """Test post-processing as part of MD cycle."""
     file_prefix = tmp_path / "Cl4Na4-nve-T300.0"
-    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.xyz"
+    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.extxyz"
     stats_path = tmp_path / "Cl4Na4-nve-T300.0-stats.dat"
     rdf_path = tmp_path / "Cl4Na4-nve-T300.0-rdf.dat"
     vaf_path = tmp_path / "Cl4Na4-nve-T300.0-vaf.dat"

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -104,7 +104,7 @@ def test_single_point_traj():
 def test_single_point_write():
     """Test writing singlepoint results."""
     data_path = DATA_PATH / "NaCl.cif"
-    results_path = Path("./NaCl-results.xyz").absolute()
+    results_path = Path("./NaCl-results.extxyz").absolute()
     assert not results_path.exists()
 
     single_point = SinglePoint(
@@ -137,7 +137,7 @@ def test_single_point_write():
 def test_single_point_write_kwargs(tmp_path):
     """Test passing write_kwargs to singlepoint results."""
     data_path = DATA_PATH / "NaCl.cif"
-    results_path = tmp_path / "NaCl.xyz"
+    results_path = tmp_path / "NaCl.extxyz"
 
     single_point = SinglePoint(
         struct_path=data_path,
@@ -155,7 +155,7 @@ def test_single_point_write_kwargs(tmp_path):
 def test_single_point_molecule(tmp_path):
     """Test singlepoint results for isolated molecule."""
     data_path = DATA_PATH / "H2O.cif"
-    results_path = tmp_path / "H2O.xyz"
+    results_path = tmp_path / "H2O.extxyz"
     single_point = SinglePoint(
         struct_path=data_path,
         architecture="mace",

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -27,7 +27,7 @@ def test_singlepoint_help():
 
 def test_singlepoint(tmp_path):
     """Test singlepoint calculation."""
-    results_path = Path("./NaCl-results.xyz").absolute()
+    results_path = Path("./NaCl-results.extxyz").absolute()
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -53,8 +53,8 @@ def test_singlepoint(tmp_path):
 
 def test_properties(tmp_path):
     """Test properties for singlepoint calculation."""
-    results_path_1 = tmp_path / "H2O-energy-results.xyz"
-    results_path_2 = tmp_path / "H2O-stress-results.xyz"
+    results_path_1 = tmp_path / "H2O-energy-results.extxyz"
+    results_path_2 = tmp_path / "H2O-stress-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -106,7 +106,7 @@ def test_properties(tmp_path):
 
 def test_read_kwargs(tmp_path):
     """Test setting read_kwargs for singlepoint calculation."""
-    results_path = tmp_path / "benzene-traj-results.xyz"
+    results_path = tmp_path / "benzene-traj-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -136,7 +136,7 @@ def test_read_kwargs(tmp_path):
 
 def test_calc_kwargs(tmp_path):
     """Test setting calc_kwargs for singlepoint calculation."""
-    results_path = tmp_path / "NaCl-results.xyz"
+    results_path = tmp_path / "NaCl-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -164,7 +164,7 @@ def test_calc_kwargs(tmp_path):
 
 def test_log(tmp_path):
     """Test log correctly written for singlepoint."""
-    results_path = tmp_path / "NaCl-results.xyz"
+    results_path = tmp_path / "NaCl-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -191,7 +191,7 @@ def test_log(tmp_path):
 
 def test_summary(tmp_path):
     """Test summary file can be read correctly."""
-    results_path = tmp_path / "benzene-traj-results.xyz"
+    results_path = tmp_path / "benzene-traj-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -232,7 +232,7 @@ def test_summary(tmp_path):
 
 def test_config(tmp_path):
     """Test passing a config file with read kwargs, and values to be overwritten."""
-    results_path = tmp_path / "benzene-traj-results.xyz"
+    results_path = tmp_path / "benzene-traj-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
     result = runner.invoke(


### PR DESCRIPTION
Aims to address part of #206, requested by @alinelena:

> -  Change default output extensions from `.xyz` to `.extxyz`