### PR TITLE
Delete duplicate struct from CLI summary

### DIFF
--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -141,6 +141,9 @@ def save_struct_calc(
     calc_kwargs : dict[str, Any]]
         Keyword arguments to pass to the calculator.
     """
+    # Remove duplicate struct if already in inputs:
+    inputs.pop("struct", None)
+
     if isinstance(s_point.struct, Atoms):
         inputs["struct"] = {
             "n_atoms": len(s_point.struct),


### PR DESCRIPTION
Resolves #242

Removes "struct" from the `inputs` dict when saving the CLI summary, as this is exactly what `save_struct_calc` is designed to do anyway, and if the `struct` is actually a trajectory, we end up with a duplicate, with binary info printed.