### PR TITLE
Tidy calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,17 @@
 *.xml
 *.cif
 *.xyz
+*.extxyz
 *.yml
 *.yaml
 *.pdf
 *.hdf5
 *.traj
+*.ipynb
+*.jpg
+*.jpeg
+*.dot
+*.png
 ~*
 *~
 .project

--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ janus phonons --struct tests/data/NaCl.cif --supercell 2x2x2 --minimize --arch m
 
 This will save the Phonopy parameters, including displacements and force constants, to `NaCl-phonopy.yml` and `NaCl-force_constants.hdf5`, in addition to generating a log file, `phonons.log`, and summary of inputs, `phonons_summary.yml`.
 
-Additionally, the `--band` option can be added to calculate the band structure and save the results to `NaCl-auto_bands.yml`:
+Additionally, the `--bands` option can be added to calculate the band structure and save the results to `NaCl-auto_bands.yml`:
 
 ```shell
-janus phonons --struct tests/data/NaCl.cif --supercell 2x2x2 --minimize --arch mace_mp --model-path small --band
+janus phonons --struct tests/data/NaCl.cif --supercell 2x2x2 --minimize --arch mace_mp --model-path small --bands
 ```
 
 If you need eigenvectors and group velocities written, add the `--write-full` option. This will generate a much larger file, but can be used to visualise phonon modes.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,9 +42,6 @@ numpydoc_validation_exclude = {
 }
 numpydoc_class_members_toctree = False
 
-# Mock import of MACE module to avoid breaking build
-autodoc_mock_imports = ["mace.cli.run_train"]
-
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -67,7 +67,7 @@ class Descriptors(FileNameMixin):
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         """
-        [write_kwargs, log_kwargs] = none_to_dict([write_kwargs, log_kwargs])
+        (write_kwargs, log_kwargs) = none_to_dict((write_kwargs, log_kwargs))
 
         self.struct = struct
         self.invariants_only = invariants_only

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -21,8 +21,6 @@ class Descriptors(FileNameMixin):
     ----------
     struct : MaybeSequence[Atoms]
         Structure(s) to calculate descriptors for.
-    struct_name : Optional[str]
-        Name of structure. Default is None.
     invariants_only : bool
         Whether only the invariant descriptors should be returned. Default is True.
     calc_per_element : bool
@@ -41,7 +39,6 @@ class Descriptors(FileNameMixin):
     def __init__(
         self,
         struct: MaybeSequence[Atoms],
-        struct_name: Optional[str] = None,
         invariants_only: bool = True,
         calc_per_element: bool = False,
         calc_per_atom: bool = False,
@@ -56,8 +53,6 @@ class Descriptors(FileNameMixin):
         ----------
         struct : MaybeSequence[Atoms]
             Structure(s) to calculate descriptors for.
-        struct_name : Optional[str]
-            Name of structure. Default is None.
         invariants_only : bool
             Whether only the invariant descriptors should be returned. Default is True.
         calc_per_element : bool
@@ -73,7 +68,6 @@ class Descriptors(FileNameMixin):
             Keyword arguments to pass to `config_logger`. Default is {}.
         """
         self.struct = struct
-        self.struct_name = struct_name
         self.invariants_only = invariants_only
         self.calc_per_element = calc_per_element
         self.calc_per_atom = calc_per_atom
@@ -91,7 +85,7 @@ class Descriptors(FileNameMixin):
         [write_kwargs, log_kwargs] = none_to_dict([write_kwargs, log_kwargs])
         self.write_kwargs = write_kwargs
 
