### PR TITLE
Fix CLI help

### DIFF
--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -32,7 +32,7 @@ from janus_core.helpers.utils import dict_paths_to_strs
 app = Typer()
 
 
-@app.command(help="Calculate MLIP descriptors.")
+@app.command()
 @use_config(yaml_converter_callback)
 def descriptors(
     # pylint: disable=too-many-arguments,too-many-locals,duplicate-code

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -34,7 +34,7 @@ from janus_core.helpers.utils import dict_paths_to_strs
 app = Typer()
 
 
-@app.command(help="Calculate equation of state.")
+@app.command()
 @use_config(yaml_converter_callback)
 def eos(
     # pylint: disable=too-many-arguments,too-many-locals,duplicate-code

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -88,9 +88,7 @@ def _set_minimize_kwargs(
     minimize_kwargs["filter_kwargs"]["scalar_pressure"] = pressure
 
 
-@app.command(
-    help="Perform geometry optimization and save optimized structure to file.",
-)
+@app.command()
 @use_config(yaml_converter_callback)
 def geomopt(
     # pylint: disable=too-many-arguments,too-many-locals,duplicate-code

--- a/janus_core/cli/janus.py
+++ b/janus_core/cli/janus.py
@@ -11,6 +11,7 @@ from janus_core.cli.geomopt import geomopt
 from janus_core.cli.md import md
 from janus_core.cli.phonons import phonons
 from janus_core.cli.singlepoint import singlepoint
+from janus_core.cli.train import train
 
 app = Typer(name="janus", no_args_is_help=True)
 app.command()(singlepoint)
@@ -19,14 +20,7 @@ app.command()(md)
 app.command()(phonons)
 app.command()(eos)
 app.command()(descriptors)
-
-# Train not imlpemented in older versions of MACE
-try:
-    from janus_core.cli.train import train
-
-    app.command()(train)
-except NotImplementedError:
-    pass
+app.command()(train)
 
 
 @app.callback(invoke_without_command=True, help="")

--- a/janus_core/cli/janus.py
+++ b/janus_core/cli/janus.py
@@ -14,13 +14,17 @@ from janus_core.cli.singlepoint import singlepoint
 from janus_core.cli.train import train
 
 app = Typer(name="janus", no_args_is_help=True)
-app.command()(singlepoint)
-app.command()(geomopt)
-app.command()(md)
-app.command()(phonons)
-app.command()(eos)
-app.command()(descriptors)
-app.command()(train)
+app.command(help="Perform single point calculations and save to file.")(singlepoint)
+app.command(help="Perform geometry optimization and save optimized structure to file.")(
+    geomopt
+)
+app.command(
+    help="Run molecular dynamics simulation, and save trajectory and statistics."
+)(md)
+app.command(help="Calculate phonons and save results.")(phonons)
+app.command(help="Calculate equation of state.")(eos)
+app.command(help="Calculate MLIP descriptors.")(descriptors)
+app.command(help="Running training for an MLIP.")(train)
 
 
 @app.callback(invoke_without_command=True, help="")

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -36,9 +36,7 @@ from janus_core.helpers.utils import dict_paths_to_strs
 app = Typer()
 
 
-@app.command(
-    help="Run molecular dynamics simulation, and save trajectory and statistics.",
-)
+@app.command()
 @use_config(yaml_converter_callback)
 def md(
     # pylint: disable=too-many-arguments,too-many-locals,invalid-name,duplicate-code

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -32,7 +32,7 @@ from janus_core.helpers.utils import dict_paths_to_strs
 app = Typer()
 
 
-@app.command(help="Calculate phonons and save results.")
+@app.command()
 @use_config(yaml_converter_callback)
 def phonons(
     # pylint: disable=too-many-arguments,too-many-locals,duplicate-code

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -31,7 +31,7 @@ from janus_core.helpers.utils import dict_paths_to_strs
 app = Typer()
 
 
-@app.command(help="Perform single point calculations and save to file.")
+@app.command()
 @use_config(yaml_converter_callback)
 def singlepoint(
     # pylint: disable=too-many-arguments,too-many-locals,duplicate-code

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -11,7 +11,7 @@ from janus_core.helpers.train import train as run_train
 app = Typer()
 
 
-@app.command(help="Running training for an MLIP.")
+@app.command()
 def train(
     mlip_config: Annotated[
         Path, Option(help="Configuration file to pass to MLIP CLI.")


### PR DESCRIPTION
Resolves #140

Fixes CLI help messages to prevent docstring dump e.g.

```
  Parameters ---------- ctx : Context     Typer (Click) Context. Automatically
  set. struct : Path     Path of structure to simulate. arch : Optional[str]
  MLIP architecture to use for single point calculations.     Default is
  "mace_mp". device : Optional[str]     Device to run model on. Default is
  "cpu". model_path : Optional[str]     Path to MLIP model. Default is `None`.
  properties : Optional[str]     Physical properties to calculate. Default is
  "energy". out : Optional[Path]     Path to save structure with calculated
  results. Default is inferred from name     of the structure file.
  read_kwargs : Optional[dict[str, Any]]     Keyword arguments to pass to
  ase.io.read. Default is {}. calc_kwargs : Optional[dict[str, Any]]
  Keyword arguments to pass to the selected calculator. Default is {}.
  write_kwargs : Optional[dict[str, Any]]     Keyword arguments to pass to
  ase.io.write when saving results. Default is {}. log : Optional[Path]
  Path to write logs to. Default is "singlepoint.log". summary : Path     Path
  to save summary of inputs and start/end time. Default is
  singlepoint_summary.yml. config : Path     Path to yaml configuration file
  to define the above options. Default is None.
```

Also moves import check for MACE training, as this is now fully supported.