### PR TITLE
Add ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,40 +9,15 @@ repos:
     - id: trailing-whitespace
     - id: check-json
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.5.6
   hooks:
-  - id: pyupgrade
-    args: ["--py39-plus"]
-
-- repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort
-      args: ["--profile=black"]
-
-- repo: https://github.com/psf/black
-  rev: 24.1.1
-  hooks:
-    - id: black
-      args: [--line-length=88]
-
-- repo: local
-  hooks:
-  - id: pylint
-    language: system
-    types: [file, python]
-    name: pylint
-    description: "This hook runs the pylint static code analyzer"
-    exclude: &exclude_files >
-      (?x)^(
-          docs/.*|
-      )$
-    entry: pylint
-    args:
-      [
-        "--good-names=e,i,j,k"
-      ]
+    # Run the linter.
+    - id: ruff
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
 
 - repo: https://github.com/numpy/numpydoc
   rev: v1.6.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,7 +74,6 @@ copyright_year_string = (
     if current_year == copyright_first_year
     else f"{copyright_first_year}-{current_year}"
 )
-# pylint: disable=redefined-builtin
 copyright = f"{copyright_year_string}, {copyright_owners}. All rights reserved"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,8 +10,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
-import sys
 import time
 
 import janus_core

--- a/docs/source/developer_guide/get_started.rst
+++ b/docs/source/developer_guide/get_started.rst
@@ -44,11 +44,23 @@ See the `tox documentation <https://tox.wiki/>`_ for further options.
 Automatic coding style check
 ++++++++++++++++++++++++++++
 
-Packages in the ``pre-commit`` dependency group allow automatic code formatting checks on every commit. To set this up, run::
+Packages in the ``pre-commit`` dependency group allow automatic code formatting and linting on every commit.
+
+To set this up, run::
 
     pre-commit install
 
-After this, `black <https://black.readthedocs.io>`_ (code formatter), `pylint <https://www.pylint.org/>`_ (linter), the `pyupgrade <https://github.com/asottile/pyupgrade>`_ (syntax upgrader), `isort <https://pycqa.github.io/isort/>`_ (import sorter), and `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`_ (docstring style validator), will run before every commit.
+After this, the `ruff linter <https://docs.astral.sh/ruff/linter/>`_, `ruff formatter <https://docs.astral.sh/ruff/formatter/>`_, and `numpydoc <https://numpydoc.readthedocs.io/en/latest/format.html>`_ (docstring style validator), will run before every commit.
+
+Rules enforced by ruff are currently set up to be comparable to:
+
+- `black <https://black.readthedocs.io>`_ (code formatter)
+- `pylint <https://www.pylint.org/>`_ (linter)
+- `pyupgrade <https://github.com/asottile/pyupgrade>`_ (syntax upgrader)
+- `isort <https://pycqa.github.io/isort/>`_ (import sorter)
+- `flake8-bugbear <https://pypi.org/project/flake8-bugbear/>`_ (bug finder)
+
+The full set of `ruff rules <https://docs.astral.sh/ruff/rules/>`_ are specified by the ``[tool.ruff]]`` sections of `pyproject.toml <https://github.com/stfc/janus-core/blob/main/pyproject.toml>`
 
 
 Building the documentation

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -13,7 +13,6 @@ from janus_core.helpers.utils import FileNameMixin, none_to_dict
 
 
 class Descriptors(FileNameMixin):
-    # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """
     Prepare and calculate MLIP descriptors for structures.
 

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -16,7 +16,6 @@ from janus_core.helpers.utils import FileNameMixin, none_to_dict, output_structs
 
 
 class EoS(FileNameMixin):
-    # pylint: disable=too-many-instance-attributes,too-few-public-methods
     """
     Prepare and calculate equation of state of a structure.
 
@@ -75,7 +74,7 @@ class EoS(FileNameMixin):
         Calculate equation of state.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-locals
+    def __init__(
         self,
         struct: Atoms,
         min_volume: float = 0.95,
@@ -268,7 +267,6 @@ class EoS(FileNameMixin):
 
     def _calc_volumes_energies(self) -> None:
         """Calculate volumes and energies for all lattice constants."""
-
         if self.logger:
             self.logger.info("Starting calculations for configurations")
             self.tracker.start_task("Calculate configurations")

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -275,7 +275,8 @@ class GeomOpt(FileNameMixin):
         if not converged:
             warnings.warn(
                 f"Optimization has not converged after {self.steps} steps. "
-                f"Current max force {max_force} > target force {self.fmax}"
+                f"Current max force {max_force} > target force {self.fmax}",
+                stacklevel=2,
             )
 
         # Write out optimized structure

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -21,7 +21,7 @@ from janus_core.helpers.utils import (
 )
 
 
-class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
+class GeomOpt(FileNameMixin):
     """
     Prepare and run geometry optimization.
 
