### PR TITLE
Fix write

### DIFF
--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, Optional, TextIO, get_args
 
 from ase import Atoms
 from ase.io import write
+from ase.io.formats import filetype
 from spglib import get_spacegroup
 
 from janus_core.helpers.janus_types import (
@@ -336,7 +337,22 @@ def output_structs(
                 image.info["arch"] = image.calc.parameters["arch"]
 
     if write_results:
-        write_kwargs.setdefault("write_results", not invalidate_calc)
+        # Check required filename is specified
+        if "filename" not in write_kwargs:
+            raise ValueError(
+                "`filename` must be specified in `write_kwargs` to write results"
+            )
+
+        # Get format of file to be written
+        write_format = write_kwargs.get(
+            "format", filetype(write_kwargs["filename"], read=False)
+        )
+
+        # write_results is only a valid kwarg for extxyz
+        if write_format in ("xyz", "extxyz"):
+            write_kwargs.setdefault("write_results", not invalidate_calc)
+        else:
+            write_kwargs.pop("write_results", None)
         write(images=images, **write_kwargs)
 
 

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from ase import Atoms
 from ase.io import read
 from typer.testing import CliRunner
 import yaml
@@ -301,3 +302,24 @@ def test_write_kwargs(tmp_path):
     assert "mace_mp_forces" in atoms.arrays
     assert "energy" in atoms.calc.results
     assert "forces" in atoms.calc.results
+
+
+def test_write_cif(tmp_path):
+    """Test writing out a cif file."""
+    results_path = tmp_path / "NaCl-results.cif"
+
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--write-kwargs",
+            "{'invalidate_calc': False, 'write_results': True}",
+            "--out",
+            results_path,
+        ],
+    )
+    assert result.exit_code == 0
+    atoms = read(results_path)
+    assert isinstance(atoms, Atoms)


### PR DESCRIPTION
Resolves #246

If `format` is not a kwarg, uses the ASE `filetype` function to determine the file format, and removes or sets the default for `write_results` depending on whether the format is xyz/extxyz or otherwise.
