### PR TITLE
Rename geomopt flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This will optimize the atomic positions and save the resulting structure in `H2O
 Additional options may be specified. This shares most options with `singlepoint`, as well as a few additional options, such as:
 
 ```shell
-janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --vectors-only --traj 'NaCl-traj.extxyz'
+janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --opt-cell-lengths --traj 'NaCl-traj.extxyz'
 ```
 
 This allows the cell vectors to be optimised, allowing only hydrostatic deformation, and saves the optimization trajectory in addition to the final structure and log.
@@ -117,7 +117,7 @@ This allows the cell vectors to be optimised, allowing only hydrostatic deformat
 Further options for the optimizer and filter can be specified using the `--minimize-kwargs` option. For example:
 
 ```shell
-janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --fully-opt --minimize-kwargs "{'filter_kwargs': {'constant_volume' : True}, 'opt_kwargs': {'alpha': 100}}"
+janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --opt-cell-fully --minimize-kwargs "{'filter_kwargs': {'constant_volume' : True}, 'opt_kwargs': {'alpha': 100}}"
 ```
 
 This allows the cell vectors and angles to be optimized, as well as the atomic positions, at constant volume, and sets the `alpha`, the initial guess for the Hessian, to 100 for the optimizer function.

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -180,7 +180,7 @@ def geomopt(
         Default is False.
     filter_func : Optional[str]
         Name of filter function from ase.filters or ase.constraints, to apply
-        constraints to atoms. If using --vectors only or --opt-cell-fully, defaults to
+        constraints to atoms. If using --opt-cell-lengths or --opt-cell-fully, defaults to
         `FrechetCellFilter` if available, otherwise `ExpCellFilter`.
     pressure : float
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -36,7 +36,7 @@ app = Typer()
 def _set_minimize_kwargs(
     minimize_kwargs: dict[str, Any],
     traj: Optional[str],
-    vectors_only: bool,
+    opt_cell_lengths: bool,
     pressure: float,
 ) -> None:
     """
@@ -48,12 +48,12 @@ def _set_minimize_kwargs(
         Other keyword arguments to pass to geometry optimizer.
     traj : Optional[str]
         Path if saving optimization frames.
-    vectors_only : bool
+    opt_cell_lengths : bool
         Whether to optimize cell vectors, as well as atomic positions, by setting
         `hydrostatic_strain` in the filter function.
     pressure : float
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
-        function if either `vectors_only` or `fully_opt` is True.
+        function if either `opt_cell_lengths` or `fully_opt` is True.
     """
     if "opt_kwargs" in minimize_kwargs:
         # Check trajectory path not duplicated
@@ -74,7 +74,8 @@ def _set_minimize_kwargs(
     if "filter_kwargs" in minimize_kwargs:
         if "hydrostatic_strain" in minimize_kwargs["filter_kwargs"]:
             raise ValueError(
-                "'hydrostatic_strain' must be passed through the --vectors-only option"
+                "'hydrostatic_strain' must be passed through the --opt-cell-lengths "
+                "option"
             )
         if "scalar_pressure" in minimize_kwargs["filter_kwargs"]:
             raise ValueError(
@@ -84,7 +85,7 @@ def _set_minimize_kwargs(
         minimize_kwargs["filter_kwargs"] = {}
 
     # Set hydrostatic_strain and scalar pressure
-    minimize_kwargs["filter_kwargs"]["hydrostatic_strain"] = vectors_only
+    minimize_kwargs["filter_kwargs"]["hydrostatic_strain"] = opt_cell_lengths
     minimize_kwargs["filter_kwargs"]["scalar_pressure"] = pressure
 
 
@@ -106,7 +107,7 @@ def geomopt(
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     model_path: ModelPath = None,
-    vectors_only: Annotated[
+    opt_cell_lengths: Annotated[
         bool,
         Option(help="Optimize cell vectors, as well as atomic positions."),
     ] = False,
@@ -121,8 +122,8 @@ def geomopt(
         Option(
             help=(
                 "Name of ASE filter/constraint function to use. If using "
-                "--vectors-only or --fully-opt, defaults to `FrechetCellFilter` if "
-                "available, otherwise `ExpCellFilter`."
+                "--opt-cell-lengths or --fully-opt, defaults to `FrechetCellFilter` "
+                "if available, otherwise `ExpCellFilter`."
             )
         ),
     ] = None,
@@ -171,7 +172,7 @@ def geomopt(
         Device to run model on. Default is "cpu".
     model_path : Optional[str]
         Path to MLIP model. Default is `None`.
-    vectors_only : bool
+    opt_cell_lengths : bool
         Whether to optimize cell vectors, as well as atomic positions, by setting
         `hydrostatic_strain` in the filter function. Default is False.
     fully_opt : bool
@@ -183,7 +184,7 @@ def geomopt(
         `FrechetCellFilter` if available, otherwise `ExpCellFilter`.
     pressure : float
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
-        function if either `vectors_only` or `fully_opt` is True. Default is 0.0.
+        function if either `opt_cell_lengths` or `fully_opt` is True. Default is 0.0.
     out : Optional[Path]
         Path to save optimized structure, or last structure if optimization did not
         converge. Default is inferred from name of structure file.
@@ -234,15 +235,16 @@ def geomopt(
     else:
         write_kwargs["filename"] = f"{s_point.struct_name}-opt.extxyz"
 
-    _set_minimize_kwargs(minimize_kwargs, traj, vectors_only, pressure)
+    _set_minimize_kwargs(minimize_kwargs, traj, opt_cell_lengths, pressure)
 
-    if fully_opt or vectors_only:
+    if fully_opt or opt_cell_lengths:
         # Use default filter unless filter function explicitly passed
         fully_opt_dict = {"filter_func": filter_func} if filter_func else {}
     else:
         if filter_func:
             raise ValueError(
-                "--vectors-only or --fully-opt must be set to use a filter function"
+                "--opt-cell-lengths or --fully-opt must be set to use a filter "
+                "function"
             )
         # Override default filter function with None
         fully_opt_dict = {"filter_func": None}

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -180,8 +180,8 @@ def geomopt(
         Default is False.
     filter_func : Optional[str]
         Name of filter function from ase.filters or ase.constraints, to apply
-        constraints to atoms. If using --opt-cell-lengths or --opt-cell-fully, defaults to
-        `FrechetCellFilter` if available, otherwise `ExpCellFilter`.
+        constraints to atoms. If using --opt-cell-lengths or --opt-cell-fully, defaults
+        to `FrechetCellFilter` if available, otherwise `ExpCellFilter`.
     pressure : float
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
         function if either `opt_cell_lengths` or `opt_cell_fully` is True. Default is

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -107,8 +107,8 @@ def test_traj(tmp_path):
     assert "mace_mp_forces" in atoms.arrays
 
 
-def test_fully_opt(tmp_path):
-    """Test passing --fully-opt without --opt-cell-lengths"""
+def test_opt_fully(tmp_path):
+    """Test passing --opt-cell-fully without --opt-cell-lengths"""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -121,7 +121,7 @@ def test_fully_opt(tmp_path):
             DATA_PATH / "NaCl-deformed.cif",
             "--out",
             results_path,
-            "--fully-opt",
+            "--opt-cell-fully",
             "--log",
             log_path,
             "--summary",
@@ -147,8 +147,8 @@ def test_fully_opt(tmp_path):
     assert atoms.cell.cellpar() == pytest.approx(expected)
 
 
-def test_fully_opt_and_vectors(tmp_path):
-    """Test passing --fully-opt with --opt-cell-lengths."""
+def test_opt_fully_and_vectors(tmp_path):
+    """Test passing --opt-cell-fully with --opt-cell-lengths."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -159,7 +159,7 @@ def test_fully_opt_and_vectors(tmp_path):
             "geomopt",
             "--struct",
             DATA_PATH / "NaCl-deformed.cif",
-            "--fully-opt",
+            "--opt-cell-fully",
             "--opt-cell-lengths",
             "--out",
             results_path,
@@ -185,8 +185,8 @@ def test_fully_opt_and_vectors(tmp_path):
     assert atoms.cell.cellpar() == pytest.approx(expected)
 
 
-def test_vectors_not_fully_opt(tmp_path):
-    """Test passing --opt-cell-lengths without --fully-opt."""
+def test_vectors_not_opt_fully(tmp_path):
+    """Test passing --opt-cell-lengths without --opt-cell-fully."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -211,7 +211,7 @@ def test_vectors_not_fully_opt(tmp_path):
     assert_log_contains(log_path, includes=["Using filter", "hydrostatic_strain: True"])
 
 
-test_data = ["--opt-cell-lengths", "--fully-opt"]
+test_data = ["--opt-cell-lengths", "--opt-cell-fully"]
 
 
 @pytest.mark.parametrize("option", test_data)
@@ -410,7 +410,7 @@ def test_invalid_config():
 
 
 def test_const_volume(tmp_path):
-    """Test setting constant volume with --fully-opt."""
+    """Test setting constant volume with --opt-cell-fully."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -425,7 +425,7 @@ def test_const_volume(tmp_path):
             DATA_PATH / "NaCl-deformed.cif",
             "--out",
             results_path,
-            "--fully-opt",
+            "--opt-cell-fully",
             "--minimize-kwargs",
             minimize_kwargs,
             "--log",
@@ -481,7 +481,7 @@ def test_filter_str(tmp_path):
             DATA_PATH / "NaCl-deformed.cif",
             "--out",
             results_path,
-            "--fully-opt",
+            "--opt-cell-fully",
             "--filter-func",
             "UnitCellFilter",
             "--log",
@@ -498,7 +498,7 @@ def test_filter_str(tmp_path):
 
 
 def test_filter_str_error(tmp_path):
-    """Test setting filter function without --fully-opt or --opt-cell-lengths."""
+    """Test setting filter function without --opt-cell-fully or --opt-cell-lengths."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -108,7 +108,7 @@ def test_traj(tmp_path):
 
 
 def test_fully_opt(tmp_path):
-    """Test passing --fully-opt without --vectors-only"""
+    """Test passing --fully-opt without --opt-cell-lengths"""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -148,7 +148,7 @@ def test_fully_opt(tmp_path):
 
 
 def test_fully_opt_and_vectors(tmp_path):
-    """Test passing --fully-opt with --vectors-only."""
+    """Test passing --fully-opt with --opt-cell-lengths."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -160,7 +160,7 @@ def test_fully_opt_and_vectors(tmp_path):
             "--struct",
             DATA_PATH / "NaCl-deformed.cif",
             "--fully-opt",
-            "--vectors-only",
+            "--opt-cell-lengths",
             "--out",
             results_path,
             "--log",
@@ -186,7 +186,7 @@ def test_fully_opt_and_vectors(tmp_path):
 
 
 def test_vectors_not_fully_opt(tmp_path):
-    """Test passing --vectors-only without --fully-opt."""
+    """Test passing --opt-cell-lengths without --fully-opt."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -199,7 +199,7 @@ def test_vectors_not_fully_opt(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--out",
             results_path,
-            "--vectors-only",
+            "--opt-cell-lengths",
             "--log",
             log_path,
             "--summary",
@@ -211,12 +211,12 @@ def test_vectors_not_fully_opt(tmp_path):
     assert_log_contains(log_path, includes=["Using filter", "hydrostatic_strain: True"])
 
 
-test_data = ["--vectors-only", "--fully-opt"]
+test_data = ["--opt-cell-lengths", "--fully-opt"]
 
 
 @pytest.mark.parametrize("option", test_data)
 def test_scalar_pressure(option, tmp_path):
-    """Test passing --pressure with --vectors-only."""
+    """Test passing --pressure with --opt-cell-lengths."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
@@ -498,7 +498,7 @@ def test_filter_str(tmp_path):
 
 
 def test_filter_str_error(tmp_path):
-    """Test setting filter function without --fully-opt or --vectors-only."""
+    """Test setting filter function without --fully-opt or --opt-cell-lengths."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"


### PR DESCRIPTION
Resolves #180

- Renames `--vectors-only` to `--opt-cell-lengths` to reduce confusion that this is in addition to optimizing cell positions.
- Renames `--fully-opt` to `--opt-cell-fully` for consistency (if we ever add something like `--opt-cell-angles`, this would be equivalent to both being true, which feels reasonably consistent)

Still open to further suggestions