@@ -78,7 +78,7 @@ class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         Run geometry optimization.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         struct: Atoms,
         fmax: float = 0.1,
@@ -204,7 +204,6 @@ class GeomOpt(FileNameMixin):  # pylint: disable=too-many-instance-attributes
 
     def set_optimizer(self) -> None:
         """Set optimizer for geometry optimization."""
-
         self._set_functions()
         if self.logger:
             self.logger.info("Using optimizer: %s", self.optimizer.__name__)

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -348,13 +348,19 @@ class MolecularDynamics(FileNameMixin):
         # Warn if attempting to rescale/minimize during dynamics
         # but equil_steps is too low
         if rescale_velocities and equil_steps < rescale_every:
-            warn("Velocities and angular momentum will not be reset during dynamics")
+            warn(
+                "Velocities and angular momentum will not be reset during dynamics",
+                stacklevel=2,
+            )
         if minimize and equil_steps < minimize_every:
-            warn("Geometry will not be minimized during dynamics")
+            warn("Geometry will not be minimized during dynamics", stacklevel=2)
 
         # Warn if attempting to remove rotation without resetting velocities
         if remove_rot and not rescale_velocities:
-            warn("Rotation will not be removed unless `rescale_velocities` is True")
+            warn(
+                "Rotation will not be removed unless `rescale_velocities` is True",
+                stacklevel=2,
+            )
 
         # Warn if mix of None and not None
         self.ramp_temp = (
@@ -371,7 +377,8 @@ class MolecularDynamics(FileNameMixin):
         ) and not self.ramp_temp:
             warn(
                 "`temp_start`, `temp_end` and `temp_step` must all be specified for "
-                "heating to run"
+                "heating to run",
+                stacklevel=2,
             )
 
         # Check validate start and end temperatures
@@ -655,7 +662,8 @@ class MolecularDynamics(FileNameMixin):
             warn(
                 "Post-processing arguments present, but no computation requested. "
                 "Please set either 'rdf_compute' or 'vaf_compute' "
-                "to do post-processing."
+                "to do post-processing.",
+                stacklevel=2,
             )
 
         data = read(self.traj_file, index=":")

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 """Run molecular dynamics simulations."""
 
 from collections.abc import Sequence
@@ -41,7 +40,7 @@ from janus_core.helpers.utils import FileNameMixin, none_to_dict, output_structs
 DENS_FACT = (units.m / 1.0e2) ** 3 / units.mol
 
 
-class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-attributes
+class MolecularDynamics(FileNameMixin):
     """
     Configure shared molecular dynamics simulation options.
 
@@ -152,7 +151,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         Get header string for molecular dynamics statistics.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
+    def __init__(
         self,
         struct: Atoms,
         ensemble: Optional[Ensembles] = None,
@@ -413,7 +412,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         self.offset = 0
         self.created_final_file = False
 
-        if "masses" not in self.struct.arrays.keys():
+        if "masses" not in self.struct.arrays:
             self.struct.set_masses()
 
         if self.seed:
@@ -476,7 +475,6 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         str
            Formatted temperature range if heating and target temp if running md.
         """
-
         temperature_prefix = ""
         if self.temp_start is not None and self.temp_end is not None:
             temperature_prefix += f"-T{self.temp_start}-T{self.temp_end}"
@@ -539,13 +537,11 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
         str
             Header for molecular dynamics statistics.
         """
-        stats_header = (
+        return (
             "# Step | Real Time [s] | Time [fs] | Epot/N [eV] | Ekin/N [eV] | "
             "T [K] | Etot/N [eV] | Density [g/cm^3] | Volume [A^3] | P [GPa] | "
             "Pxx [GPa] | Pyy [GPa] | Pzz [GPa] | Pyz [GPa] | Pxz [GPa] | Pxy [GPa]"
         )
-
-        return stats_header
 
     def get_stats(self) -> str:
         """
@@ -594,7 +590,7 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             density = 0.0
             pressure_tensor = np.zeros(6)
 