-        FileNameMixin.__init__(self, self.struct, self.struct_name, None)
+        FileNameMixin.__init__(self, self.struct, None, None)
 
         self.write_kwargs.setdefault(
             "filename",

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -43,6 +43,11 @@ class Descriptors(FileNameMixin):
         Logger if log file has been specified.
     tracker : Optional[OfflineEmissionsTracker]
         Tracker if logging is enabled.
+
+    Methods
+    -------
+    run()
+        Calculate descriptors for structure(s)
     """
 
     def __init__(
@@ -113,7 +118,7 @@ class Descriptors(FileNameMixin):
         )
 
     def run(self) -> None:
-        """Calculate."""
+        """Calculate descriptors for structure(s)."""
         if self.logger:
             self.logger.info("Starting descriptors calculation")
             self.tracker.start()
@@ -133,7 +138,7 @@ class Descriptors(FileNameMixin):
 
     def _calc_descriptors(self, struct: Atoms) -> None:
         """
-        Calculate MLIP descriptors for the given structure(s).
+        Calculate MLIP descriptors a given structure.
 
         Parameters
         ----------

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -91,7 +91,7 @@ class Descriptors(FileNameMixin):
         self.logger = config_logger(**log_kwargs)
 
         # Set output file
-        FileNameMixin.__init__(self, struct, None, None)
+        FileNameMixin.__init__(self, struct, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("descriptors.extxyz").absolute(),

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -24,8 +24,6 @@ class EoS(FileNameMixin):
     ----------
     struct : Atoms
         Structure to calculate equation of state for.
-    struct_name : Optional[str]
-        Name of structure. Default is None.
     min_volume : float
         Minimum volume scale factor. Default is 0.95.
     max_volume : float
@@ -59,7 +57,6 @@ class EoS(FileNameMixin):
     def __init__(  # pylint: disable=too-many-arguments,too-many-locals
         self,
         struct: Atoms,
-        struct_name: Optional[str] = None,
         min_volume: float = 0.95,
         max_volume: float = 1.05,
         n_volumes: int = 7,
@@ -81,8 +78,6 @@ class EoS(FileNameMixin):
         ----------
         struct : Atoms
             Structure.
-        struct_name : Optional[str]
-            Name of structure. Default is None.
         min_volume : float
             Minimum volume scale factor. Default is 0.95.
         max_volume : float
@@ -160,7 +155,7 @@ class EoS(FileNameMixin):
         self.logger = config_logger(**log_kwargs)
         self.tracker = config_tracker(self.logger, **tracker_kwargs)
 
-        FileNameMixin.__init__(self, struct, struct_name, file_prefix)
+        FileNameMixin.__init__(self, struct, None, file_prefix)
 
         self.write_kwargs.setdefault(
             "filename",

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -125,8 +125,8 @@ class EoS(FileNameMixin):
         lattice_scalars : NDArray[float64]
             Lattice scalars of generated structures.
         """
-        [minimize_kwargs, write_kwargs, log_kwargs, tracker_kwargs] = none_to_dict(
-            [minimize_kwargs, write_kwargs, log_kwargs, tracker_kwargs]
+        (minimize_kwargs, write_kwargs, log_kwargs, tracker_kwargs) = none_to_dict(
+            (minimize_kwargs, write_kwargs, log_kwargs, tracker_kwargs)
         )
 
         self.struct = struct

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -52,6 +52,27 @@ class EoS(FileNameMixin):
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_tracker`. Default is {}.
+
+    Attributes
+    ----------
+    logger : Optional[logging.Logger]
+        Logger if log file has been specified.
+    tracker : Optional[OfflineEmissionsTracker]
+        Tracker if logging is enabled.
+    results : EoSResults
+        Dictionary containing equation of state ASE object, and the fitted minimum
+        bulk modulus, volume, and energy.
+    volumes : list[float]
+        List of volumes of generated structures.
+    energies : list[float]
+        List of energies of generated structures.
+    lattice_scalars : NDArray[float64]
+        Lattice scalars of generated structures.
+
+    Methods
+    -------
+    run()
+        Calculate equation of state.
     """
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-locals
@@ -108,22 +129,6 @@ class EoS(FileNameMixin):
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
-
-        Attributes
-        ----------
-        logger : Optional[logging.Logger]
-            Logger if log file has been specified.
-        tracker : Optional[OfflineEmissionsTracker]
-            Tracker if logging is enabled.
-        results : EoSResults
-            Dictionary containing equation of state ASE object, and the fitted minimum
-            bulk modulus, volume, and energy.
-        volumes : list[float]
-            List of volumes of generated structures.
-        energies : list[float]
-            List of energies of generated structures.
-        lattice_scalars : NDArray[float64]
-            Lattice scalars of generated structures.
         """
         (minimize_kwargs, write_kwargs, log_kwargs, tracker_kwargs) = none_to_dict(
             (minimize_kwargs, write_kwargs, log_kwargs, tracker_kwargs)

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -179,7 +179,7 @@ class EoS(FileNameMixin):
         self.tracker = config_tracker(self.logger, **tracker_kwargs)
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, None, file_prefix)
+        FileNameMixin.__init__(self, self.struct, file_prefix)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("generated.extxyz").absolute(),

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -69,6 +69,13 @@ class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         Logger if log file has been specified.
     tracker : Optional[OfflineEmissionsTracker]
         Tracker if logging is enabled.
+
+    Methods
+    -------
+    set_optimizer()
+        Set optimizer for geometry optimization.
+    run()
+        Run geometry optimization.
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -226,7 +233,7 @@ class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         else:
             self.dyn = self.optimizer(self.struct, **self.opt_kwargs)
 
-    def _set_functions(self):
+    def _set_functions(self) -> None:
         """Set optimizer and filter functions."""
         if isinstance(self.optimizer, str):
             try:
@@ -240,7 +247,7 @@ class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
             except AttributeError as e:
                 raise AttributeError(f"No such filter: {self.filter_func}") from e
 
-    def run(self):
+    def run(self) -> None:
         """Run geometry optimization."""
         s_grp = spacegroup(self.struct, self.symmetry_tolerance, self.angle_tolerance)
         self.struct.info["initial_spacegroup"] = s_grp

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -186,7 +186,7 @@ class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         self.tracker = config_tracker(self.logger, **tracker_kwargs)
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, None, None)
+        FileNameMixin.__init__(self, self.struct, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("opt.extxyz").absolute(),

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -130,22 +130,22 @@ class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
         """
-        [
+        (
             filter_kwargs,
             opt_kwargs,
             write_kwargs,
             traj_kwargs,
             log_kwargs,
             tracker_kwargs,
-        ] = none_to_dict(
-            [
+        ) = none_to_dict(
+            (
                 filter_kwargs,
                 opt_kwargs,
                 write_kwargs,
                 traj_kwargs,
                 log_kwargs,
                 tracker_kwargs,
-            ]
+            )
         )
 
         self.struct = struct

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -389,7 +389,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         self.tracker = config_tracker(self.logger, **tracker_kwargs)
 
         # Set output file names
-        FileNameMixin.__init__(self, self.struct, None, file_prefix, self.ensemble)
+        FileNameMixin.__init__(self, self.struct, file_prefix, self.ensemble)
         self.final_file = self._build_filename(
             "final.extxyz",
             self._parameter_prefix if file_prefix is None else "",

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -36,7 +36,7 @@ from janus_core.helpers.janus_types import (
 )
 from janus_core.helpers.log import config_logger, config_tracker
 from janus_core.helpers.post_process import compute_rdf, compute_vaf
-from janus_core.helpers.utils import FileNameMixin, output_structs
+from janus_core.helpers.utils import FileNameMixin, none_to_dict, output_structs
 
 DENS_FACT = (units.m / 1.0e2) ** 3 / units.mol
 
@@ -276,13 +276,33 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             Random seed used by numpy.random and random functions, such as in Langevin.
             Default is None.
         """
+        [
+            minimize_kwargs,
+            write_kwargs,
+            post_process_kwargs,
+            correlation_kwargs,
+            log_kwargs,
+            tracker_kwargs,
+        ] = none_to_dict(
+            [
+                minimize_kwargs,
+                write_kwargs,
+                post_process_kwargs,
+                correlation_kwargs,
+                log_kwargs,
+                tracker_kwargs,
+            ]
+        )
+
         self.struct = struct
-        self.timestep = timestep * units.fs
+        self.ensemble = ensemble
         self.steps = steps
+        self.timestep = timestep * units.fs
         self.temp = temp
         self.equil_steps = equil_steps
         self.minimize = minimize
         self.minimize_every = minimize_every
+        self.minimize_kwargs = minimize_kwargs
         self.rescale_velocities = rescale_velocities
         self.remove_rot = remove_rot
         self.rescale_every = rescale_every
@@ -302,17 +322,13 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         self.temp_end = temp_end
         self.temp_step = temp_step
         self.temp_time = temp_time * units.fs if temp_time else None
-        self.write_kwargs = write_kwargs if write_kwargs is not None else {}
-        self.post_process_kwargs = (
-            post_process_kwargs if post_process_kwargs is not None else {}
-        )
-        self.correlation_kwargs = (
-            correlation_kwargs if correlation_kwargs is not None else {}
-        )
+        self.write_kwargs = write_kwargs
+        self.post_process_kwargs = post_process_kwargs
+        self.correlation_kwargs = correlation_kwargs
         self.log_kwargs = log_kwargs
-        self.ensemble = ensemble
         self.seed = seed
 
+        # Validate parameters
         if not isinstance(struct, Atoms):
             if isinstance(struct, Sequence) and isinstance(struct[0], Atoms):
                 raise NotImplementedError(
@@ -320,26 +336,15 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
                 )
             raise ValueError("`struct` must be an ASE Atoms object")
 
-        FileNameMixin.__init__(self, struct, None, file_prefix, ensemble)
-
-        self.write_kwargs.setdefault(
-            "columns", ["symbols", "positions", "momenta", "masses"]
-        )
         if "append" in self.write_kwargs:
             raise ValueError("`append` cannot be specified when writing files")
 
-        self.log_kwargs = (
-            log_kwargs if log_kwargs else {}
-        )  # pylint: disable=duplicate-code
-        self.tracker_kwargs = (
-            tracker_kwargs if tracker_kwargs else {}
-        )  # pylint: disable=duplicate-code
         if self.log_kwargs and "filename" not in self.log_kwargs:
             raise ValueError("'filename' must be included in `log_kwargs`")
 
-        self.log_kwargs.setdefault("name", __name__)
-        self.logger = config_logger(**self.log_kwargs)
-        self.tracker = config_tracker(self.logger, **self.tracker_kwargs)
+        # Check temperatures for heating differ
+        if self.temp_start is not None and self.temp_start == self.temp_end:
+            raise ValueError("Start and end temperatures must be different")
 
         # Warn if attempting to rescale/minimize during dynamics
         # but equil_steps is too low
@@ -351,10 +356,6 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         # Warn if attempting to remove rotation without resetting velocities
         if remove_rot and not rescale_velocities:
             warn("Rotation will not be removed unless `rescale_velocities` is True")
-
-        # Check temperatures for heating differ
-        if self.temp_start is not None and self.temp_start == self.temp_end:
-            raise ValueError("Start and end temperatures must be different")
 
         # Warn if mix of None and not None
         self.ramp_temp = (
@@ -374,14 +375,21 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
                 "heating to run"
             )
 
+        # Check validate start and end temperatures
         if self.ramp_temp and (self.temp_start < 0 or self.temp_end < 0):
             raise ValueError("Start and end temperatures must be positive")
 
-        self.minimize_kwargs = minimize_kwargs if minimize_kwargs else {}
-        self.restart_files = []
-        self.dyn: Union[Langevin, VelocityVerlet, ASE_NPT]
-        self.n_atoms = len(self.struct)
+        self.write_kwargs.setdefault(
+            "columns", ["symbols", "positions", "momenta", "masses"]
+        )
 
+        # Configure logging
+        self.log_kwargs.setdefault("name", __name__)
+        self.logger = config_logger(**self.log_kwargs)
+        self.tracker = config_tracker(self.logger, **tracker_kwargs)
+
+        # Set output file names
+        FileNameMixin.__init__(self, self.struct, None, file_prefix, self.ensemble)
         self.final_file = self._build_filename(
             "final.extxyz",
             self._parameter_prefix if file_prefix is None else "",
@@ -397,6 +405,10 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             self._parameter_prefix if file_prefix is None else "",
             filename=self.traj_file,
         )
+
+        self.restart_files = []
+        self.dyn: Union[Langevin, VelocityVerlet, ASE_NPT]
+        self.n_atoms = len(self.struct)
 
         self.offset = 0
         self.created_final_file = False

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -276,22 +276,22 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             Random seed used by numpy.random and random functions, such as in Langevin.
             Default is None.
         """
-        [
+        (
             minimize_kwargs,
             write_kwargs,
             post_process_kwargs,
             correlation_kwargs,
             log_kwargs,
             tracker_kwargs,
-        ] = none_to_dict(
-            [
+        ) = none_to_dict(
+            (
                 minimize_kwargs,
                 write_kwargs,
                 post_process_kwargs,
                 correlation_kwargs,
                 log_kwargs,
                 tracker_kwargs,
-            ]
+            )
         )
 
         self.struct = struct

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -501,14 +501,14 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             f"res-{step}.extxyz", f"T{self.temp}", prefix_override=self.restart_stem
         )
 
-    def _parse_correlations(self):
+    def _parse_correlations(self) -> None:
         """Parse correlation kwargs into Correlations."""
         if self.correlation_kwargs:
             self._correlations = [Correlation(**cor) for cor in self.correlation_kwargs]
         else:
             self._correlations = ()
 
-    def _attach_correlations(self):
+    def _attach_correlations(self) -> None:
         """Attach all correlations to self.dyn."""
         for i, _ in enumerate(self._correlations):
             self.dyn.attach(
@@ -516,7 +516,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
                 self._correlations[i].update_frequency,
             )
 
-    def _write_correlations(self):
+    def _write_correlations(self) -> None:
         """Write out the correlations."""
         if self._correlations:
             param_pref = self._parameter_prefix if self.file_prefix is None else ""

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -49,9 +49,6 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
     ----------
     struct : Atoms
         Structure to simulate.
-    struct_name : str
-        Name of structure to simulate. Default is inferred from filepath or
-        chemical formula.
     ensemble : Ensembles
         Name for thermodynamic ensemble. Default is None.
     steps : int
@@ -158,7 +155,6 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
     def __init__(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
         self,
         struct: Atoms,
-        struct_name: Optional[str] = None,
         ensemble: Optional[Ensembles] = None,
         steps: int = 0,
         timestep: float = 1.0,
@@ -201,9 +197,6 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         ----------
         struct : Atoms
             Structure to simulate.
-        struct_name : Optional[str]
-            Name of structure to simulate. Default is inferred from filepath or
-            chemical formula.
         ensemble : Ensembles
             Name for thermodynamic ensemble. Default is None.
         steps : int
@@ -327,7 +320,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
                 )
             raise ValueError("`struct` must be an ASE Atoms object")
 
-        FileNameMixin.__init__(self, struct, struct_name, file_prefix, ensemble)
+        FileNameMixin.__init__(self, struct, None, file_prefix, ensemble)
 
         self.write_kwargs.setdefault(
             "columns", ["symbols", "positions", "momenta", "masses"]

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -77,6 +77,31 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         Logger if log file has been specified.
     tracker : Optional[OfflineEmissionsTracker]
         Tracker if logging is enabled.
+
+    Methods
+    -------
+    calc_force_constants(write_force_consts)
+        Calculate force constants and optionally write results.
+    write_force_constants(phonopy_file, force_consts_to_hdf5 force_consts_file)
+        Write results of force constants calculations.
+    calc_bands(write_bands)
+        Calculate band structure and optionally write and plot results.
+    write_bands(bands_file, save_plots, plot_file)
+        Write results of band structure calculations.
+    calc_thermal_props(write_thermal)
+        Calculate thermal properties and optionally write results.
+    write_thermal_props(thermal_file)
+        Write results of thermal properties calculations.
+    calc_dos(mesh, write_dos)
+        Calculate density of states and optionally write results.
+    write_dos(dos_file, plot_to_file, plot_file, plot_bands, plot_bands_file)
+        Write results of DOS calculation.
+    calc_pdos(mesh, write_pdos)
+        Calculate projected density of states and optionally write results.
+    write_pdos(pdos_file, plot_to_file, plot_file)
+        Write results of PDOS calculation.
+    run()
+        Run phonon calculations.
     """
 
     def __init__(  # pylint: disable=too-many-arguments,disable=too-many-locals

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -187,7 +187,8 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         self.tracker = config_tracker(self.logger, **tracker_kwargs)
 
         # Set output file prefix
-        FileNameMixin.__init__(self, self.struct, None, file_prefix)
+        FileNameMixin.__init__(self, self.struct, file_prefix)
+
         if self.minimize:
             if self.logger:
                 self.minimize_kwargs["log_kwargs"] = {

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -229,20 +229,21 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         value : MaybeSequence[PhononCalcs]
             Phonon calculations to be run.
         """
-        self._calcs = value
 
-        if isinstance(self._calcs, str):
-            self._calcs = (self._calcs,)
+        if isinstance(value, str):
+            value = (value,)
 
-            for calc in self._calcs:
+            for calc in value:
                 if calc not in get_args(PhononCalcs):
                     raise NotImplementedError(
                         f"Calculations '{calc}' cannot currently be performed."
                     )
 
         # If none specified, only force constants will be calculated
-        if not self._calcs:
-            self._cals = ()
+        if not value:
+            value = ()
+
+        self._calcs = value
 
     def calc_force_constants(
         self, write_force_consts: Optional[bool] = None, **kwargs

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -727,42 +727,21 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         atoms = self._Phonopy_to_ASEAtoms(struct)
         return atoms.get_forces()
 
-    def run(
-        self,
-        *,
-        calcs: Optional[MaybeSequence[PhononCalcs]] = None,
-        write_results: Optional[bool] = (None),
-    ) -> None:
-        """
-        Run phonon calculations.
-
-        Parameters
-        ----------
-        calcs : Optional[MaybeSequence[PhononCalcs]]
-            Phonon calculations to run. Default is self.calcs.
-        write_results : bool
-            True to write out structure with results of calculations. Default is
-            self.write_results.
-        """
-        # Parameters can be overwritten, otherwise default to values from instantiation
-        if calcs is None:
-            calcs = self.calcs
-        if write_results is None:
-            write_results = self.write_results
-
+    def run(self) -> None:
+        """Run phonon calculations."""
         # Calculate force constants
         self.calc_force_constants()
 
         # Calculate band structure
-        if "bands" in calcs:
+        if "bands" in self.calcs:
             self.calc_bands()
 
         # Calculate thermal properties if specified
-        if "thermal" in calcs:
+        if "thermal" in self.calcs:
             self.calc_thermal_props()
 
         # Calculate DOS and PDOS if specified
-        if "dos" in calcs:
-            self.calc_dos(plot_bands="bands" in calcs)
-        if "pdos" in calcs:
+        if "dos" in self.calcs:
+            self.calc_dos(plot_bands="bands" in self.calcs)
+        if "pdos" in self.calcs:
             self.calc_pdos()

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -744,8 +744,10 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
             self.write_results.
         """
         # Parameters can be overwritten, otherwise default to values from instantiation
-        calcs = calcs if calcs else self.calcs
-        write_results = write_results if write_results else self.write_results
+        if calcs is None:
+            calcs = self.calcs
+        if write_results is None:
+            write_results = self.write_results
 
         # Calculate force constants
         self.calc_force_constants()

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -145,8 +145,8 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
         """
-        [minimize_kwargs, log_kwargs, tracker_kwargs] = none_to_dict(
-            [minimize_kwargs, log_kwargs, tracker_kwargs]
+        (minimize_kwargs, log_kwargs, tracker_kwargs) = none_to_dict(
+            (minimize_kwargs, log_kwargs, tracker_kwargs)
         )
 
         self.struct = struct

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -23,8 +23,6 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
     ----------
     struct : Atoms
         Structrure to calculate phonons for.
-    struct_name : Optional[str]
-        Name of structure. Default is inferred from chemical formula of `struct`.
     supercell : MaybeList[int]
         Size of supercell for calculation. Default is 2.
     displacement : float
@@ -53,8 +51,8 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
     minimize_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to geometry optimizer. Default is {}.
     file_prefix : Optional[PathLike]
-        Prefix for output filenames. Default is inferred from structure name, or
-        chemical formula of the structure.
+        Prefix for output filenames. Default is inferred from chemical formula of the
+        structure.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -75,7 +73,6 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments,disable=too-many-locals
         self,
         struct: Atoms,
-        struct_name: Optional[str] = None,
         supercell: MaybeList[int] = 2,
         displacement: float = 0.01,
         t_step: float = 50.0,
@@ -98,8 +95,6 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         ----------
         struct : Atoms
             Structrure to calculate phonons for.
-        struct_name : Optional[str]
-            Name of structure. Default is inferred from chemical formula if `struct`.
         supercell : MaybeList[int]
             Size of supercell for calculation. Default is 2.
         displacement : float
@@ -143,7 +138,7 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
                 )
             raise ValueError("`struct` must be an ASE Atoms object")
 
-        FileNameMixin.__init__(self, struct, struct_name, file_prefix)
+        FileNameMixin.__init__(self, struct, None, file_prefix)
 
         [minimize_kwargs, log_kwargs, tracker_kwargs] = none_to_dict(
             [minimize_kwargs, log_kwargs, tracker_kwargs]

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -250,21 +250,22 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         value : MaybeSequence[Properties]
             Physical properties to be calculated.
         """
-        self._properties = value
 
-        if isinstance(self._properties, str):
-            self._properties = (self._properties,)
+        if isinstance(value, str):
+            value = (value,)
 
-        if isinstance(self._properties, Sequence):
-            for prop in self._properties:
+        if isinstance(value, Sequence):
+            for prop in value:
                 if prop not in get_args(Properties):
                     raise NotImplementedError(
                         f"Property '{prop}' cannot currently be calculated."
                     )
 
         # If none specified, get all valid properties
-        if not self._properties:
-            self._properties = get_args(Properties)
+        if not value:
+            value = get_args(Properties)
+
+        self._properties = value
 
     def _get_potential_energy(self) -> MaybeList[float]:
         """

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -341,9 +341,12 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             Dictionary of calculated results, with keys from `properties`.
         """
         # Parameters can be overwritten, otherwise default to values from instantiation
-        properties = self.properties
-        write_results = write_results if write_results else self.write_results
-        write_kwargs = write_kwargs if write_kwargs else self.write_kwargs
+        if properties is None:
+            properties = self.properties
+        if write_results is None:
+            write_results = self.write_results
+        if write_kwargs is None:
+            write_kwargs = self.write_kwargs
 
         self.results = {}
 

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -314,26 +314,51 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         stress = self.struct.get_stress()
         return stress
 
-    def run(self) -> CalcResults:
+    def run(
+        self,
+        *,
+        properties: Optional[MaybeSequence[Properties]] = None,
+        write_results: Optional[bool] = None,
+        write_kwargs: Optional[OutputKwargs] = None,
+    ) -> CalcResults:
         """
         Run single point calculations.
+
+        Parameters
+        ----------
+        properties : Optional[MaybeSequence[Properties]]
+            Physical properties to calculate. Default is self.properties.
+        write_results : bool
+            True to write out structure with results of calculations. Default is
+            self.write_results.
+        write_kwargs : Optional[OutputKwargs],
+            Keyword arguments to pass to ase.io.write if saving structure with
+            results of calculations. Default is self.write_kwargs.
 
         Returns
         -------
         CalcResults
             Dictionary of calculated results, with keys from `properties`.
         """
+        # Parameters can be overwritten, otherwise default to values from instantiation
+        if properties is None:
+            properties = self.properties
+        if write_results is None:
+            write_results = self.write_results
+        if write_kwargs is None:
+            write_kwargs = self.write_kwargs
+
         self.results = {}
 
         if self.logger:
             self.logger.info("Starting single point calculation")
             self.tracker.start_task("Single point")
 
-        if "energy" in self.properties:
+        if "energy" in properties:
             self.results["energy"] = self._get_potential_energy()
-        if "forces" in self.properties:
+        if "forces" in properties:
             self.results["forces"] = self._get_forces()
-        if "stress" in self.properties:
+        if "stress" in properties:
             self.results["stress"] = self._get_stress()
 
         if self.logger:
@@ -343,9 +368,9 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
 
         output_structs(
             self.struct,
-            write_results=self.write_results,
-            properties=self.properties,
-            write_kwargs=self.write_kwargs,
+            write_results=write_results,
+            properties=properties,
+            write_kwargs=write_kwargs,
         )
 
         return self.results

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from copy import copy
+from pathlib import Path
 from typing import Any, Optional, get_args
 
 from ase import Atoms
@@ -171,8 +172,10 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         self.read_kwargs.setdefault("index", ":")
 
         # Read structure if given as path
+        file_prefix = None
         if self.struct_path:
             self.read_structure()
+            file_prefix = Path(self.struct_path).stem
 
         # Configure logging
         log_kwargs.setdefault("name", __name__)
@@ -185,7 +188,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             self.logger.info("Single point calculator configured")
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, None, None)
+        FileNameMixin.__init__(self, self.struct, None, file_prefix)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("results.extxyz").absolute(),

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -188,7 +188,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             self.logger.info("Single point calculator configured")
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, None, file_prefix)
+        FileNameMixin.__init__(self, self.struct, file_prefix)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("results.extxyz").absolute(),

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -314,51 +314,26 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         stress = self.struct.get_stress()
         return stress
 
-    def run(
-        self,
-        *,
-        properties: Optional[MaybeSequence[Properties]] = None,
-        write_results: Optional[bool] = None,
-        write_kwargs: Optional[OutputKwargs] = None,
-    ) -> CalcResults:
+    def run(self) -> CalcResults:
         """
         Run single point calculations.
-
-        Parameters
-        ----------
-        properties : Optional[MaybeSequence[Properties]]
-            Physical properties to calculate. Default is self.properties.
-        write_results : bool
-            True to write out structure with results of calculations. Default is
-            self.write_results.
-        write_kwargs : Optional[OutputKwargs],
-            Keyword arguments to pass to ase.io.write if saving structure with
-            results of calculations. Default is self.write_kwargs.
 
         Returns
         -------
         CalcResults
             Dictionary of calculated results, with keys from `properties`.
         """
-        # Parameters can be overwritten, otherwise default to values from instantiation
-        if properties is None:
-            properties = self.properties
-        if write_results is None:
-            write_results = self.write_results
-        if write_kwargs is None:
-            write_kwargs = self.write_kwargs
-
         self.results = {}
 
         if self.logger:
             self.logger.info("Starting single point calculation")
             self.tracker.start_task("Single point")
 
-        if "energy" in properties:
+        if "energy" in self.properties:
             self.results["energy"] = self._get_potential_energy()
-        if "forces" in properties:
+        if "forces" in self.properties:
             self.results["forces"] = self._get_forces()
-        if "stress" in properties:
+        if "stress" in self.properties:
             self.results["stress"] = self._get_stress()
 
         if self.logger:
@@ -368,9 +343,9 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
 
         output_structs(
             self.struct,
-            write_results=write_results,
-            properties=properties,
-            write_kwargs=write_kwargs,
+            write_results=self.write_results,
+            properties=self.properties,
+            write_kwargs=self.write_kwargs,
         )
 
         return self.results

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -42,7 +42,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         "forces", and "stress" will be returned.
     write_results : bool
         True to write out structure with results of calculations. Default is False.
-    architecture : Literal[architectures]
+    arch : Architectures
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
     device : Devices
@@ -87,7 +87,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         struct_path: Optional[PathLike] = None,
         properties: MaybeSequence[Properties] = (),
         write_results: bool = False,
-        architecture: Architectures = "mace_mp",
+        arch: Architectures = "mace_mp",
         device: Devices = "cpu",
         model_path: Optional[PathLike] = None,
         read_kwargs: Optional[ASEReadArgs] = None,
@@ -112,7 +112,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             "forces", and "stress" will be returned.
         write_results : bool
             True to write out structure with results of calculations. Default is False.
-        architecture : Architectures
+        arch : Architectures
             MLIP architecture to use for single point calculations.
             Default is "mace_mp".
         device : Devices
@@ -142,7 +142,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         self.struct_path = struct_path
         self.properties = properties
         self.write_results = write_results
-        self.architecture = architecture
+        self.arch = arch
         self.device = device
         self.model_path = model_path
         self.read_kwargs = read_kwargs
@@ -211,7 +211,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
     def set_calculator(self) -> None:
         """Configure calculator and attach to structure."""
         calculator = choose_calculator(
-            architecture=self.architecture,
+            arch=self.arch,
             device=self.device,
             model_path=self.model_path,
             **self.calc_kwargs,

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -132,9 +132,9 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
         """
-        [read_kwargs, calc_kwargs, write_kwargs, log_kwargs, tracker_kwargs] = (
+        (read_kwargs, calc_kwargs, write_kwargs, log_kwargs, tracker_kwargs) = (
             none_to_dict(
-                [read_kwargs, calc_kwargs, write_kwargs, log_kwargs, tracker_kwargs]
+                (read_kwargs, calc_kwargs, write_kwargs, log_kwargs, tracker_kwargs)
             )
         )
 

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -253,7 +253,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         self._properties = value
 
         if isinstance(self._properties, str):
-            self._properties = [self._properties]
+            self._properties = (self._properties,)
 
         if isinstance(self._properties, Sequence):
             for prop in self._properties:
@@ -341,12 +341,9 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             Dictionary of calculated results, with keys from `properties`.
         """
         # Parameters can be overwritten, otherwise default to values from instantiation
-        if properties is None:
-            properties = self.properties
-        if write_results is None:
-            write_results = self.write_results
-        if write_kwargs is None:
-            write_kwargs = self.write_kwargs
+        properties = self.properties
+        write_results = write_results if write_results else self.write_results
+        write_kwargs = write_kwargs if write_kwargs else self.write_kwargs
 
         self.results = {}
 

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -238,7 +238,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         return self._properties
 
     @properties.setter
-    def properties(self, value) -> None:
+    def properties(self, value: MaybeSequence[Properties]) -> None:
         """
         Setter for `properties`.
 

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -119,7 +119,7 @@ def descriptors(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        architecture=arch,
+        arch=arch,
         device=device,
         model_path=model_path,
         read_kwargs=read_kwargs,

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -134,6 +134,8 @@ def descriptors(
     # Set default filname for writing structure with descriptors if not specified
     if out:
         write_kwargs["filename"] = out
+    else:
+        write_kwargs["filename"] = f"{s_point.file_prefix}-descriptors.extxyz"
 
     # Dictionary of inputs for optimize function
     descriptors_kwargs = {

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -134,8 +134,6 @@ def descriptors(
     # Set default filname for writing structure with descriptors if not specified
     if out:
         write_kwargs["filename"] = out
-    else:
-        write_kwargs["filename"] = f"{s_point.struct_name}-descriptors.extxyz"
 
     # Dictionary of inputs for optimize function
     descriptors_kwargs = {

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -152,7 +152,7 @@ def eos(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        architecture=arch,
+        arch=arch,
         device=device,
         model_path=model_path,
         read_kwargs=read_kwargs,

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -167,6 +167,9 @@ def eos(
         raise ValueError("'fmax' must be passed through the --fmax option")
     minimize_kwargs["fmax"] = fmax
 
+    if not file_prefix:
+        file_prefix = s_point.file_prefix
+
     # Dictionary of inputs for eos
     eos_kwargs = {
         "struct": s_point.struct,

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -42,10 +42,6 @@ def eos(
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,
-    struct_name: Annotated[
-        Optional[str],
-        Option(help="Name of structure name."),
-    ] = None,
     min_volume: Annotated[float, Option(help="Minimum volume scale factor.")] = 0.95,
     max_volume: Annotated[float, Option(help="Maximum volume scale factor.")] = 1.05,
     n_volumes: Annotated[int, Option(help="Number of volumes.")] = 7,
@@ -96,9 +92,6 @@ def eos(
         Typer (Click) Context. Automatically set.
     struct : Path
         Path of structure to simulate.
-    struct_name : Optional[str]
-        Name of structure to simulate. Default is inferred from filepath or chemical
-        formula.
     min_volume : float
         Minimum volume scale factor. Default is 0.95.
     max_volume : float
@@ -159,7 +152,6 @@ def eos(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        struct_name=struct_name,
         architecture=arch,
         device=device,
         model_path=model_path,
@@ -178,7 +170,6 @@ def eos(
     # Dictionary of inputs for eos
     eos_kwargs = {
         "struct": s_point.struct,
-        "struct_name": s_point.struct_name,
         "min_volume": min_volume,
         "max_volume": max_volume,
         "n_volumes": n_volumes,

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -223,7 +223,7 @@ def geomopt(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        architecture=arch,
+        arch=arch,
         device=device,
         model_path=model_path,
         read_kwargs=read_kwargs,

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -238,8 +238,6 @@ def geomopt(
     # Set default filname for writing optimized structure if not specified
     if out:
         write_kwargs["filename"] = out
-    else:
-        write_kwargs["filename"] = f"{s_point.struct_name}-opt.extxyz"
 
     _set_minimize_kwargs(minimize_kwargs, traj, opt_cell_lengths, pressure)
 

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -238,6 +238,8 @@ def geomopt(
     # Set default filname for writing optimized structure if not specified
     if out:
         write_kwargs["filename"] = out
+    else:
+        write_kwargs["filename"] = f"{s_point.file_prefix}-opt.extxyz"
 
     _set_minimize_kwargs(minimize_kwargs, traj, opt_cell_lengths, pressure)
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -334,6 +334,9 @@ def md(
 
     log_kwargs = {"filename": log, "filemode": "a"}
 
+    if not file_prefix:
+        file_prefix = s_point.file_prefix
+
     dyn_kwargs = {
         "struct": s_point.struct,
         "timestep": timestep,

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -45,17 +45,6 @@ def md(
     ctx: Context,
     ensemble: Annotated[str, Option(help="Name of thermodynamic ensemble.")],
     struct: StructPath,
-    struct_name: Annotated[
-        str,
-        Option(
-            help=(
-                """
-                Name of structure to simulate. Default is inferred from filepath or
-                chemical formula.
-                """
-            )
-        ),
-    ] = None,
     steps: Annotated[int, Option(help="Number of steps in simulation.")] = 0,
     timestep: Annotated[float, Option(help="Timestep for integrator, in fs.")] = 1.0,
     temp: Annotated[float, Option(help="Temperature, in K.")] = 300.0,
@@ -204,9 +193,6 @@ def md(
         Name of thermodynamic ensemble.
     struct : Path
         Path of structure to simulate.
-    struct_name : Optional[str]
-        Name of structure to simulate. Default is inferred from filepath or chemical
-        formula.
     steps : int
         Number of steps in simulation. Default is 0.
     timestep : float
@@ -338,7 +324,6 @@ def md(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        struct_name=struct_name,
         architecture=arch,
         device=device,
         model_path=model_path,
@@ -351,7 +336,6 @@ def md(
 
     dyn_kwargs = {
         "struct": s_point.struct,
-        "struct_name": s_point.struct_name,
         "timestep": timestep,
         "steps": steps,
         "temp": temp,

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -324,7 +324,7 @@ def md(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        architecture=arch,
+        arch=arch,
         device=device,
         model_path=model_path,
         read_kwargs=read_kwargs,

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -235,6 +235,9 @@ def phonons(
     if len(supercell) != 3:
         raise ValueError("Please pass three lattice vectors in the form 1x2x3")
 
+    if not file_prefix:
+        file_prefix = s_point.file_prefix
+
     # Dictionary of inputs for phonons
     phonons_kwargs = {
         "struct": s_point.struct,

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -238,9 +238,20 @@ def phonons(
     if not file_prefix:
         file_prefix = s_point.file_prefix
 
+    calcs = []
+    if bands:
+        calcs.append("bands")
+    if thermal:
+        calcs.append("thermal")
+    if dos:
+        calcs.append("dos")
+    if pdos:
+        calcs.append("pdos")
+
     # Dictionary of inputs for phonons
     phonons_kwargs = {
         "struct": s_point.struct,
+        "calcs": calcs,
         "supercell": supercell,
         "displacement": displacement,
         "t_min": temp_start,
@@ -263,11 +274,6 @@ def phonons(
     del inputs["log_kwargs"]
     inputs["log"] = log
 
-    inputs["band"] = bands
-    inputs["dos"] = dos
-    inputs["pdos"] = pdos
-    inputs["thermal"] = thermal
-
     save_struct_calc(
         inputs, s_point, arch, device, model_path, read_kwargs, calc_kwargs
     )
@@ -278,20 +284,9 @@ def phonons(
     # Save summary information before calculations begin
     start_summary(command="phonons", summary=summary, inputs=inputs)
 
-    # Initialise phonons class
+    # Initialise phonons class and run calculations
     phonon = Phonons(**phonons_kwargs)
-
-    calcs = []
-    if bands:
-        calcs.append("bands")
-    if thermal:
-        calcs.append("thermal")
-    if dos:
-        calcs.append("dos")
-    if pdos:
-        calcs.append("pdos")
-
-    phonon.run(calcs=calcs)
+    phonon.run()
 
     # Time after calculations have finished
     end_summary(summary)

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -64,7 +64,7 @@ def phonons(
         float,
         Option(help="Temperature step for thermal properties calculations, in K."),
     ] = 50,
-    band: Annotated[
+    bands: Annotated[
         bool,
         Option(help="Whether to compute band structure."),
     ] = False,
@@ -74,7 +74,7 @@ def phonons(
     ] = True,
     plot_to_file: Annotated[
         bool,
-        Option(help="Whether to plot bandstructure and/pr dos/pdos when calculated."),
+        Option(help="Whether to plot band structure and/or dos/pdos when calculated."),
     ] = False,
     dos: Annotated[
         bool,
@@ -151,7 +151,7 @@ def phonons(
     temp_step : float
         Temperature step for thermal calculations, in K. Unused if `thermal` is False.
         Default is 50.0.
-    band : bool
+    bands : bool
         Whether to calculate and save the band structure. Default is False.
     hdf5 : bool
         Whether to save force constants in hdf5 format. Default is True.
@@ -250,7 +250,7 @@ def phonons(
         "minimize_kwargs": minimize_kwargs,
         "file_prefix": file_prefix,
         "log_kwargs": log_kwargs,
-        "hdf5": hdf5,
+        "force_consts_to_hdf5": hdf5,
         "plot_to_file": plot_to_file,
         "symmetrize": symmetrize,
         "write_full": write_full,
@@ -263,7 +263,7 @@ def phonons(
     del inputs["log_kwargs"]
     inputs["log"] = log
 
-    inputs["band"] = band
+    inputs["band"] = bands
     inputs["dos"] = dos
     inputs["pdos"] = pdos
     inputs["thermal"] = thermal
@@ -281,22 +281,17 @@ def phonons(
     # Initialise phonons class
     phonon = Phonons(**phonons_kwargs)
 
-    # Calculate force constants
-    phonon.calc_force_constants()
-
-    # Calculate phonons
-    if band:
-        phonon.calc_bands()
-
-    # Calculate DOS and PDOS is specified
+    calcs = []
+    if bands:
+        calcs.append("bands")
     if thermal:
-        phonon.calc_thermal_props()
-
-    # Calculate DOS and PDOS is specified
+        calcs.append("thermal")
     if dos:
-        phonon.calc_dos()
+        calcs.append("dos")
     if pdos:
-        phonon.calc_pdos()
+        calcs.append("pdos")
+
+    phonon.run(calcs=calcs)
 
     # Time after calculations have finished
     end_summary(summary)

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -40,10 +40,6 @@ def phonons(
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,
-    struct_name: Annotated[
-        Optional[str],
-        Option(help="Name of structure name."),
-    ] = None,
     supercell: Annotated[
         str,
         Option(help="Supercell lattice vectors in the form '1x2x3'."),
@@ -139,9 +135,6 @@ def phonons(
         Typer (Click) Context. Automatically set.
     struct : Path
         Path of structure to simulate.
-    struct_name : Optional[PathLike]
-        Name of structure to simulate. Default is inferred from filepath or chemical
-        formula.
     supercell : str
         Supercell lattice vectors. Must be passed in the form '1x2x3'. Default is
         2x2x2.
@@ -216,7 +209,6 @@ def phonons(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        struct_name=struct_name,
         architecture=arch,
         device=device,
         model_path=model_path,
@@ -246,7 +238,6 @@ def phonons(
     # Dictionary of inputs for phonons
     phonons_kwargs = {
         "struct": s_point.struct,
-        "struct_name": s_point.struct_name,
         "supercell": supercell,
         "displacement": displacement,
         "t_min": temp_start,

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -209,7 +209,7 @@ def phonons(
     # Set up single point calculator
     s_point = SinglePoint(
         struct_path=struct,
-        architecture=arch,
+        arch=arch,
         device=device,
         model_path=model_path,
         read_kwargs=read_kwargs,

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -118,6 +118,9 @@ def singlepoint(
 
     singlepoint_kwargs = {
         "struct_path": struct,
+        "properties": properties,
+        "write_kwargs": write_kwargs,
+        "write_results": True,
         "architecture": arch,
         "device": device,
         "model_path": model_path,
@@ -150,7 +153,7 @@ def singlepoint(
     start_summary(command="singlepoint", summary=summary, inputs=inputs)
 
     # Run singlepoint calculation
-    s_point.run(properties=properties, write_results=True, write_kwargs=write_kwargs)
+    s_point.run()
 
     # Save time after simulation has finished
     end_summary(summary)

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -121,7 +121,7 @@ def singlepoint(
         "properties": properties,
         "write_kwargs": write_kwargs,
         "write_results": True,
-        "architecture": arch,
+        "arch": arch,
         "device": device,
         "model_path": model_path,
         "read_kwargs": read_kwargs,

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -168,14 +168,12 @@ def save_struct_calc(
         inputs["struct"] = {
             "n_atoms": len(s_point.struct),
             "struct_path": s_point.struct_path,
-            "struct_name": s_point.struct_name,
             "formula": s_point.struct.get_chemical_formula(),
         }
     elif isinstance(s_point.struct, Sequence):
         inputs["traj"] = {
             "length": len(s_point.struct),
             "struct_path": s_point.struct_path,
-            "struct_name": s_point.struct_name,
             "struct": {
                 "n_atoms": len(s_point.struct[0]),
                 "formula": s_point.struct[0].get_chemical_formula(),

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -144,6 +144,7 @@ Architectures = Literal[
 Devices = Literal["cpu", "cuda", "mps", "xpu"]
 Ensembles = Literal["nph", "npt", "nve", "nvt", "nvt-nh"]
 Properties = Literal["energy", "stress", "forces"]
+PhononCalcs = Literal["bands", "dos", "pdos", "thermal"]
 
 
 class OutputKwargs(ASEWriteArgs, total=False):

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -65,7 +65,7 @@ def _set_model_path(
 
 def choose_calculator(
     # pylint: disable=too-many-locals, too-many-statements
-    architecture: Architectures = "mace",
+    arch: Architectures = "mace",
     device: Devices = "cpu",
     model_path: Optional[PathLike] = None,
     **kwargs,
@@ -75,7 +75,7 @@ def choose_calculator(
 
     Parameters
     ----------
-    architecture : Architectures, optional
+    arch : Architectures
         MLIP architecture. Default is "mace".
     device : Devices
         Device to run calculator on. Default is "cpu".
@@ -97,7 +97,7 @@ def choose_calculator(
         Invalid architecture specified.
     """
     # pylint: disable=import-outside-toplevel, too-many-branches, import-error
-    # Optional imports handled via `architecture`. We could catch these,
+    # Optional imports handled via `arch`. We could catch these,
     # but the error message is clear if imports are missing.
 
     model_path = _set_model_path(model_path, kwargs)
@@ -105,7 +105,7 @@ def choose_calculator(
     if not device in get_args(Devices):
         raise ValueError(f"`device` must be one of: {get_args(Devices)}")
 
-    if architecture == "mace":
+    if arch == "mace":
         from mace import __version__
         from mace.calculators import MACECalculator
 
@@ -113,14 +113,14 @@ def choose_calculator(
         if model_path is None:
             raise ValueError(
                 "Please specify `model_path`, as there is no "
-                f"default model for {architecture}"
+                f"default model for {arch}"
             )
         # Default to float64 precision
         kwargs.setdefault("default_dtype", "float64")
 
         calculator = MACECalculator(model_paths=model_path, device=device, **kwargs)
 
-    elif architecture == "mace_mp":
+    elif arch == "mace_mp":
         from mace import __version__
         from mace.calculators import mace_mp
 
@@ -130,7 +130,7 @@ def choose_calculator(
 
         calculator = mace_mp(model=model, device=device, **kwargs)
 
-    elif architecture == "mace_off":
+    elif arch == "mace_off":
         from mace import __version__
         from mace.calculators import mace_off
 
@@ -140,7 +140,7 @@ def choose_calculator(
 
         calculator = mace_off(model=model, device=device, **kwargs)
 
-    elif architecture == "m3gnet":
+    elif arch == "m3gnet":
         from matgl import __version__, load_model
         from matgl.apps.pes import Potential
         from matgl.ext.ase import M3GNetCalculator
@@ -164,7 +164,7 @@ def choose_calculator(
 
         calculator = M3GNetCalculator(potential=potential, **kwargs)
 
-    elif architecture == "chgnet":
+    elif arch == "chgnet":
         from chgnet import __version__
         from chgnet.model.dynamics import CHGNetCalculator
         from chgnet.model.model import CHGNet
@@ -185,7 +185,7 @@ def choose_calculator(
 
         calculator = CHGNetCalculator(model=model, use_device=device, **kwargs)
 
-    elif architecture == "alignn":
+    elif arch == "alignn":
         from alignn import __version__
         from alignn.ff.ff import (
             AlignnAtomwiseCalculator,
@@ -206,7 +206,7 @@ def choose_calculator(
 
         calculator = AlignnAtomwiseCalculator(path=path, device=device, **kwargs)
 
-    elif architecture == "sevennet":
+    elif arch == "sevennet":
         from sevenn._const import SEVENN_VERSION as __version__
         from sevenn.sevennet_calculator import SevenNetCalculator
 
@@ -223,11 +223,11 @@ def choose_calculator(
 
     else:
         raise ValueError(
-            f"Unrecognized {architecture=}. Suported architectures "
+            f"Unrecognized {arch=}. Suported architectures "
             f"are {', '.join(Architectures.__args__)}"
         )
 
     calculator.parameters["version"] = __version__
-    calculator.parameters["arch"] = architecture
+    calculator.parameters["arch"] = arch
 
     return calculator

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -173,12 +173,12 @@ def none_to_dict(dictionaries: Sequence[Optional[dict]]) -> Generator[dict, None
     dictionaries : Sequence[dict]
         Sequence of dictionaries that be be None.
 
-    Returns
-    -------
-    Generator[dict]
-        Generator of dictionaries set to {} if previously None.
+    Yields
+    ------
+    dict
+        Input dictionaries or ``{}`` if empty or `None`.
     """
-    return (dictionary if dictionary else {} for dictionary in dictionaries)
+    yield from (dictionary if dictionary else {} for dictionary in dictionaries)
 
 
 def dict_paths_to_strs(dictionary: dict) -> None:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -1,7 +1,7 @@
 """Utility functions for janus_core."""
 
 from abc import ABC
-from collections.abc import Collection, Sequence
+from collections.abc import Collection, Generator, Sequence
 from io import StringIO
 from pathlib import Path
 from typing import Any, Literal, Optional, TextIO, get_args
@@ -192,23 +192,21 @@ def spacegroup(
     )
 
 
-def none_to_dict(dictionaries: list[Optional[dict]]) -> list[dict]:
+def none_to_dict(dictionaries: Sequence[Optional[dict]]) -> Generator[dict]:
     """
     Ensure dictionaries that may be None are dictionaires.
 
     Parameters
     ----------
-    dictionaries : list[dict]
-        List of dictionaries that be be None.
+    dictionaries : Sequence[dict]
+        Sequence of dictionaries that be be None.
 
     Returns
     -------
-    list[dict]
-        Dictionaries set to {} if previously None.
+    Generator[dict]
+        Generator of dictionaries set to {} if previously None.
     """
-    for i, dictionary in enumerate(dictionaries):
-        dictionaries[i] = dictionary if dictionary else {}
-    return dictionaries
+    return (dictionary if dictionary else {} for dictionary in dictionaries)
 
 
 def dict_paths_to_strs(dictionary: dict) -> None:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -164,7 +164,7 @@ def spacegroup(
     )
 
 
-def none_to_dict(dictionaries: Sequence[Optional[dict]]) -> Generator[dict]:
+def none_to_dict(dictionaries: Sequence[Optional[dict]]) -> Generator[dict, None, None]:
     """
     Ensure dictionaries that may be None are dictionaires.
 

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -76,7 +76,7 @@ def test_md_correlations(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -19,7 +19,7 @@ def test_calc_descriptors(tmp_path):
     """Test calculating equation of state from ASE atoms object."""
     struct = read(DATA_PATH / "NaCl.cif")
     log_file = tmp_path / "descriptors.log"
-    struct.calc = choose_calculator(architecture="mace_mp", model=MODEL_PATH)
+    struct.calc = choose_calculator(arch="mace_mp", model=MODEL_PATH)
 
     descriptors = Descriptors(
         struct,
@@ -44,7 +44,7 @@ def test_calc_per_element(tmp_path):
     log_file = tmp_path / "descriptors.log"
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_eos.py
+++ b/tests/test_eos.py
@@ -19,7 +19,7 @@ def test_calc_eos(tmp_path):
     """Test calculating equation of state from ASE atoms object."""
     struct = read(DATA_PATH / "NaCl.cif")
     log_file = tmp_path / "eos.log"
-    struct.calc = choose_calculator(architecture="mace_mp", model=MODEL_PATH)
+    struct.calc = choose_calculator(arch="mace_mp", model=MODEL_PATH)
 
     eos = EoS(
         struct,
@@ -41,7 +41,7 @@ def test_no_optimize(tmp_path):
     log_file = tmp_path / "eos.log"
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     eos = EoS(
@@ -70,7 +70,7 @@ def test_extra_potentials(arch, device, tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture=arch,
+        arch=arch,
         device=device,
     )
 
@@ -96,7 +96,7 @@ def test_invalid_struct():
     """Test setting invalid structure."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "benzene-traj.xyz",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_filenamemixin.py
+++ b/tests/test_filenamemixin.py
@@ -22,82 +22,68 @@ class DummyFileHandler(FileNameMixin):  # pylint: disable=too-few-public-methods
 
 
 @pytest.mark.parametrize(
-    "params,struct_name,file_prefix",
+    "params,file_prefix",
     (
         # Defaults to structure atoms from ASE
-        ((STRUCT, None, None), "C6H6", "C6H6"),
-        # Passing structure name sets file_prefix
-        ((STRUCT, "benzene", None), "benzene", "benzene"),
+        ((STRUCT, None), "C6H6"),
         # file_prefix just sets itself
-        ((STRUCT, None, "benzene"), "C6H6", "benzene"),
-        ((STRUCT, "benzene", "cake"), "benzene", "cake"),
+        ((STRUCT, "benzene"), "benzene"),
         # file_prefix ignores additional
-        ((STRUCT, "benzene", "benzene", "wowzers"), "benzene", "benzene"),
+        ((STRUCT, "benzene", "wowzers"), "benzene"),
         # Additional only applies where no file_prefix
-        ((STRUCT, "benzene", None, "wowzers"), "benzene", "benzene-wowzers"),
-        ((STRUCT, None, None, "wowzers"), "C6H6", "C6H6-wowzers"),
+        ((STRUCT, None, "wowzers"), "C6H6-wowzers"),
     ),
 )
-def test_file_name_mixin_init(params, struct_name, file_prefix):
+def test_file_name_mixin_init(params, file_prefix):
     """Test various options for initializing the mixin."""
     file_mix = DummyFileHandler(*params)
 
-    assert file_mix.struct_name == struct_name
     assert file_mix.file_prefix == Path(file_prefix)
 
 
 @pytest.mark.parametrize(
     "mixin_params,file_args,file_kwargs,file_name",
     (
-        ((STRUCT, None, None), ("data.xyz",), {}, "C6H6-data.xyz"),
-        ((STRUCT, "benzene", None), ("data.xyz",), {}, "benzene-data.xyz"),
-        ((STRUCT, None, "benzene"), ("data.xyz",), {}, "benzene-data.xyz"),
-        ((STRUCT, "benzene", "benzene"), ("data.xyz",), {}, "benzene-data.xyz"),
-        ((STRUCT, "benzene", "benzene"), ("data.xyz",), {}, "benzene-data.xyz"),
-        (
-            (STRUCT, "benzene", "benzene", "wowzers"),
-            ("data.xyz",),
-            {},
-            "benzene-data.xyz",
-        ),
-        ((STRUCT, None, "benzene", "wowzers"), ("data.xyz",), {}, "benzene-data.xyz"),
-        ((STRUCT, None, None, "wowzers"), ("data.xyz",), {}, "C6H6-wowzers-data.xyz"),
+        ((STRUCT, None), ("data.xyz",), {}, "C6H6-data.xyz"),
+        ((STRUCT, "benzene"), ("data.xyz",), {}, "benzene-data.xyz"),
+        ((STRUCT, "benzene", "wowzers"), ("data.xyz",), {}, "benzene-data.xyz"),
+        ((STRUCT, None, "wowzers"), ("data.xyz",), {}, "C6H6-wowzers-data.xyz"),
         # Additional stacks with base
         (
-            (STRUCT, None, None, "wowzers"),
+            (STRUCT, None, "wowzers"),
             ("data.xyz", "beef"),
             {},
             "C6H6-wowzers-beef-data.xyz",
         ),
         # Prefix override ignores class options
         (
-            (STRUCT, None, None, "wowzers"),
+            (STRUCT, None, "wowzers"),
             ("data.xyz",),
             {"prefix_override": "beef"},
             "beef-data.xyz",
         ),
         # But not additional
         (
-            (STRUCT, None, None, "wowzers"),
+            (STRUCT, None, "wowzers"),
             ("data.xyz", "tasty"),
             {"prefix_override": "beef"},
             "beef-tasty-data.xyz",
         ),
         # Filename overrides everything
         (
-            (STRUCT, None, None, "wowzers"),
+            (STRUCT, None, "wowzers"),
             ("data.xyz",),
             {"filename": "hello.xyz"},
             "hello.xyz",
         ),
         (
-            (STRUCT, None, None, "wowzers"),
+            (STRUCT, None, "wowzers"),
             ("data.xyz",),
             {"prefix_override": "beef", "filename": "hello.xyz"},
             "hello.xyz",
         ),
         (
-            (STRUCT, None, None, "wowzers"),
+            (STRUCT, None, "wowzers"),
             ("data.xyz", "tasty"),
             {"prefix_override": "beef", "filename": "hello.xyz"},
             "hello.xyz",

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -58,9 +58,10 @@ def test_saving_struct(tmp_path):
         struct_path=DATA_PATH / "NaCl.cif",
         architecture="mace",
         calc_kwargs={"model": MODEL_PATH},
+        properties="energy",
     )
 
-    init_energy = single_point.run("energy")["energy"]
+    init_energy = single_point.run()["energy"]
 
     optimizer = GeomOpt(
         single_point.struct,
@@ -194,9 +195,10 @@ def test_restart(tmp_path):
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl-deformed.cif",
         calc_kwargs={"model": MODEL_PATH},
+        properties="energy",
     )
 
-    init_energy = single_point.run("energy")["energy"]
+    init_energy = single_point.run()["energy"]
     optimizer = GeomOpt(
         single_point.struct,
         steps=2,
@@ -207,7 +209,7 @@ def test_restart(tmp_path):
     with pytest.warns(UserWarning):
         optimizer.run()
 
-    intermediate_energy = single_point.run("energy")["energy"]
+    intermediate_energy = single_point.run()["energy"]
     assert intermediate_energy < init_energy
 
     optimizer = GeomOpt(
@@ -217,7 +219,7 @@ def test_restart(tmp_path):
         fmax=0.0001,
     )
     optimizer.run()
-    final_energy = single_point.run("energy")["energy"]
+    final_energy = single_point.run()["energy"]
     assert final_energy < intermediate_energy
 
 

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -33,12 +33,12 @@ test_data = [
 ]
 
 
-@pytest.mark.parametrize("architecture, struct_path, expected, kwargs", test_data)
-def test_optimize(architecture, struct_path, expected, kwargs):
+@pytest.mark.parametrize("arch, struct_path, expected, kwargs", test_data)
+def test_optimize(arch, struct_path, expected, kwargs):
     """Test optimizing geometry using MACE."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / struct_path,
-        architecture=architecture,
+        arch=arch,
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -56,7 +56,7 @@ def test_saving_struct(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
         properties="energy",
     )
@@ -78,7 +78,7 @@ def test_saving_traj(tmp_path):
     """Test saving optimization trajectory output."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     optimizer = GeomOpt(
@@ -93,7 +93,7 @@ def test_traj_reformat(tmp_path):
     """Test saving optimization trajectory in different format."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -115,7 +115,7 @@ def test_missing_traj_kwarg(tmp_path):
     """Test error if saving trajectory without opt_kwargs."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     traj_path = tmp_path / "NaCl-traj.extxyz"
@@ -127,13 +127,13 @@ def test_hydrostatic_strain():
     """Test setting hydrostatic strain for filter."""
     single_point_1 = SinglePoint(
         struct_path=DATA_PATH / "NaCl-deformed.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
     single_point_2 = SinglePoint(
         struct_path=DATA_PATH / "NaCl-deformed.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -170,7 +170,7 @@ def test_hydrostatic_strain():
 def test_set_calc():
     """Test setting the calculator without SinglePoint."""
     struct = read(DATA_PATH / "NaCl.cif")
-    struct.calc = choose_calculator(architecture="mace_mp", model=MODEL_PATH)
+    struct.calc = choose_calculator(arch="mace_mp", model=MODEL_PATH)
 
     init_energy = struct.get_potential_energy()
     optimizer = GeomOpt(struct)
@@ -228,7 +228,7 @@ def test_space_group():
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl-sg.cif",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -245,7 +245,7 @@ def test_str_optimizer(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl-sg.cif",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -266,7 +266,7 @@ def test_invalid_str_optimizer():
     """Test setting invalid optimizer function with string."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl-sg.cif",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -284,7 +284,7 @@ def test_str_filter(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl-sg.cif",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -306,7 +306,7 @@ def test_invalid_str_filter():
     """Test setting invalid filter function with string."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl-sg.cif",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -318,7 +318,7 @@ def test_invalid_struct():
     """Test setting invalid structure."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "benzene-traj.xyz",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -29,7 +29,7 @@ def test_help():
 
 def test_geomopt(tmp_path):
     """Test geomopt calculation."""
-    results_path = Path("./Cl4Na4-opt.extxyz").absolute()
+    results_path = Path("./NaCl-opt.extxyz").absolute()
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -29,7 +29,7 @@ def test_help():
 
 def test_geomopt(tmp_path):
     """Test geomopt calculation."""
-    results_path = Path("./NaCl-opt.extxyz").absolute()
+    results_path = Path("./Cl4Na4-opt.extxyz").absolute()
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -30,7 +30,7 @@ def test_init(ensemble, expected):
     """Test initialising ensembles."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     dyn = ensemble(
@@ -55,7 +55,7 @@ def test_npt():
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     npt = NPT(
@@ -106,7 +106,7 @@ def test_nvt_nh():
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nvt_nh = NVT_NH(
@@ -150,7 +150,7 @@ def test_nve(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nve = NVE(
@@ -188,7 +188,7 @@ def test_nph():
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nph = NPH(
@@ -232,7 +232,7 @@ def test_restart(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nvt = NVT(
@@ -279,7 +279,7 @@ def test_minimize(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     init_energy = single_point.struct.get_potential_energy()
@@ -305,7 +305,7 @@ def test_reset_velocities(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "H2O.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     # Give structure arbitrary velocities
@@ -337,7 +337,7 @@ def test_remove_rot(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "H2O.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     # Give structure arbitrary angular velocities
@@ -380,7 +380,7 @@ def test_traj_start(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nvt = NVT(
@@ -422,7 +422,7 @@ def test_minimize_every(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -453,7 +453,7 @@ def test_rescale_every(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -496,7 +496,7 @@ def test_rotate_restart(tmp_path):
     restart_path_3 = tmp_path / "Cl4Na4-nvt-T300.0-res-3.extxyz"
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nvt = NVT(
@@ -524,7 +524,7 @@ def test_atoms_struct(tmp_path):
     stats_path = tmp_path / "Cl4Na4-nvt-T300.0-stats.dat"
 
     struct = read(DATA_PATH / "NaCl.cif")
-    struct.calc = choose_calculator(architecture="mace_mp", model=MODEL_PATH)
+    struct.calc = choose_calculator(arch="mace_mp", model=MODEL_PATH)
 
     nvt = NVT(
         struct=struct,
@@ -555,7 +555,7 @@ def test_heating(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -590,7 +590,7 @@ def test_noramp_heating(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -612,7 +612,7 @@ def test_heating_md(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nvt = NVT(
@@ -662,7 +662,7 @@ def test_heating_files():
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nvt = NVT(
@@ -711,7 +711,7 @@ def test_heating_md_files():
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     nvt = NVT(
@@ -753,7 +753,7 @@ def test_ramp_negative(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -787,7 +787,7 @@ def test_cooling(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -830,7 +830,7 @@ def test_ensemble_kwargs(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 
@@ -848,7 +848,7 @@ def test_invalid_struct():
     """Test setting invalid structure."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "benzene-traj.xyz",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -345,41 +345,6 @@ def test_invalid_config():
     assert isinstance(result.exception, ValueError)
 
 
-def test_struct_name(tmp_path):
-    """Test specifying the structure name."""
-    struct_name = "EXAMPLE"
-    struct_path = tmp_path / struct_name
-    stats_path = tmp_path / f"{struct_name}-nvt-T10.0-stats.dat"
-    traj_path = tmp_path / f"{struct_name}-nvt-T10.0-traj.extxyz"
-    final_path = tmp_path / f"{struct_name}-nvt-T10.0-final.extxyz"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
-    result = runner.invoke(
-        app,
-        [
-            "md",
-            "--struct",
-            DATA_PATH / "NaCl.cif",
-            "--ensemble",
-            "nvt",
-            "--steps",
-            "2",
-            "--temp",
-            "10",
-            "--struct-name",
-            str(struct_path),
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
-        ],
-    )
-    assert result.exit_code == 0
-    assert stats_path.exists()
-    assert traj_path.exists()
-    assert final_path.exists()
-
-
 def test_ensemble_kwargs(tmp_path):
     """Test passing ensemble-kwargs to NPT."""
     struct_path = DATA_PATH / "NaCl.cif"

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -96,7 +96,7 @@ def test_model_model_paths(kwargs):
 
 @pytest.mark.parametrize("architecture", ["mace_mp", "mace_off"])
 def test_invalid_device(architecture):
-    """Test error raised for invalid device is specified."""
+    """Test error raised if invalid device is specified."""
     with pytest.raises(ValueError):
         choose_calculator(architecture=architecture, device="invalid")
 

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -27,7 +27,7 @@ ALIGNN_PATH = MODEL_PATH / "v5.27.2024"
 
 
 @pytest.mark.parametrize(
-    "architecture, device, kwargs",
+    "arch, device, kwargs",
     [
         ("mace", "cpu", {"model": MACE_MP_PATH}),
         ("mace", "cpu", {"model_paths": MACE_MP_PATH}),
@@ -51,20 +51,20 @@ ALIGNN_PATH = MODEL_PATH / "v5.27.2024"
         ("chgnet", "cpu", {"model": CHGNET_MODEL}),
     ],
 )
-def test_mlips(architecture, device, kwargs):
+def test_mlips(arch, device, kwargs):
     """Test mace calculators can be configured."""
-    calculator = choose_calculator(architecture=architecture, device=device, **kwargs)
+    calculator = choose_calculator(arch=arch, device=device, **kwargs)
     assert calculator.parameters["version"] is not None
 
 
 def test_invalid_arch():
     """Test error raised for invalid architecture."""
     with pytest.raises(ValueError):
-        choose_calculator(architecture="invalid")
+        choose_calculator(arch="invalid")
 
 
 @pytest.mark.parametrize(
-    "architecture, model_path",
+    "arch, model_path",
     [
         ("mace", "/invalid/path"),
         ("mace_off", "/invalid/path"),
@@ -73,10 +73,10 @@ def test_invalid_arch():
         ("chgnet", "/invalid/path"),
     ],
 )
-def test_invalid_model_path(architecture, model_path):
+def test_invalid_model_path(arch, model_path):
     """Test error raised for invalid model_path."""
     with pytest.raises((ValueError, RuntimeError)):
-        choose_calculator(architecture=architecture, model_path=model_path)
+        choose_calculator(arch=arch, model_path=model_path)
 
 
 @pytest.mark.parametrize(
@@ -91,19 +91,19 @@ def test_invalid_model_path(architecture, model_path):
 def test_model_model_paths(kwargs):
     """Test error raised if model path is specified in multiple ways."""
     with pytest.raises(ValueError):
-        choose_calculator(architecture="mace", **kwargs)
+        choose_calculator(arch="mace", **kwargs)
 
 
-@pytest.mark.parametrize("architecture", ["mace_mp", "mace_off"])
-def test_invalid_device(architecture):
+@pytest.mark.parametrize("arch", ["mace_mp", "mace_off"])
+def test_invalid_device(arch):
     """Test error raised if invalid device is specified."""
     with pytest.raises(ValueError):
-        choose_calculator(architecture=architecture, device="invalid")
+        choose_calculator(arch=arch, device="invalid")
 
 
 @pytest.mark.extra_mlips
 @pytest.mark.parametrize(
-    "architecture, device, kwargs",
+    "arch, device, kwargs",
     [
         ("alignn", "cpu", {}),
         ("alignn", "cpu", {"model_path": ALIGNN_PATH}),
@@ -117,10 +117,10 @@ def test_invalid_device(architecture):
         ("sevennet", "cpu", {"model": "sevennet-0"}),
     ],
 )
-def test_extra_mlips(architecture, device, kwargs):
+def test_extra_mlips(arch, device, kwargs):
     """Test extra MLIPs (alignn) can be configured."""
     calculator = choose_calculator(
-        architecture=architecture,
+        arch=arch,
         device=device,
         **kwargs,
     )
@@ -132,22 +132,22 @@ def test_extra_mlips(architecture, device, kwargs):
     "kwargs",
     [
         {
-            "architecture": "alignn",
+            "arch": "alignn",
             "model_path": ALIGNN_PATH / "best_model.pt",
             "model": ALIGNN_PATH / "best_model.pt",
         },
         {
-            "architecture": "alignn",
+            "arch": "alignn",
             "model_path": ALIGNN_PATH / "best_model.pt",
             "path": ALIGNN_PATH / "best_model.pt",
         },
         {
-            "architecture": "sevennet",
+            "arch": "sevennet",
             "model_path": SEVENNET_PATH,
             "path": SEVENNET_PATH,
         },
         {
-            "architecture": "sevennet",
+            "arch": "sevennet",
             "model_path": SEVENNET_PATH,
             "model": SEVENNET_PATH,
         },

--- a/tests/test_phonons.py
+++ b/tests/test_phonons.py
@@ -21,11 +21,8 @@ def test_init():
         architecture="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
-    phonons = Phonons(
-        struct=single_point.struct,
-        struct_name=single_point.struct_name,
-    )
-    assert phonons.struct_name == "NaCl"
+    phonons = Phonons(struct=single_point.struct)
+    assert str(phonons.file_prefix) == "Cl4Na4"
 
 
 def test_calc_phonons():

--- a/tests/test_phonons.py
+++ b/tests/test_phonons.py
@@ -18,7 +18,7 @@ def test_init():
     """Test initialising Phonons."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     phonons = Phonons(struct=single_point.struct)
@@ -28,7 +28,7 @@ def test_init():
 def test_calc_phonons():
     """Test calculating phonons from ASE atoms object."""
     struct = read(DATA_PATH / "NaCl.cif")
-    struct.calc = choose_calculator(architecture="mace_mp", model=MODEL_PATH)
+    struct.calc = choose_calculator(arch="mace_mp", model=MODEL_PATH)
 
     phonons = Phonons(
         struct=struct,
@@ -43,7 +43,7 @@ def test_optimize(tmp_path):
     log_file = tmp_path / "phonons.log"
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
     phonons = Phonons(
@@ -63,7 +63,7 @@ def test_invalid_struct():
     """Test setting invalid structure."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "benzene-traj.xyz",
-        architecture="mace_mp",
+        arch="mace_mp",
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_phonons.py
+++ b/tests/test_phonons.py
@@ -34,7 +34,7 @@ def test_calc_phonons():
         struct=struct,
     )
 
-    phonons.calc_force_constants(write_results=False)
+    phonons.calc_force_constants(write_force_consts=False)
     assert "phonon" in phonons.results
 
 
@@ -51,7 +51,7 @@ def test_optimize(tmp_path):
         log_kwargs={"filename": log_file},
         minimize=True,
     )
-    phonons.calc_force_constants(write_results=False)
+    phonons.calc_force_constants(write_force_consts=False)
 
     assert_log_contains(
         log_file,

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -73,10 +73,22 @@ def test_bands_simple(tmp_path):
         ],
     )
     assert result.exit_code == 0
+
     assert autoband_results.exists()
     with open(autoband_results, encoding="utf8") as file:
         bands = yaml.safe_load(file)
-        assert "eigenvector" not in bands["phonon"][0]["band"][0].keys()
+    assert "eigenvector" not in bands["phonon"][0]["band"][0].keys()
+
+    # Read phonons summary file
+    assert summary_path.exists()
+    with open(summary_path, encoding="utf8") as file:
+        phonon_summary = yaml.safe_load(file)
+
+    assert "command" in phonon_summary
+    assert "janus phonons" in phonon_summary["command"]
+    assert "inputs" in phonon_summary
+    assert "calcs" in phonon_summary["inputs"]
+    assert phonon_summary["inputs"]["calcs"][0] == "bands"
 
 
 def test_hdf5(tmp_path):
@@ -214,13 +226,22 @@ def test_plot(tmp_path):
     assert pdos_results.exists()
     assert dos_results.exists()
     assert hdf5_results.exists()
-    assert autoband_results.exists()
     for svg in svgs:
         assert svg.exists()
+
+    assert autoband_results.exists()
     with open(autoband_results, encoding="utf8") as file:
         bands = yaml.safe_load(file)
-        assert "eigenvector" in bands["phonon"][0]["band"][0].keys()
-        assert "group_velocity" in bands["phonon"][0]["band"][0].keys()
+    assert "eigenvector" in bands["phonon"][0]["band"][0].keys()
+    assert "group_velocity" in bands["phonon"][0]["band"][0].keys()
+
+    # Read phonons summary file
+    assert summary_path.exists()
+    with open(summary_path, encoding="utf8") as file:
+        phonon_summary = yaml.safe_load(file)
+    assert phonon_summary["inputs"]["calcs"][0] == "bands"
+    assert phonon_summary["inputs"]["calcs"][1] == "dos"
+    assert phonon_summary["inputs"]["calcs"][2] == "pdos"
 
 
 def test_supercell(tmp_path):

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -43,7 +43,7 @@ def test_bands(tmp_path):
             log_path,
             "--summary",
             summary_path,
-            "--band",
+            "--bands",
         ],
     )
     assert result.exit_code == 0
@@ -68,7 +68,7 @@ def test_bands_simple(tmp_path):
             log_path,
             "--summary",
             summary_path,
-            "--band",
+            "--bands",
             "--no-write-full",
         ],
     )
@@ -199,7 +199,7 @@ def test_plot(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--pdos",
             "--dos",
-            "--band",
+            "--bands",
             "--hdf5",
             "--plot-to-file",
             "--file-prefix",

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -26,7 +26,7 @@ def test_md_pp(tmp_path):
 
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )
 

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -40,7 +40,7 @@ def test_potential_energy(
     calc_kwargs["model"] = MACE_PATH
     single_point = SinglePoint(
         struct_path=struct_path,
-        architecture="mace",
+        arch="mace",
         calc_kwargs=calc_kwargs,
         properties=properties,
     )
@@ -64,7 +64,7 @@ def test_single_point_none():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
     )
 
@@ -77,7 +77,7 @@ def test_single_point_clean():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "H2O.cif",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
     )
 
@@ -91,7 +91,7 @@ def test_single_point_traj():
     """Test single point stress using MACE calculator."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "benzene-traj.xyz",
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
         properties="energy",
     )
@@ -116,7 +116,7 @@ def test_single_point_write():
 
     single_point = SinglePoint(
         struct_path=data_path,
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
         write_results=True,
     )
@@ -149,7 +149,7 @@ def test_single_point_write_kwargs(tmp_path):
 
     single_point = SinglePoint(
         struct_path=data_path,
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
         write_results=True,
         write_kwargs={"filename": results_path},
@@ -168,7 +168,7 @@ def test_single_point_molecule(tmp_path):
     results_path = tmp_path / "H2O.extxyz"
     single_point = SinglePoint(
         struct_path=data_path,
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
         properties="energy",
     )
@@ -192,7 +192,7 @@ def test_invalid_prop():
     with pytest.raises(NotImplementedError):
         SinglePoint(
             struct_path=DATA_PATH / "H2O.cif",
-            architecture="mace",
+            arch="mace",
             calc_kwargs={"model": MACE_PATH},
             properties="invalid",
         )
@@ -203,7 +203,7 @@ def test_atoms():
     struct = read(DATA_PATH / "NaCl.cif")
     single_point = SinglePoint(
         struct=struct,
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
         properties="energy",
     )
@@ -218,7 +218,7 @@ def test_atoms_and_path():
         SinglePoint(
             struct=struct,
             struct_path=struct_path,
-            architecture="mace",
+            arch="mace",
             calc_kwargs={"model": MACE_PATH},
         )
 
@@ -227,7 +227,7 @@ def test_no_atoms_or_path():
     """Test passing neither ASE Atoms structure nor structure path."""
     with pytest.raises(ValueError):
         SinglePoint(
-            architecture="mace",
+            arch="mace",
             calc_kwargs={"model": MACE_PATH},
         )
 
@@ -237,7 +237,7 @@ def test_invalidate_calc():
     struct_path = DATA_PATH / "NaCl.cif"
     single_point = SinglePoint(
         struct_path=struct_path,
-        architecture="mace",
+        arch="mace",
         calc_kwargs={"model": MACE_PATH},
         write_kwargs={"invalidate_calc": False},
     )
@@ -261,7 +261,7 @@ def test_mlips(arch, device, expected_energy):
     """Test single point energy using CHGNET and M3GNET calculators."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture=arch,
+        arch=arch,
         device=device,
         properties="energy",
     )
@@ -283,7 +283,7 @@ def test_extra_mlips_alignn(arch, device, expected_energy, kwargs):
     """Test single point energy using extra mlips calculators."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        architecture=arch,
+        arch=arch,
         device=device,
         properties="energy",
         **kwargs,

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -111,7 +111,7 @@ def test_single_point_traj():
 def test_single_point_write():
     """Test writing singlepoint results."""
     data_path = DATA_PATH / "NaCl.cif"
-    results_path = Path("./Cl4Na4-results.extxyz").absolute()
+    results_path = Path("./NaCl-results.extxyz").absolute()
     assert not results_path.exists()
 
     single_point = SinglePoint(

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -28,7 +28,7 @@ def test_singlepoint_help():
 
 def test_singlepoint(tmp_path):
     """Test singlepoint calculation."""
-    results_path = Path("./Cl4Na4-results.extxyz").absolute()
+    results_path = Path("./NaCl-results.extxyz").absolute()
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -28,7 +28,7 @@ def test_singlepoint_help():
 
 def test_singlepoint(tmp_path):
     """Test singlepoint calculation."""
-    results_path = Path("./NaCl-results.extxyz").absolute()
+    results_path = Path("./Cl4Na4-results.extxyz").absolute()
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,21 +142,20 @@ def test_output_structs(
 
 
 @pytest.mark.parametrize(
-    "dicts",
+    "dicts_in",
     [
         [None, {"a": 1}, {}, {"b": 2, "a": 11}, None],
         (None, {"a": 1}, {}, {"b": 2, "a": 11}, None),
     ],
 )
-def test_none_to_dict(dicts):
+def test_none_to_dict(dicts_in):
     """Test none_to_dict removes Nones from sequence, and preserves dictionaries."""
-    dicts = list(none_to_dict(dicts))
+    dicts = list(none_to_dict(dicts_in))
     for dictionary in dicts:
         assert dictionary is not None
 
     assert dicts[0] == {}
-    assert dicts[1]["a"] == 1
-    assert dicts[2] == {}
-    assert dicts[3]["b"] == 2
-    assert dicts[3]["a"] == 11
+    assert dicts[1] == dicts_in[1]
+    assert dicts[2] == dicts_in[2]
+    assert dicts[3] == dicts_in[3]
     assert dicts[4] == {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from janus_core.helpers.mlip_calculators import choose_calculator
 from janus_core.helpers.utils import (
     dict_paths_to_strs,
     dict_remove_hyphens,
+    none_to_dict,
     output_structs,
 )
 
@@ -138,3 +139,24 @@ def test_output_structs(
 
     else:
         assert not output_file.exists()
+
+
+@pytest.mark.parametrize(
+    "dicts",
+    [
+        [None, {"a": 1}, {}, {"b": 2, "a": 11}, None],
+        (None, {"a": 1}, {}, {"b": 2, "a": 11}, None),
+    ],
+)
+def test_none_to_dict(dicts):
+    """Test none_to_dict removes Nones from sequence, and preserves dictionaries."""
+    dicts = list(none_to_dict(dicts))
+    for dictionary in dicts:
+        assert dictionary is not None
+
+    assert dicts[0] == {}
+    assert dicts[1]["a"] == 1
+    assert dicts[2] == {}
+    assert dicts[3]["b"] == 2
+    assert dicts[3]["a"] == 11
+    assert dicts[4] == {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,7 +75,7 @@ def test_output_structs(
 ):
     """Test output_structs copies/moves results to Atoms.info and writes files."""
     struct = read(DATA_PATH)
-    struct.calc = choose_calculator(architecture=arch)
+    struct.calc = choose_calculator(arch=arch)
 
     if not properties:
         results_keys = set(get_args(Properties))


### PR DESCRIPTION
Depends on #224 and #221 (will need rebasing)

Aims to address part of #206:

> - Consider the interaction and need for file_prefix and struct_name
>   - In some cases e.g. eos, I think they may actually do exactly the same thing
>   - I'd propose potentially removing struct_name as an option completely, unless there's a clear benefit, to simplify the setting of file names
 > - Check other settings are consistent between calculations

New changes are all in the final commit: ([Tidy calculations](https://github.com/stfc/janus-core/commit/1fd66b16e33a2598dd7ed809e802356a68139e2f)):

- Removes `struct_name`, since `file_prefix` performs essentially the same purpose (`FileNameMixin` should be updated similarly, although we may want to add in something for an optional filepath somehow)
- Refactors `SinglePoint` to be more consistent with other calculations, so all kwargs passed on init normally, but can also be overwritten when calling `run`
- Refactors phonons to clarify order of function calls, and includes `run` function that takes a similar sequence of calculations to the CLI interface.