### PR TITLE
Update sevenn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,11 @@ torch-dftd = "0.4.0"
 codecarbon = "^2.5.0"
 alignn = { version = "2024.5.27", optional = true }
 sevenn = { version = "0.9.3", optional = true }
-torch_scatter = { version = "^2.1.2", optional = true }
 torch_geometric = { version = "^2.5.3", optional = true }
 
 [tool.poetry.extras]
 alignnff = ["alignn"]
-sevennet = ["sevenn", "torch_scatter", "torch_geometric"]
+sevennet = ["sevenn", "torch_geometric"]
 
 [tool.poetry.group.dev.dependencies]
 coverage = {extras = ["toml"], version = "^7.4.1"}

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -293,7 +293,7 @@ test_extra_mlips_data = [
     ("alignn", "cpu", -11.148092269897461, {}),
     ("sevennet", "cpu", -27.061979293823242, {"model_path": SEVENNET_PATH}),
     ("sevennet", "cpu", -27.061979293823242, {}),
-    ("sevennet", "cpu", -27.061979293823242, {"model": "SevenNet-0_11July2024"}),
+    ("sevennet", "cpu", -27.061979293823242, {"model_path": "SevenNet-0_11July2024"}),
 ]
 
 


### PR DESCRIPTION
Resolves #235

Also fixes a test that a single point test, as unlike setting the calculator, `SinglePoint`only takes `model_path` or `calc_kwargs`, so cannot take `model`.