### PR TITLE
Update MLIP installations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
     - name: Install python dependencies
       run: |
         poetry env use ${{ matrix.python-version }}
-        poetry install --with dev --extras "chgnet m3gnet"
+        poetry install --with dev --extras "all"
 
     - name: Run test suite
       env:
         # show timings of tests
         PYTEST_ADDOPTS: "--durations=0"
-      run: poetry run pytest --cov janus_core --cov-append .
+      run: poetry run pytest --run-extra-mlips --cov janus_core --cov-append .
 
     - name: Report coverage to Coveralls
       uses: coverallsapp/github-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       run: |
         poetry env use ${{ matrix.python-version }}
-        poetry install --with dev --extras "all"
+        poetry install --with dev --extras all
 
     - name: Run test suite
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install python dependencies
       run: |
         poetry env use ${{ matrix.python-version }}
-        poetry install --with dev
+        poetry install --with dev --extras "chgnet m3gnet"
 
     - name: Run test suite
       env:
@@ -95,7 +95,7 @@ jobs:
     - name: Install python dependencies
       run: |
         poetry env use 3.11
-        poetry install --with pre-commit,docs,dev
+        poetry install --with pre-commit,docs,dev --extras "chgnet m3gnet"
 
     - name: Run pre-commit
       run: |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ or to install all supported MLIPs:
 python3 -m pip install janus-core[all]
 ```
 
+Individual `extras` are listed in [Getting Started](https://stfc.github.io/janus-core/getting_started/getting_started.html#installation), as well as in [pyproject.toml](pyproject.toml) under `[tool.poetry.extras]`.
+
 
 ### Further help
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Tools for machine learnt interatomic potentials
 
 - Python >= 3.9
 - ASE >= 3.23
-- chgnet = 0.3.8
 - mace-torch = 0.3.6
-- matgl = 1.1.2
+- chgnet = 0.3.8 (optional)
+- matgl = 1.1.3 (optional)
 - sevenn = 0.9.3 (optional)
 - alignn = 2024.5.27 (optional)
 
@@ -44,6 +44,20 @@ To get all the latest changes, `janus-core` can also be installed from GitHub:
 
 ```
 python3 -m pip install git+https://github.com/stfc/janus-core.git
+```
+
+By default, MACE is the only MLIP installed.
+
+Other MLIPs can be installed as `extras`. For example, to install CHGNet and M3GNet, run:
+
+```python
+python3 -m pip install janus-core[chgnet,m3gnet]
+```
+
+or to install all supported MLIPs:
+
+```python
+python3 -m pip install janus-core[all]
 ```
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -14,12 +14,6 @@ def pytest_addoption(parser):
         default=False,
         help="Test additional MLIPs",
     )
-    parser.addoption(
-        "--run-slow",
-        action="store_true",
-        default=False,
-        help="Run slow tests",
-    )
 
 
 def pytest_configure(config):
@@ -27,18 +21,14 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "extra_mlips: mark test as containing extra MLIPs"
     )
-    config.addinivalue_line("markers", "slow: mark test as slow")
 
 
 def pytest_collection_modifyitems(config, items):
     """Skip tests if marker applied to unit tests."""
-    if config.getoption("--run-extra-mlips") or config.getoption("--run-slow"):
-        # --run-extra-mlips or --run-slow given in cli: do not skip tests
+    if config.getoption("--run-extra-mlips"):
+        # --run-extra-mlips given in cli: do not skip tests
         return
     skip_extra_mlips = pytest.mark.skip(reason="need --run-extra-mlips option to run")
-    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
     for item in items:
         if "extra_mlips" in item.keywords:
             item.add_marker(skip_extra_mlips)
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)

--- a/docs/source/developer_guide/get_started.rst
+++ b/docs/source/developer_guide/get_started.rst
@@ -30,7 +30,7 @@ Packages in the ``dev`` dependency group allow tests to be run locally using ``p
 
 Alternatively, tests can be run in separate virtual environments using ``tox``::
 
-    tox run -e all
+    tox run -e ALL
 
 This will run all unit tests for multiple versions of Python, in addition to testing that the pre-commit passes, and that documentation builds, mirroring the automated tests on GitHub.
 

--- a/docs/source/developer_guide/get_started.rst
+++ b/docs/source/developer_guide/get_started.rst
@@ -18,7 +18,7 @@ Dependencies useful for development can then be installed by running::
 
 Extras, such as optional MLIPs, can also be installed by running::
 
-    poetry install --with pre-commit,dev,docs --extras "alignnff sevennet"
+    poetry install --with pre-commit,dev,docs --extras "alignn sevennet"
 
 or to install all supported MLIPs::
 

--- a/docs/source/developer_guide/get_started.rst
+++ b/docs/source/developer_guide/get_started.rst
@@ -20,6 +20,10 @@ Extras, such as optional MLIPs, can also be installed by running::
 
     poetry install --with pre-commit,dev,docs --extras "alignnff sevennet"
 
+or to install all supported MLIPs::
+
+    poetry install --with pre-commit,dev,docs --extras all
+
 
 Running unit tests
 ++++++++++++++++++

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -14,7 +14,7 @@ The following steps can then be taken, using `ALIGNN-FF <https://github.com/usni
 
 Dependencies for ``janus-core`` are specified through a ``pyproject.toml`` file, with syntax defined by `poetry's dependency specification <https://python-poetry.org/docs/dependency-specification/>`_.
 