-        stats = (
+        return (
             f"{step:10d} {real_time.total_seconds():.3f} {time:13.2f} {e_pot:.8e} "
             f"{e_kin:.8e} {current_temp:.3f} {e_pot + e_kin:.8e} {density:.3f} "
             f"{volume:.8e} {pressure:.8e} {pressure_tensor[0]:.8e} "
@@ -602,8 +598,6 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             f"{pressure_tensor[3]:.8e} {pressure_tensor[4]:.8e} "
             f"{pressure_tensor[5]:.8e}"
         )
-
-        return stats
 
     def _write_stats_file(self) -> None:
         """Write molecular dynamics statistics."""
@@ -715,7 +709,6 @@ class MolecularDynamics(FileNameMixin):  # pylint: disable=too-many-instance-att
             compute_rdf(data, ana, filename=out_paths, **rdf_args)
 
         if self.post_process_kwargs.get("vaf_compute", False):
-
             file_name = self.post_process_kwargs.get("vaf_output_file", None)
             use_vel = self.post_process_kwargs.get("vaf_velocities", False)
             fft = self.post_process_kwargs.get("vaf_fft", False)
@@ -930,7 +923,7 @@ class NPT(MolecularDynamics):
             Additional keyword arguments.
         """
         self.pressure = pressure
-        super().__init__(ensemble=ensemble, file_prefix=file_prefix, *args, **kwargs)
+        super().__init__(*args, ensemble=ensemble, file_prefix=file_prefix, **kwargs)
 
         ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
         self.ttime = thermostat_time * units.fs
@@ -965,7 +958,6 @@ class NPT(MolecularDynamics):
         str
            Formatted temperature range if heating and target temp if running md.
         """
-
         pressure = f"-p{self.pressure}" if not isinstance(self, NVT_NH) else ""
         return f"{super()._parameter_prefix}{pressure}"
 
@@ -1061,7 +1053,7 @@ class NVT(MolecularDynamics):
         **kwargs
             Additional keyword arguments.
         """
-        super().__init__(ensemble=ensemble, *args, **kwargs)
+        super().__init__(*args, ensemble=ensemble, **kwargs)
 
         ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
         self.dyn = Langevin(
@@ -1141,7 +1133,7 @@ class NVE(MolecularDynamics):
         **kwargs
             Additional keyword arguments.
         """
-        super().__init__(ensemble=ensemble, *args, **kwargs)
+        super().__init__(*args, ensemble=ensemble, **kwargs)
         ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
 
         self.dyn = VelocityVerlet(
@@ -1152,7 +1144,7 @@ class NVE(MolecularDynamics):
         )
 
 
-class NVT_NH(NPT):  # pylint: disable=invalid-name
+class NVT_NH(NPT):  # noqa: N801 (invalid-class-name)
     """
     Configure NVT Nosé-Hoover simulation.
 
@@ -1196,11 +1188,11 @@ class NVT_NH(NPT):  # pylint: disable=invalid-name
         """
         ensemble_kwargs = ensemble_kwargs if ensemble_kwargs else {}
         super().__init__(
+            *args,
             ensemble=ensemble,
             thermostat_time=thermostat_time,
             barostat_time=None,
             ensemble_kwargs=ensemble_kwargs,
-            *args,
             **kwargs,
         )
 

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -20,7 +20,7 @@ from janus_core.helpers.log import config_logger, config_tracker
 from janus_core.helpers.utils import FileNameMixin, none_to_dict
 
 
-class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
+class Phonons(FileNameMixin):
     """
     Configure, perform phonon calculations and write out results.
 
@@ -104,7 +104,7 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         Run phonon calculations.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments,disable=too-many-locals
+    def __init__(
         self,
         struct: Atoms,
         calcs: MaybeSequence[PhononCalcs] = (),
@@ -254,7 +254,6 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
         value : MaybeSequence[PhononCalcs]
             Phonon calculations to be run.
         """
-
         if isinstance(value, str):
             value = (value,)
 
@@ -690,8 +689,8 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
             bplt.savefig(plot_file)
 
     # No magnetic moments considered
-    def _Phonopy_to_ASEAtoms(self, struct: PhonopyAtoms) -> Atoms:
-        # pylint: disable=invalid-name
+    # Disable invalid-function-name
+    def _Phonopy_to_ASEAtoms(self, struct: PhonopyAtoms) -> Atoms:  # noqa: N802
         """
         Convert Phonopy Atoms structure to ASE Atoms structure.
 
@@ -714,8 +713,8 @@ class Phonons(FileNameMixin):  # pylint: disable=too-many-instance-attributes
             calculator=self.calc,
         )
 
-    def _ASE_to_PhonopyAtoms(self, struct: Atoms) -> PhonopyAtoms:
-        # pylint: disable=invalid-name
+    # Disable invalid-function-name
+    def _ASE_to_PhonopyAtoms(self, struct: Atoms) -> PhonopyAtoms:  # noqa: N802
         """
         Convert ASE Atoms structure to Phonopy Atoms structure.
 

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -25,7 +25,7 @@ from janus_core.helpers.mlip_calculators import choose_calculator
 from janus_core.helpers.utils import FileNameMixin, none_to_dict, output_structs
 
 
-class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attributes
+class SinglePoint(FileNameMixin):
     """
     Prepare and perform single point calculations.
 
@@ -81,7 +81,7 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         Run single point calculations.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(
         self,
         struct: Optional[MaybeSequence[Atoms]] = None,
         struct_path: Optional[PathLike] = None,
@@ -250,7 +250,6 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
         value : MaybeSequence[Properties]
             Physical properties to be calculated.
         """
-
         if isinstance(value, str):
             value = (value,)
 
@@ -277,11 +276,9 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             Potential energy of structure(s).
         """
         if isinstance(self.struct, Sequence):
-            energies = [struct.get_potential_energy() for struct in self.struct]
-            return energies
+            return [struct.get_potential_energy() for struct in self.struct]
 
-        energy = self.struct.get_potential_energy()
-        return energy
+        return self.struct.get_potential_energy()
 
     def _get_forces(self) -> MaybeList[ndarray]:
         """
@@ -293,11 +290,9 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             Forces of structure(s).
         """
         if isinstance(self.struct, Sequence):
-            forces = [struct.get_forces() for struct in self.struct]
-            return forces
+            return [struct.get_forces() for struct in self.struct]
 
-        force = self.struct.get_forces()
-        return force
+        return self.struct.get_forces()
 
     def _get_stress(self) -> MaybeList[ndarray]:
         """
@@ -309,11 +304,9 @@ class SinglePoint(FileNameMixin):  # pylint: disable=too-many-instance-attribute
             Stress of structure(s).
         """
         if isinstance(self.struct, Sequence):
-            stresses = [struct.get_stress() for struct in self.struct]
-            return stresses
+            return [struct.get_stress() for struct in self.struct]
 
-        stress = self.struct.get_stress()
-        return stress
+        return self.struct.get_stress()
 
     def run(self) -> CalcResults:
         """

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -35,7 +35,6 @@ app = Typer()
 @app.command()
 @use_config(yaml_converter_callback)
 def descriptors(
-    # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -38,7 +38,6 @@ app = Typer()
 @app.command()
 @use_config(yaml_converter_callback)
 def eos(
-    # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,
@@ -143,7 +142,7 @@ def eos(
         [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs]
     )
 
-    if not eos_type in get_args(EoSNames):
+    if eos_type not in get_args(EoSNames):
         raise ValueError(f"Fit type must be one of: {get_args(EoSNames)}")
 
     # Read only first structure by default and ensure only one image is read

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -93,7 +93,6 @@ def _set_minimize_kwargs(
 @app.command()
 @use_config(yaml_converter_callback)
 def geomopt(
-    # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -40,7 +40,6 @@ app = Typer()
 @app.command()
 @use_config(yaml_converter_callback)
 def md(
-    # pylint: disable=too-many-arguments,too-many-locals,invalid-name,duplicate-code
     # numpydoc ignore=PR02
     ctx: Context,
     ensemble: Annotated[str, Option(help="Name of thermodynamic ensemble.")],
@@ -315,7 +314,7 @@ def md(
         ]
     )
 
-    if not ensemble in get_args(Ensembles):
+    if ensemble not in get_args(Ensembles):
         raise ValueError(f"ensemble must be in {get_args(Ensembles)}")
 
     # Read only first structure by default and ensure only one image is read

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -36,7 +36,6 @@ app = Typer()
 @app.command()
 @use_config(yaml_converter_callback)
 def phonons(
-    # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -34,7 +34,6 @@ app = Typer()
 @app.command()
 @use_config(yaml_converter_callback)
 def singlepoint(
-    # pylint: disable=too-many-arguments,too-many-locals,duplicate-code
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -28,7 +28,7 @@ def parse_dict_class(value: Union[str, ASEReadArgs]):
     return TyperDict(ast.literal_eval(value))
 
 
-class TyperDict:  #  pylint: disable=too-few-public-methods
+class TyperDict:
     """
     Custom dictionary for typer.
 
@@ -51,7 +51,7 @@ class TyperDict:  #  pylint: disable=too-few-public-methods
 
     def __str__(self):
         """
-        String representation of class.
+        Return string representation of class.
 
         Returns
         -------

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -145,7 +145,6 @@ def save_struct_calc(
 
     Parameters
     ----------
-
     inputs : dict
         Inputs dictionary to add information to.
     s_point : SinglePoint

--- a/janus_core/helpers/correlator.py
+++ b/janus_core/helpers/correlator.py
@@ -1,6 +1,4 @@
-"""
-Module to correlate scalar data on-the-fly.
-"""
+"""Module to correlate scalar data on-the-fly."""
 
 from collections.abc import Iterable
 from typing import Union
@@ -24,8 +22,6 @@ class Correlator:
     averaging : int
         Averaging window per block level.
     """
-
-    # pylint: disable=too-many-instance-attributes
 
     def __init__(self, *, blocks: int, points: int, averaging: int):
         """
@@ -54,7 +50,6 @@ class Correlator:
         self._correlation = np.zeros((self._blocks, self._points))
         self._count_correlated = np.zeros((self._blocks, self._points), dtype=int)
 
-    # pylint: disable=invalid-name
     def update(self, a: float, b: float):
         """
         Update the correlation, <ab>, with new values a and b.
@@ -68,7 +63,6 @@ class Correlator:
         """
         self._propagate(a, b, 0)
 
-    # pylint: disable=invalid-name
     def _propagate(self, a: float, b: float, block: int):
         """
         Propagate update down block hierarchy.
@@ -127,7 +121,7 @@ class Correlator:
 
     def _shifts_valid(self, block: int, p_i: int, p_j: int) -> bool:
         """
-        True if the shift registers have data.
+        Return True if the shift registers have data.
 
         Parameters
         ----------
@@ -200,7 +194,6 @@ class Correlation:
         Frequency to update the correlation, md steps.
     """
 
-    # pylint: disable=invalid-name, too-many-instance-attributes
     def __init__(
         self,
         a: Union[Observable, tuple[Observable, tuple, dict]],
@@ -288,7 +281,7 @@ class Correlation:
 
     def __str__(self) -> str:
         """
-        String representation of correlation.
+        Return string representation of correlation.
 
         Returns
         -------

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -84,7 +84,6 @@ class PostProcessKwargs(TypedDict, total=False):
     vaf_output_file: Optional[PathLike]
 
 
-# pylint: disable=too-few-public-methods
 @runtime_checkable
 class Observable(Protocol):
     """Signature for correlation observable getter."""

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -64,7 +64,6 @@ def _set_model_path(
 
 
 def choose_calculator(
-    # pylint: disable=too-many-locals, too-many-statements
     arch: Architectures = "mace",
     device: Devices = "cpu",
     model_path: Optional[PathLike] = None,
@@ -96,13 +95,9 @@ def choose_calculator(
     ValueError
         Invalid architecture specified.
     """
-    # pylint: disable=import-outside-toplevel, too-many-branches, import-error
-    # Optional imports handled via `arch`. We could catch these,
-    # but the error message is clear if imports are missing.
-
     model_path = _set_model_path(model_path, kwargs)
 
-    if not device in get_args(Devices):
+    if device not in get_args(Devices):
         raise ValueError(f"`device` must be one of: {get_args(Devices)}")
 
     if arch == "mace":
@@ -207,7 +202,8 @@ def choose_calculator(
         calculator = AlignnAtomwiseCalculator(path=path, device=device, **kwargs)
 
     elif arch == "sevennet":
-        from sevenn._const import SEVENN_VERSION as __version__
+        # Disable constant-imported-as-non-constant
+        from sevenn._const import SEVENN_VERSION as __version__  # noqa: N811
         from sevenn.sevennet_calculator import SevenNetCalculator
 
         if isinstance(model_path, Path):

--- a/janus_core/helpers/observables.py
+++ b/janus_core/helpers/observables.py
@@ -1,11 +1,8 @@
-"""
-Module for built-in correlation observables.
-"""
+"""Module for built-in correlation observables."""
 
 from ase import Atoms, units
 
 
-# pylint: disable=too-few-public-methods
 class Stress:
     """
     Observable for stress components.

--- a/janus_core/helpers/post_process.py
+++ b/janus_core/helpers/post_process.py
@@ -32,7 +32,6 @@ def _process_index(index: SliceLike) -> StartStopStep:
     StartStopStep
         Standardized `SliceLike` as `start`, `stop`, `step` triplet.
     """
-
     if isinstance(index, int):
         if index == -1:
             return (index, None, 1)
@@ -44,7 +43,7 @@ def _process_index(index: SliceLike) -> StartStopStep:
     return index
 
 
-def compute_rdf(  # pylint: disable=too-many-locals,too-many-branches
+def compute_rdf(
     data: MaybeSequence[Atoms],
     ana: Optional[Analysis] = None,
     /,
@@ -219,7 +218,6 @@ def compute_vaf(
     MaybeSequence[NDArray[float64]]
         Computed VAF(s).
     """
-
     # Ensure if passed scalars they are turned into correct dimensionality
     if not isinstance(filter_atoms, Sequence):
         filter_atoms = (filter_atoms,)

--- a/janus_core/helpers/stats.py
+++ b/janus_core/helpers/stats.py
@@ -1,6 +1,4 @@
-"""
-Module that reads the md stats output timeseries.
-"""
+"""Module that reads the md stats output timeseries."""
 
 from collections.abc import Iterator
 from functools import singledispatchmethod
@@ -30,8 +28,6 @@ class Stats:
         File that contains the stats of a molecular dynamics simulation.
     """
 
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(self, source: PathLike) -> None:
         """
         Initialise MD stats reader.
@@ -41,7 +37,6 @@ class Stats:
         source : PathLike
             File that contains the stats of a molecular dynamics simulation.
         """
-
         self._data = zeros((0, 0))
         self._labels = ()
         self._units = ()
@@ -211,9 +206,7 @@ class Stats:
         return zip(self.labels, self.units)
 
     def read(self) -> None:
-        """
-        Read MD stats and store them in `data`.
-        """
+        """Read MD stats and store them in `data`."""
         self._data = genfromtxt(self.source, skip_header=1)
         with open(self.source, "r+", encoding="utf-8") as file:
             head = file.readline().split("|")
@@ -231,7 +224,6 @@ class Stats:
         str
            Summary of the `data`.
         """
-
         header = f"contains {self.columns} timeseries, each with {self.rows} elements"
         header += "\nindex label units"
         for index, (label, unit) in enumerate(self.data_tags):

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -19,7 +19,7 @@ from janus_core.helpers.janus_types import (
 )
 
 
-class FileNameMixin(ABC):
+class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-method)
     """
     Provide mixin functions for standard filename handling.
 

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -19,7 +19,7 @@ from janus_core.helpers.janus_types import (
 )
 
 
-class FileNameMixin(ABC):  # pylint: disable=too-few-public-methods
+class FileNameMixin(ABC):
     """
     Provide mixin functions for standard filename handling.
 
@@ -471,7 +471,6 @@ def _dump_ascii(
     --------
     write_table : Main entry function.
     """
-
     print(f"# {' | '.join(header)}", file=file)
 
     for cols in zip(*columns.values()):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ codecarbon = "^2.5.0"
 alignn = { version = "2024.5.27", optional = true }
 sevenn = { version = "0.9.3", optional = true }
 torch_geometric = { version = "^2.5.3", optional = true }
+ruff = "^0.5.6"
 
 [tool.poetry.extras]
 alignnff = ["alignn"]
@@ -61,9 +62,8 @@ wheel = "^0.42"
 [tool.poetry.group.pre-commit]
 optional = true
 [tool.poetry.group.pre-commit.dependencies]
-black = "^24.1.1"
 pre-commit = "^3.6.0"
-pylint = "^2.15.10"
+ruff = "^0.5.6"
 
 [tool.poetry.group.docs]
 optional = true
@@ -80,15 +80,6 @@ sphinx-copybutton = "^0.5.2"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
-line-length = 88
-
-[tool.pylint.format]
-max-line-length = 88
-max-args = 10
-good-names = ["e", "i", "j", "k"]
-min-similarity-lines=9
-
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)
 python_files = "test_*.py"
@@ -100,11 +91,41 @@ pythonpath = ["."]
 # reporting which lines of your plugin are covered by tests
 source=["janus_core"]
 
-[tool.isort]
-# Configuration of [isort](https://isort.readthedocs.io)
-line_length = 88
-force_sort_within_sections = true
-sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
+[tool.ruff]
+exclude = ["conf.py"]
+target-version = "py39"
+
+[tool.ruff.lint]
+# Ignore complexity
+ignore = ["C901"]
+select = [
+    # pylint
+    "C", "R",
+    # pydocstyle
+    "D",
+    # pycodestyle
+    "E", "W",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "I",
+    # pep8-naming
+    "N",
+    # isort
+    "UP",
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.pylint]
+max-args = 10
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = false
 
 [tool.numpydoc_validation]
 # report on all checks, except the below

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ codecarbon = "^2.5.0"
 alignn = { version = "2024.5.27", optional = true }
 sevenn = { version = "0.9.3", optional = true }
 torch_geometric = { version = "^2.5.3", optional = true }
-ruff = "^0.5.6"
+ruff = "^0.5.7"
 
 [tool.poetry.extras]
 alignnff = ["alignn"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,8 @@ target-version = "py39"
 # Ignore complexity
 ignore = ["C901"]
 select = [
+    # flake8-bugbear
+    "B",
     # pylint
     "C", "R",
     # pydocstyle

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -1,4 +1,4 @@
-"""Test the Correlator"""
+"""Test the Correlator."""
 
 from collections.abc import Iterable
 from pathlib import Path
@@ -21,13 +21,10 @@ MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"
 runner = CliRunner()
 
 
-# pylint: disable=invalid-name
 def correlate(
     x: Iterable[float], y: Iterable[float], *, fft: bool = True
 ) -> Iterable[float]:
-    """
-    Direct correlation of x and y. If fft uses np.correlate in full mode.
-    """
+    """Direct correlation of x and y. If fft uses np.correlate in full mode."""
     n = min(len(x), len(y))
     if fft:
         cor = np.correlate(x, y, "full")
@@ -42,7 +39,7 @@ def correlate(
 
 
 def test_setup():
-    """Test initial values"""
+    """Test initial values."""
     cor = Correlator(blocks=1, points=100, averaging=2)
     correlation, lags = cor.get()
     assert len(correlation) == len(lags)
@@ -50,7 +47,7 @@ def test_setup():
 
 
 def test_correlation():
-    """Test Correlator against np.correlate"""
+    """Test Correlator against np.correlate."""
     points = 100
     cor = Correlator(blocks=1, points=points, averaging=1)
     signal = np.exp(-np.linspace(0.0, 1.0, points))
@@ -67,7 +64,6 @@ def test_correlation():
     assert fft == approx(correlation, rel=1e-10)
 
 
-# pylint: disable=too-many-locals
 def test_md_correlations(tmp_path):
     """Test correlations as part of MD cycle."""
     file_prefix = tmp_path / "Cl4Na4-nve-T300.0"
@@ -80,9 +76,8 @@ def test_md_correlations(tmp_path):
         calc_kwargs={"model": MODEL_PATH},
     )
 
-    # pylint: disable=unused-argument
     def user_observable_a(atoms: Atoms, kappa, **kwargs) -> float:
-        """User specified getter for correlation"""
+        """User specified getter for correlation."""
         return (
             kwargs["gamma"]
             * kappa

--- a/tests/test_filenamemixin.py
+++ b/tests/test_filenamemixin.py
@@ -11,13 +11,11 @@ DATA_PATH = Path(__file__).parent / "data"
 STRUCT = read(DATA_PATH / "benzene.xyz")
 
 
-class DummyFileHandler(FileNameMixin):  # pylint: disable=too-few-public-methods
+class DummyFileHandler(FileNameMixin):
     """Used for testing FileNameMixin methods."""
 
     def build_filename(self, *args, **kwargs):
-        """
-        Expose _build_filename publicly.
-        """
+        """Expose _build_filename publicly."""
         return self._build_filename(*args, **kwargs)
 
 

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -225,7 +225,6 @@ def test_restart(tmp_path):
 
 def test_space_group():
     """Test spacegroup of the structure."""
-
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl-sg.cif",
         arch="mace_mp",

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -15,10 +15,6 @@ DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
 
-# Many pylint now warnings raised due to similar log/summary flags
-# These depend on tmp_path, so not easily refactorisable
-# pylint: disable=duplicate-code
-
 
 def test_help():
     """Test calling `janus geomopt --help`."""
@@ -109,7 +105,7 @@ def test_traj(tmp_path):
 
 
 def test_opt_fully(tmp_path):
-    """Test passing --opt-cell-fully without --opt-cell-lengths"""
+    """Test passing --opt-cell-fully without --opt-cell-lengths."""
     results_path = tmp_path / "NaCl-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -266,7 +266,7 @@ def test_restart(tmp_path):
         assert " | Target T [K]" in lines[0]
         # Includes step 0, and step 4 from restart
         assert len(lines) == 10
-        assert 8 == int(lines[-1].split()[0])
+        assert int(lines[-1].split()[0]) == 8
 
     traj = read(traj_path, index=":")
     assert all(isinstance(image, Atoms) for image in traj)
@@ -548,7 +548,6 @@ def test_atoms_struct(tmp_path):
 
 def test_heating(tmp_path):
     """Test heating with no MD."""
-    # pylint: disable=invalid-name
     file_prefix = tmp_path / "NaCl-heating"
     final_file = tmp_path / "NaCl-heating-final.extxyz"
     log_file = tmp_path / "nvt.log"
@@ -699,8 +698,7 @@ def test_heating_files():
 
 
 def test_heating_md_files():
-    """Test default heating files when also running md"""
-
+    """Test default heating files when also running md."""
     traj_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz")
     stats_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
     final_path = Path("Cl4Na4-nvt-T10-T20-T25.0-final.extxyz")
@@ -779,7 +777,6 @@ def test_ramp_negative(tmp_path):
 
 def test_cooling(tmp_path):
     """Test cooling with no MD."""
-    # pylint: disable=invalid-name
     file_prefix = tmp_path / "NaCl-cooling"
     final_path = tmp_path / "NaCl-cooling-final.extxyz"
     stats_cooling_path = tmp_path / "NaCl-cooling-stats.dat"

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -16,10 +16,6 @@ DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
 
-# Many pylint now warnings raised due to similar log/summary flags
-# These depend on tmp_path, so not easily refactorisable
-# pylint: disable=duplicate-code
-
 
 def test_md_help():
     """Test calling `janus md --help`."""

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -13,10 +13,6 @@ DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
 
-# Many pylint now warnings raised due to similar log/summary flags
-# These depend on tmp_path, so not easily refactorisable
-# pylint: disable=duplicate-code
-
 
 def test_help():
     """Test calling `janus phonons --help`."""
@@ -77,7 +73,7 @@ def test_bands_simple(tmp_path):
     assert autoband_results.exists()
     with open(autoband_results, encoding="utf8") as file:
         bands = yaml.safe_load(file)
-    assert "eigenvector" not in bands["phonon"][0]["band"][0].keys()
+    assert "eigenvector" not in bands["phonon"][0]["band"][0]
 
     # Read phonons summary file
     assert summary_path.exists()
@@ -190,7 +186,7 @@ def test_pdos(tmp_path):
 
 
 def test_plot(tmp_path):
-    """Test for ploting routines"""
+    """Test for ploting routines."""
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
     pdos_results = tmp_path / "NaCl-pdos.dat"
@@ -232,8 +228,8 @@ def test_plot(tmp_path):
     assert autoband_results.exists()
     with open(autoband_results, encoding="utf8") as file:
         bands = yaml.safe_load(file)
-    assert "eigenvector" in bands["phonon"][0]["band"][0].keys()
-    assert "group_velocity" in bands["phonon"][0]["band"][0].keys()
+    assert "eigenvector" in bands["phonon"][0]["band"][0]
+    assert "group_velocity" in bands["phonon"][0]["band"][0]
 
     # Read phonons summary file
     assert summary_path.exists()

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -109,7 +109,7 @@ def test_md_pp_cli(tmp_path):
 
 
 def test_rdf():
-    """Test computation of RDF"""
+    """Test computation of RDF."""
     data = read(DATA_PATH / "benzene.xyz")
     rdf = post_process.compute_rdf(data, index=0, rmax=5.0, nbins=100)
 
@@ -135,7 +135,7 @@ def test_rdf():
 
 
 def test_rdf_by_elements():
-    """Test the by_elements method of compute rdf"""
+    """Test the by_elements method of compute rdf."""
     data = read(DATA_PATH / "benzene.xyz")
 
     rdfs = post_process.compute_rdf(
@@ -173,7 +173,7 @@ def test_rdf_by_elements():
 
 
 def test_vaf():
-    """Test vaf will run"""
+    """Test vaf will run."""
     data = read(DATA_PATH / "lj-traj.xyz", index=":")
     vaf = post_process.compute_vaf(data)
 

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -14,10 +14,6 @@ DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
 
-# Many pylint warnings now raised due to similar log/summary flags
-# These depend on tmp_path, so not easily refactorisable
-# pylint: disable=duplicate-code
-
 
 def test_singlepoint_help():
     """Test calling `janus singlepoint --help`."""

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 import shutil
 
-from mace.cli.run_train import run as run_train  # pylint: disable=unused-import
 from typer.testing import CliRunner
 import yaml
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,10 +77,7 @@ def test_output_structs(
     struct = read(DATA_PATH)
     struct.calc = choose_calculator(arch=arch)
 
-    if not properties:
-        results_keys = set(get_args(Properties))
-    else:
-        results_keys = set(properties)
+    results_keys = set(get_args(Properties)) if not properties else set(properties)
     label_keys = {f"{arch}_{key}" for key in results_keys}
 
     write_kwargs = {}


### PR DESCRIPTION
Resolves #233

- Replaces black, pylint, pyupgrade and isort with ruff
- Keeps numpydoc since, although ruff does some `numpy` checks, I don't think it covers everything that the sphinx addon does

There's not a direct correspondence between every rule we had and the new set, but generally black is covered by the formatter, and pylint, pyupgrade and isort are covered by the linter.

We could consider adding flake8-bugbear ("B"), since this does some checks that pylint picked up on previously that I'm not sure the current set up checks.

Full rulesets available here: https://docs.astral.sh/ruff/rules/