### PR TITLE
Fix write params

### DIFF
--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -239,8 +239,8 @@ def results_to_info(
     if not properties:
         properties = get_args(Properties)
 
-    if struct.calc:
-        # Set default architecture from calculator name
+    # Only add to info if MLIP calculator with "arch" parameter set
+    if struct.calc and "arch" in struct.calc.parameters:
         arch = struct.calc.parameters["arch"]
         struct.info["arch"] = arch
 

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -93,8 +93,8 @@ def test_traj_reformat(tmp_path):
     """Test saving optimization trajectory in different format."""
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
-        arch="mace",
-        calc_kwargs={"model": MODEL_PATH},
+        arch="mace_mp",
+        calc_kwargs={"model": MODEL_PATH, "dispersion": True},
     )
 
     traj_path_binary = tmp_path / "NaCl.traj"


### PR DESCRIPTION
Resolves #261

Adds check that `arch` in is `calc.parameters` before attempting to write MLIP architecture to info, and tests this.

The test uses the `arch=mace_mp` , rather than `mace`, as setting dispersion for `mace` does not create the same `SumCalculator`, which is the root of the bug. See: https://github.com/ACEsuit/mace/blob/main/mace/calculators/foundations_models.py#L132

The individual MLIP calculators (e.g. `mace.calculators.mace.MACECalculator`) have a `todict` method, which writes the parameters when writing a trajectory format, but this method does not exist for the `SumCalculator`, which is why the error only occurs in certain situations, such as adding dispersion to `mace_mp`, before writing and reading back in the trajectory binary file.