-New MLIPs should initially be added as optional dependencies under ``[tool.poetry.dependencies]``, and added as an ``extra`` under ``[tool.poetry.extras]``::
+New MLIPs should be added as optional dependencies under ``[tool.poetry.dependencies]``, and added as an ``extra`` under ``[tool.poetry.extras]``::
 
     [tool.poetry.dependencies]
     alignn = { version = "2024.5.27", optional = true }
@@ -37,6 +37,11 @@ Extra dependencies can then be installed by running:
     poetry lock
     poetry install --extras "alignnff sevennet"
 
+or, for all extras:
+
+.. code-block:: bash
+
+    poetry install --extras all
 
 
 2. Register MLIP architecture

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -22,7 +22,7 @@ New MLIPs should be added as optional dependencies under ``[tool.poetry.dependen
     torch_geometric = { version = "^2.5.3", optional = true }
 
     [tool.poetry.extras]
-    alignnff = ["alignn"]
+    alignn = ["alignn"]
     sevennet = ["sevenn", "torch_geometric"]
 
 Poetry will automatically resolve dependencies of the MLIP, if present, to ensure consistency with existing dependencies.
@@ -35,7 +35,7 @@ Extra dependencies can then be installed by running:
 .. code-block:: bash
 
     poetry lock
-    poetry install --extras "alignnff sevennet"
+    poetry install --extras "alignn sevennet"
 
 or, for all extras:
 

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -49,3 +49,12 @@ or to install all supported MLIPs:
 .. code-block:: python
 
     python3 -m pip install janus-core[all]
+
+Currently supported extras are:
+
+- ``alignn``: `ALIGNN <https://github.com/usnistgov/alignn>`_
+- ``chgnet``: `CHGNet <https://github.com/CederGroupHub/chgnet/>`_
+- ``m3gnet``: `M3GNet <https://github.com/materialsvirtuallab/matgl/>`_
+- ``sevenn``: `SevenNet <https://github.com/MDIL-SNU/SevenNet/>`_
+
+``extras`` are also listed in `pyproject.toml <https://github.com/stfc/janus-core/blob/main/pyproject.toml>`_ under ``[tool.poetry.extras]``.

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -9,9 +9,9 @@ Dependencies
 
 - Python >= 3.9
 - ASE >= 3.23
-- chgnet = 0.3.8
 - mace-torch = 0.3.6
-- matgl = 1.1.2
+- chgnet = 0.3.8 (optional)
+- matgl = 1.1.3 (optional)
 - sevenn = 0.9.3 (optional)
 - alignn = 2024.5.27 (optional)
 
@@ -35,3 +35,17 @@ To get all the latest changes, ``janus-core`` can also be installed from GitHub:
 .. code-block:: bash
 
     python3 -m pip install git+https://github.com/stfc/janus-core.git
+
+By default, MACE is the only MLIP installed.
+
+Other MLIPs can be installed as ``extras``. For example, to install CHGNet and M3GNet, run:
+
+.. code-block:: python
+
+    python3 -m pip install janus-core[chgnet,m3gnet]
+
+or to install all supported MLIPs:
+
+.. code-block:: python
+
+    python3 -m pip install janus-core[all]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ ruff = "^0.5.7"
 
 [tool.poetry.extras]
 all = ["alignn", "chgnet", "matgl", "dgl", "torchdata", "sevenn", "torch_geometric"]
-alignnff = ["alignn"]
+alignn = ["alignn"]
 chgnet = ["chgnet"]
 m3gnet = ["matgl", "dgl", "torchdata"]
 sevennet = ["sevenn", "torch_geometric"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,29 +26,34 @@ documentation = "https://stfc.github.io/janus-core/"
 janus = "janus_core.cli.janus:app"
 
 [tool.poetry.dependencies]
-python = "^3.9"
 ase = "^3.23"
-chgnet = "0.3.8"
-dgl = "2.1.0" # Pin due to matgl installation issues
+codecarbon = "^2.5.0"
 mace-torch = "0.3.6"
-matgl = "1.1.2"
 numpy = "^1.26.4"
-pyyaml = "^6.0.1"
-typer = "^0.9.0"
-typer-config = "^1.4.0"
 phonopy = "^2.23.1"
+python = "^3.9"
+pyyaml = "^6.0.1"
 seekpath = "^1.9.7"
 spglib = "^2.3.0"
-torchdata = "0.7.1" # Pin due to dgl issue
+torch = ">= 2.1, <= 2.2" # Range required for dgl
 torch-dftd = "0.4.0"
-codecarbon = "^2.5.0"
+typer = "^0.9.0"
+typer-config = "^1.4.0"
+
 alignn = { version = "2024.5.27", optional = true }
+chgnet = {version = "0.3.8", optional = true}
+dgl = { version = "2.1.0", optional = true } # Pin due to matgl installation issues
+matgl = { version = "1.1.3", optional = true}
 sevenn = { version = "0.9.3", optional = true }
+torchdata = {version = "0.7.1", optional = true} # Pin due to dgl issue
 torch_geometric = { version = "^2.5.3", optional = true }
 ruff = "^0.5.7"
 
 [tool.poetry.extras]
+all = ["alignn", "chgnet", "matgl", "dgl", "torchdata", "sevenn", "torch_geometric"]
 alignnff = ["alignn"]
+chgnet = ["chgnet"]
+m3gnet = ["matgl", "dgl", "torchdata"]
 sevennet = ["sevenn", "torch_geometric"]
 
 [tool.poetry.group.dev.dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,8 @@ usedevelop=True
 [testenv:py{39,310,311,312}]
 description = Run the test suite against Python versions
 allowlist_externals = poetry
-commands_pre = poetry install --no-root --sync --extras "chgnet m3gnet"
-commands = poetry run pytest {posargs} --cov janus_core --import-mode importlib
+commands_pre = poetry install --no-root --sync --extras "all"
+commands = poetry run pytest {posargs} --run-extra-mlips --cov janus_core --import-mode importlib
 
 [testenv:pre-commit]
 description = Run the pre-commit checks

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,3 @@ description = Build the documentation
 allowlist_externals = poetry, echo
 commands_pre = poetry install --no-root --sync
 commands = poetry run sphinx-build -nW --keep-going -b html {posargs} docs/source docs/build/html
-
-[testenv:extra-mlips]
-description = Run the additional tests suite against Python versions
-allowlist_externals = poetry
-commands_pre = poetry install --no-root --sync --extras "all"
-commands = poetry run pytest {posargs} --run-extra-mlips --run-slow --cov janus_core --import-mode importlib

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ usedevelop=True
 [testenv:py{39,310,311,312}]
 description = Run the test suite against Python versions
 allowlist_externals = poetry
-commands_pre = poetry install --no-root --sync
+commands_pre = poetry install --no-root --sync --extras "chgnet m3gnet"
 commands = poetry run pytest {posargs} --cov janus_core --import-mode importlib
 
 [testenv:pre-commit]
@@ -25,5 +25,5 @@ commands = poetry run sphinx-build -nW --keep-going -b html {posargs} docs/sourc
 [testenv:extra-mlips]
 description = Run the additional tests suite against Python versions
 allowlist_externals = poetry
-commands_pre = poetry install --no-root --sync --with extra-mlips
+commands_pre = poetry install --no-root --sync --extras "all"
 commands = poetry run pytest {posargs} --run-extra-mlips --run-slow --cov janus_core --import-mode importlib

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ usedevelop=True
 [testenv:py{39,310,311,312}]
 description = Run the test suite against Python versions
 allowlist_externals = poetry
-commands_pre = poetry install --no-root --sync --extras "all"
+commands_pre = poetry install --no-root --sync --extras all
 commands = poetry run pytest {posargs} --run-extra-mlips --cov janus_core --import-mode importlib
 
 [testenv:pre-commit]


### PR DESCRIPTION
Resolves #255

Moves chgnet and m3gnet to optional dependencies again, but still tests against these in the CI/with tox.

I need to double check all the installation mechanisms, but this should mean pip/poetry install janus-core should only install MACE, and with extras we can install each MLIP individually, or install all together.

To do:

- [x] Update docs to reflect these changes (probably after #227 is merged)
- [x] Test against all MLIPs