### PR TITLE
Add version for sevennet

### DIFF
--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -207,9 +207,8 @@ def choose_calculator(
         calculator = AlignnAtomwiseCalculator(path=path, device=device, **kwargs)
 
     elif architecture == "sevennet":
+        from sevenn._const import SEVENN_VERSION as __version__
         from sevenn.sevennet_calculator import SevenNetCalculator
-
-        __version__ = "0.0.0"
 
         if isinstance(model_path, Path):
             model = str(model_path)

--- a/release.sh
+++ b/release.sh
@@ -4,8 +4,8 @@ version=$1
 
 sed -i "s;^version =.*;version = \"$version\";g" pyproject.toml
 
-git add pyproject.toml 
+git add pyproject.toml
 git commit -m "bump version for release $version"
 git tag -f -a v$version -m "release $version"
-git push 
-git push --tags 
+git push
+git push --tags


### PR DESCRIPTION
The version is in `sevenn._const`, and seems to be used by them in the same way e.g. https://github.com/MDIL-SNU/SevenNet/blob/main/sevenn/sevenn_logger.py#L244