### PR TITLE
Fix calculator copies

### DIFF
--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -1,6 +1,6 @@
 """Equation of State."""
 
-from copy import deepcopy
+from copy import copy
 from typing import Any, Optional
 
 from ase import Atoms
@@ -270,7 +270,7 @@ class EoS(FileNameMixin):
         )
         for lattice_scalar in self.lattice_scalars:
             c_struct = self.struct.copy()
-            c_struct.calc = deepcopy(self.struct.calc)
+            c_struct.calc = copy(self.struct.calc)
             c_struct.set_cell(cell * lattice_scalar, scale_atoms=True)
 
             # Minimize new structure

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -1,7 +1,7 @@
 """Prepare and perform single point calculations."""
 
 from collections.abc import Sequence
-from copy import deepcopy
+from copy import copy
 from pathlib import Path
 from typing import Any, Optional, get_args
 
@@ -221,7 +221,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
 
         if isinstance(self.struct, Sequence):
             for struct in self.struct:
-                struct.calc = deepcopy(calculator)
+                struct.calc = copy(calculator)
             # Return single Atoms object if only one image in list
             if len(self.struct) == 1:
                 self.struct = self.struct[0]


### PR DESCRIPTION
Resolves memory issues due using `deepcopy` when using the same calculator for multiple structures.

`copy` still seemed to be sufficient to resolve #217, as discussed in #218.