### PR TITLE
Optimisation of CLI startup time

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ import janus_core
 extensions = [
     "numpydoc",
     "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Optional, get_args
 
 from ase import Atoms
-from ase.io import read
 from numpy import ndarray
 
 from janus_core.helpers.janus_types import (
@@ -203,6 +202,8 @@ class SinglePoint(FileNameMixin):
         If the file contains multiple structures, only the last configuration
         will be read by default.
         """
+        from ase.io import read
+
         if not self.struct_path:
             raise ValueError("`struct_path` must be defined")
 

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -110,13 +110,6 @@ def descriptors(
     from janus_core.calculations.single_point import SinglePoint
     from janus_core.helpers.utils import dict_paths_to_strs
 
-    from janus_core.cli.utils import (
-        check_config,
-        end_summary,
-        parse_typer_dicts,
-        save_struct_calc,
-        start_summary,
-    )
 
     # Check options from configuration file are all valid
     check_config(ctx)

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -6,8 +6,6 @@ from typing import Annotated
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.descriptors import Descriptors
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -28,7 +26,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -109,6 +106,18 @@ def descriptors(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.descriptors import Descriptors
+    from janus_core.calculations.single_point import SinglePoint
+    from janus_core.helpers.utils import dict_paths_to_strs
+
+    from janus_core.cli.utils import (
+        check_config,
+        end_summary,
+        parse_typer_dicts,
+        save_struct_calc,
+        start_summary,
+    )
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -110,7 +110,6 @@ def descriptors(
     from janus_core.calculations.single_point import SinglePoint
     from janus_core.helpers.utils import dict_paths_to_strs
 
-
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -6,8 +6,6 @@ from typing import Annotated, Optional, get_args
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.eos import EoS
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -30,8 +28,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.janus_types import EoSNames
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -136,6 +132,11 @@ def eos(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.eos import EoS
+    from janus_core.calculations.single_point import SinglePoint
+    from janus_core.helpers.janus_types import EoSNames
+    from janus_core.helpers.utils import dict_paths_to_strs
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -6,8 +6,6 @@ from typing import Annotated, Any, Optional
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.geom_opt import GeomOpt
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -30,7 +28,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -210,6 +207,10 @@ def geomopt(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.geom_opt import GeomOpt
+    from janus_core.calculations.single_point import SinglePoint
+    from janus_core.helpers.utils import dict_paths_to_strs
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/janus.py
+++ b/janus_core/cli/janus.py
@@ -4,7 +4,6 @@ from typing import Annotated
 
 from typer import Exit, Option, Typer
 
-from janus_core import __version__
 from janus_core.cli.descriptors import descriptors
 from janus_core.cli.eos import eos
 from janus_core.cli.geomopt import geomopt
@@ -41,6 +40,8 @@ def print_version(
     version : bool
         Whether to print the current janus-core version.
     """
+    from janus_core import __version__
+
     if version:
         print(f"janus-core version: {__version__}")
         raise Exit()

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -6,8 +6,6 @@ from typing import Annotated, Optional, get_args
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_NH
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -32,8 +30,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.janus_types import Ensembles
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -294,6 +290,11 @@ def md(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_NH
+    from janus_core.calculations.single_point import SinglePoint
+    from janus_core.helpers.janus_types import Ensembles
+    from janus_core.helpers.utils import dict_paths_to_strs
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -6,8 +6,6 @@ from typing import Annotated, Optional
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.phonons import Phonons
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -29,7 +27,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -196,6 +193,10 @@ def phonons(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.phonons import Phonons
+    from janus_core.calculations.single_point import SinglePoint
+    from janus_core.helpers.utils import dict_paths_to_strs
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -6,7 +6,6 @@ from typing import Annotated
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -27,7 +26,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -101,6 +99,8 @@ def singlepoint(
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.helpers.utils import dict_paths_to_strs
+
     # Check options from configuration file are all valid
     check_config(ctx)
 
@@ -130,6 +130,7 @@ def singlepoint(
     }
 
     # Initialise singlepoint structure and calculator
+    from janus_core.calculations.single_point import SinglePoint
     s_point = SinglePoint(**singlepoint_kwargs)
 
     # Store inputs for yaml summary

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -131,6 +131,7 @@ def singlepoint(
 
     # Initialise singlepoint structure and calculator
     from janus_core.calculations.single_point import SinglePoint
+
     s_point = SinglePoint(**singlepoint_kwargs)
 
     # Store inputs for yaml summary

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -6,10 +6,8 @@ from typing import Annotated
 from typer import Option, Typer
 import yaml
 
-from janus_core.cli.utils import carbon_summary, end_summary, start_summary
-from janus_core.helpers.train import train as run_train
-
 from janus_core.cli.types import LogPath, Summary
+from janus_core.cli.utils import carbon_summary, end_summary, start_summary
 
 app = Typer()
 

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -1,7 +1,7 @@
 """Set up MLIP training commandline interface."""
 
 from pathlib import Path
-from typing import Annotated, TYPE_CHECKING
+from typing import Annotated
 
 from typer import Option, Typer
 import yaml
@@ -22,8 +22,8 @@ def train(
     fine_tune: Annotated[
         bool, Option(help="Whether to fine-tune a foundational model.")
     ] = False,
-    log: "LogPath" = "train.log",
-    summary: "Summary" = "train_summary.yml",
+    log: LogPath = "train.log",
+    summary: Summary = "train_summary.yml",
 ):
     """
     Run training for MLIP by passing a configuration file to the MLIP's CLI.

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -1,14 +1,16 @@
 """Set up MLIP training commandline interface."""
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, TYPE_CHECKING
 
 from typer import Option, Typer
 import yaml
 
-from janus_core.cli.types import LogPath, Summary
 from janus_core.cli.utils import carbon_summary, end_summary, start_summary
 from janus_core.helpers.train import train as run_train
+
+if TYPE_CHECKING:
+    from janus_core.cli.types import LogPath, Summary
 
 app = Typer()
 
@@ -39,6 +41,8 @@ def train(
         Path to save summary of inputs and start/end time. Default is
         train_summary.yml.
     """
+    from janus_core.helpers.train import train as run_train
+
     with open(mlip_config, encoding="utf8") as config_file:
         config = yaml.safe_load(config_file)
 

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -9,8 +9,7 @@ import yaml
 from janus_core.cli.utils import carbon_summary, end_summary, start_summary
 from janus_core.helpers.train import train as run_train
 
-if TYPE_CHECKING:
-    from janus_core.cli.types import LogPath, Summary
+from janus_core.cli.types import LogPath, Summary
 
 app = Typer()
 
@@ -23,8 +22,8 @@ def train(
     fine_tune: Annotated[
         bool, Option(help="Whether to fine-tune a foundational model.")
     ] = False,
-    log: LogPath = "train.log",
-    summary: Summary = "train_summary.yml",
+    log: "LogPath" = "train.log",
+    summary: "Summary" = "train_summary.yml",
 ):
     """
     Run training for MLIP by passing a configuration file to the MLIP's CLI.

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -6,10 +6,10 @@ from typing import Annotated, Union
 
 from typer import Option
 
-from janus_core.helpers.janus_types import ASEReadArgs
+#type: from janus_core.helpers.janus_types import ASEReadArgs
 
 
-def parse_dict_class(value: Union[str, ASEReadArgs]):
+def parse_dict_class(value: Union[str, "ASEReadArgs"]):
     """
     Convert string input into a dictionary.
 

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -2,11 +2,13 @@
 
 import ast
 from pathlib import Path
-from typing import Annotated, Union
+from typing import Annotated, TYPE_CHECKING, Union
 
 from typer import Option
 
-#type: from janus_core.helpers.janus_types import ASEReadArgs
+
+if TYPE_CHECKING:
+    from janus_core.helpers.janus_types import ASEReadArgs
 
 
 def parse_dict_class(value: Union[str, "ASEReadArgs"]):

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -2,10 +2,9 @@
 
 import ast
 from pathlib import Path
-from typing import Annotated, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Annotated, Union
 
 from typer import Option
-
 
 if TYPE_CHECKING:
     from janus_core.helpers.janus_types import ASEReadArgs

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -6,15 +6,11 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from ase import Atoms
 from typer import Context
-from typer_config import conf_callback_factory, yaml_loader
-import yaml
+from typer_config import conf_callback_factory
 
-from janus_core.calculations.single_point import SinglePoint
-from janus_core.cli.types import TyperDict
-from janus_core.helpers.janus_types import Architectures, ASEReadArgs, Devices
-from janus_core.helpers.utils import dict_remove_hyphens
+#type: from janus_core.cli.types import TyperDict
+#type: from janus_core.helpers.janus_types import Architectures, ASEReadArgs, Devices
 
 
 def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
@@ -37,7 +33,7 @@ def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
         raise ValueError("`read_kwargs['index']` must be an integer") from e
 
 
-def parse_typer_dicts(typer_dicts: list[TyperDict]) -> list[dict]:
+def parse_typer_dicts(typer_dicts: list["TyperDict"]) -> list[dict]:
     """
     Convert list of TyperDict objects to list of dictionaries.
 
@@ -80,6 +76,11 @@ def yaml_converter_loader(config_file: str) -> dict[str, Any]:
     dict[str, Any]
         Dictionary with loaded configuration.
     """
+    from typer_config import yaml_loader
+
+    from janus_core.helpers.utils import dict_remove_hyphens
+
+
     if not config_file:
         return {}
 
@@ -104,6 +105,8 @@ def start_summary(*, command: str, summary: Path, inputs: dict) -> None:
     inputs : dict
         Inputs to CLI command to save.
     """
+    import yaml
+
     save_info = {
         "command": f"janus {command}",
         "start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S"),
@@ -157,11 +160,11 @@ def end_summary(summary: Path) -> None:
 
 def save_struct_calc(
     inputs: dict,
-    s_point: SinglePoint,
-    arch: Architectures,
-    device: Devices,
+    s_point: "janus_core.calculations.single_point.SinglePoint",
+    arch: "Architectures",
+    device: "Devices",
     model_path: str,
-    read_kwargs: ASEReadArgs,
+    read_kwargs: "ASEReadArgs",
     calc_kwargs: dict[str, Any],
 ) -> None:
     """
@@ -184,6 +187,8 @@ def save_struct_calc(
     calc_kwargs : dict[str, Any]]
         Keyword arguments to pass to the calculator.
     """
+    from ase import Atoms
+
     # Remove duplicate struct if already in inputs:
     inputs.pop("struct", None)
 

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
         Architectures,
         ASEReadArgs,
         Devices,
-        SinglePoint
     )
+    from janus_core.calculations.single_point import SinglePoint
 
 
 def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -5,16 +5,22 @@ from __future__ import annotations
 from collections.abc import Sequence
 import datetime
 import logging
-from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
-from typer import Context
 from typer_config import conf_callback_factory
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+    from typer import Context
+
     from janus_core.cli.types import TyperDict
-    from janus_core.helpers.janus_types import Architectures, ASEReadArgs, Devices, SinglePoint
+    from janus_core.helpers.janus_types import (
+        Architectures,
+        ASEReadArgs,
+        Devices,
+        SinglePoint
+    )
 
 
 def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -90,7 +90,6 @@ def yaml_converter_loader(config_file: str) -> dict[str, Any]:
 
     from janus_core.helpers.utils import dict_remove_hyphens
 
-
     if not config_file:
         return {}
 

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -131,6 +131,8 @@ def carbon_summary(*, summary: Path, log: Path) -> None:
     log : Path
         Path to log file with carbon emissions saved.
     """
+    import yaml
+
     with open(log, encoding="utf8") as file:
         logs = yaml.safe_load(file)
 

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -1,16 +1,20 @@
 """Utility functions for CLI."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import datetime
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from typer import Context
 from typer_config import conf_callback_factory
 
-#type: from janus_core.cli.types import TyperDict
-#type: from janus_core.helpers.janus_types import Architectures, ASEReadArgs, Devices
+
+if TYPE_CHECKING:
+    from janus_core.cli.types import TyperDict
+    from janus_core.helpers.janus_types import Architectures, ASEReadArgs, Devices, SinglePoint
 
 
 def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
@@ -149,6 +153,8 @@ def end_summary(summary: Path) -> None:
     summary : Path
         Path to summary file being saved.
     """
+    import yaml
+
     with open(summary, "a", encoding="utf8") as outfile:
         yaml.dump(
             {"end_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S")},
@@ -160,11 +166,11 @@ def end_summary(summary: Path) -> None:
 
 def save_struct_calc(
     inputs: dict,
-    s_point: "janus_core.calculations.single_point.SinglePoint",
-    arch: "Architectures",
-    device: "Devices",
+    s_point: SinglePoint,
+    arch: Architectures,
+    device: Devices,
     model_path: str,
-    read_kwargs: "ASEReadArgs",
+    read_kwargs: ASEReadArgs,
     calc_kwargs: dict[str, Any],
 ) -> None:
     """

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -5,22 +5,22 @@ from __future__ import annotations
 from collections.abc import Sequence
 import datetime
 import logging
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from typer_config import conf_callback_factory
 
-
 if TYPE_CHECKING:
     from pathlib import Path
+
     from typer import Context
 
+    from janus_core.calculations.single_point import SinglePoint
     from janus_core.cli.types import TyperDict
     from janus_core.helpers.janus_types import (
         Architectures,
         ASEReadArgs,
         Devices,
     )
-    from janus_core.calculations.single_point import SinglePoint
 
 
 def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
@@ -43,7 +43,7 @@ def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
         raise ValueError("`read_kwargs['index']` must be an integer") from e
 
 
-def parse_typer_dicts(typer_dicts: list["TyperDict"]) -> list[dict]:
+def parse_typer_dicts(typer_dicts: list[TyperDict]) -> list[dict]:
     """
     Convert list of TyperDict objects to list of dictionaries.
 

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -1,5 +1,7 @@
 """Module containing types used in Janus-Core."""
 
+from __future__ import annotations
+
 from collections.abc import Collection, Sequence
 from enum import Enum
 import logging
@@ -9,15 +11,18 @@ from typing import (
     Literal,
     Optional,
     Protocol,
+    TYPE_CHECKING,
     TypedDict,
     TypeVar,
     Union,
     runtime_checkable,
 )
 
-#type: from ase import Atoms
-#type: import numpy as np
-#type: from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from ase import Atoms
+    from numpy import float64 as np_float64
+    from numpy.typing import NDArray
 
 # General
 
@@ -167,8 +172,8 @@ class CalcResults(TypedDict, total=False):
     """Return type from calculations."""
 
     energy: MaybeList[float]
-    forces: MaybeList["NDArray[np.float64]"]
-    stress: MaybeList["NDArray[np.float64]"]
+    forces: MaybeList[NDArray[np_float64]]
+    stress: MaybeList[NDArray[np_float64]]
 
 
 class EoSResults(TypedDict, total=False):

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -8,16 +8,15 @@ import logging
 from pathlib import Path, PurePath
 from typing import (
     IO,
+    TYPE_CHECKING,
     Literal,
     Optional,
     Protocol,
-    TYPE_CHECKING,
     TypedDict,
     TypeVar,
     Union,
     runtime_checkable,
 )
-
 
 if TYPE_CHECKING:
     from ase import Atoms
@@ -178,6 +177,7 @@ class CalcResults(TypedDict, total=False):
 
 class EoSResults(TypedDict, total=False):
     """Return type from calculations."""
+
     from ase.eos import EquationOfState
 
     eos: EquationOfState

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -50,7 +50,7 @@ class ASEWriteArgs(TypedDict, total=False):
     """Main arguments for ase.io.write."""
 
     filename: Union[str, PurePath, IO]
-    images: MaybeSequence["Atoms"]
+    images: MaybeSequence[Atoms]
     format: Optional[str]
     parallel: bool
     append: bool
@@ -92,7 +92,7 @@ class PostProcessKwargs(TypedDict, total=False):
 class Observable(Protocol):
     """Signature for correlation observable getter."""
 
-    def __call__(self, atoms: "ase.Atoms", *args, **kwargs) -> float:
+    def __call__(self, atoms: Atoms, *args, **kwargs) -> float:
         """
         Call the getter.
 

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -15,10 +15,9 @@ from typing import (
     runtime_checkable,
 )
 
-from ase import Atoms
-from ase.eos import EquationOfState
-import numpy as np
-from numpy.typing import NDArray
+#type: from ase import Atoms
+#type: import numpy as np
+#type: from numpy.typing import NDArray
 
 # General
 
@@ -46,7 +45,7 @@ class ASEWriteArgs(TypedDict, total=False):
     """Main arguments for ase.io.write."""
 
     filename: Union[str, PurePath, IO]
-    images: MaybeSequence[Atoms]
+    images: MaybeSequence["Atoms"]
     format: Optional[str]
     parallel: bool
     append: bool
@@ -88,7 +87,7 @@ class PostProcessKwargs(TypedDict, total=False):
 class Observable(Protocol):
     """Signature for correlation observable getter."""
 
-    def __call__(self, atoms: Atoms, *args, **kwargs) -> float:
+    def __call__(self, atoms: "ase.Atoms", *args, **kwargs) -> float:
         """
         Call the getter.
 
@@ -168,12 +167,13 @@ class CalcResults(TypedDict, total=False):
     """Return type from calculations."""
 
     energy: MaybeList[float]
-    forces: MaybeList[NDArray[np.float64]]
-    stress: MaybeList[NDArray[np.float64]]
+    forces: MaybeList["NDArray[np.float64]"]
+    stress: MaybeList["NDArray[np.float64]"]
 
 
 class EoSResults(TypedDict, total=False):
     """Return type from calculations."""
+    from ase.eos import EquationOfState
 
     eos: EquationOfState
     bulk_modulus: float

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -9,16 +9,13 @@ Similar in spirit to matcalc and quacc approaches
 from pathlib import Path
 from typing import Any, Optional, Union, get_args
 
-from ase.calculators.calculator import Calculator
-import torch
-
 from janus_core.helpers.janus_types import Architectures, Devices, PathLike
 
 
 def _set_model_path(
     model_path: Optional[PathLike] = None,
     kwargs: Optional[dict[str, Any]] = None,
-) -> Optional[Union[PathLike, torch.nn.Module]]:
+) -> Optional[Union[PathLike, "torch.nn.Module"]]:
     """
     Set `model_path`.
 
@@ -68,7 +65,7 @@ def choose_calculator(
     device: Devices = "cpu",
     model_path: Optional[PathLike] = None,
     **kwargs,
-) -> Calculator:
+) -> "ase.calculators.Calculator":
     """
     Choose MLIP calculator to configure.
 
@@ -136,6 +133,8 @@ def choose_calculator(
         calculator = mace_off(model=model, device=device, **kwargs)
 
     elif arch == "m3gnet":
+        import torch
+
         from matgl import __version__, load_model
         from matgl.apps.pes import Potential
         from matgl.ext.ase import M3GNetCalculator

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -9,13 +9,13 @@ Similar in spirit to matcalc and quacc approaches
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Union, get_args, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, Union, get_args
 
 from janus_core.helpers.janus_types import Architectures, Devices, PathLike
 
 if TYPE_CHECKING:
-    import torch.nn
     from ase.calculators.calculator import Calculator
+    import torch.nn
 
 def _set_model_path(
     model_path: Optional[PathLike] = None,

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -14,9 +14,8 @@ from typing import Any, Optional, Union, get_args, TYPE_CHECKING
 from janus_core.helpers.janus_types import Architectures, Devices, PathLike
 
 if TYPE_CHECKING:
-    from ase.calculators import Calculator
     import torch.nn
-
+    from ase.calculators.calculator import Calculator
 
 def _set_model_path(
     model_path: Optional[PathLike] = None,

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -6,16 +6,22 @@ Similar in spirit to matcalc and quacc approaches
 - https://github.com/Quantum-Accelerators/quacc.git
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any, Optional, Union, get_args
+from typing import Any, Optional, Union, get_args, TYPE_CHECKING
 
 from janus_core.helpers.janus_types import Architectures, Devices, PathLike
+
+if TYPE_CHECKING:
+    from ase.calculators import Calculator
+    import torch.nn
 
 
 def _set_model_path(
     model_path: Optional[PathLike] = None,
     kwargs: Optional[dict[str, Any]] = None,
-) -> Optional[Union[PathLike, "torch.nn.Module"]]:
+) -> Optional[Union[PathLike, torch.nn.Module]]:
     """
     Set `model_path`.
 
@@ -65,7 +71,7 @@ def choose_calculator(
     device: Devices = "cpu",
     model_path: Optional[PathLike] = None,
     **kwargs,
-) -> "ase.calculators.Calculator":
+) -> Calculator:
     """
     Choose MLIP calculator to configure.
 
@@ -133,11 +139,10 @@ def choose_calculator(
         calculator = mace_off(model=model, device=device, **kwargs)
 
     elif arch == "m3gnet":
-        import torch
-
         from matgl import __version__, load_model
         from matgl.apps.pes import Potential
         from matgl.ext.ase import M3GNetCalculator
+        import torch
 
         # Set before loading model to avoid type mismatches
         torch.set_default_dtype(torch.float32)
@@ -162,6 +167,7 @@ def choose_calculator(
         from chgnet import __version__
         from chgnet.model.dynamics import CHGNetCalculator
         from chgnet.model.model import CHGNet
+        import torch
 
         # Set before loading to avoid type mismatches
         torch.set_default_dtype(torch.float32)

--- a/janus_core/helpers/train.py
+++ b/janus_core/helpers/train.py
@@ -3,11 +3,6 @@
 from pathlib import Path
 from typing import Any, Optional
 
-try:
-    from mace.cli.run_train import run as run_train
-except ImportError as e:
-    raise NotImplementedError("Please update MACE to use this module.") from e
-from mace.tools import build_default_arg_parser as mace_parser
 import yaml
 
 from janus_core.helpers.janus_types import PathLike
@@ -62,6 +57,12 @@ def train(
     tracker_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_tracker`. Default is {}.
     """
+    from mace.tools import build_default_arg_parser as mace_parser
+    try:
+        from mace.cli.run_train import run as run_train
+    except ImportError as e:
+        raise NotImplementedError("Please update MACE to use this module.") from e
+
     (log_kwargs, tracker_kwargs) = none_to_dict((log_kwargs, tracker_kwargs))
 
     if req_file_keys is None:

--- a/janus_core/helpers/train.py
+++ b/janus_core/helpers/train.py
@@ -58,6 +58,7 @@ def train(
         Keyword arguments to pass to `config_tracker`. Default is {}.
     """
     from mace.tools import build_default_arg_parser as mace_parser
+
     try:
         from mace.cli.run_train import run as run_train
     except ImportError as e:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -6,9 +6,6 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Literal, Optional, TextIO, get_args
 
-from ase import Atoms
-from ase.io import write
-from ase.io.formats import filetype
 from spglib import get_spacegroup
 
 from janus_core.helpers.janus_types import (
@@ -44,7 +41,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
     def __init__(
         self,
-        struct: MaybeSequence[Atoms],
+        struct: MaybeSequence["ase.Atoms"],
         file_prefix: Optional[PathLike],
         *additional,
     ):
@@ -67,7 +64,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
     @staticmethod
     def _get_default_prefix(
-        file_prefix: Optional[PathLike], struct: MaybeSequence[Atoms], *additional
+        file_prefix: Optional[PathLike], struct: MaybeSequence["ase.Atoms"], *additional
     ) -> str:
         """
         Determine the default prefix from the structure  or provided file_prefix.
@@ -132,7 +129,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
 
 def spacegroup(
-    struct: Atoms, sym_tolerance: float = 0.001, angle_tolerance: float = -1.0
+    struct: "ase.Atoms", sym_tolerance: float = 0.001, angle_tolerance: float = -1.0
 ) -> str:
     """
     Determine the spacegroup for a structure.
@@ -218,7 +215,7 @@ def dict_remove_hyphens(dictionary: dict) -> dict:
 
 
 def results_to_info(
-    struct: Atoms,
+    struct: "ase.Atoms",
     *,
     properties: Collection[Properties] = (),
     invalidate_calc: bool = False,
@@ -258,7 +255,7 @@ def results_to_info(
 
 
 def output_structs(
-    images: MaybeSequence[Atoms],
+    images: MaybeSequence["ase.Atoms"],
     *,
     set_info: bool = True,
     write_results: bool = False,
@@ -285,6 +282,10 @@ def output_structs(
     write_kwargs : Optional[ASEWriteArgs]
         Keyword arguments passed to ase.io.write. Default is {}.
     """
+    from ase import Atoms
+    from ase.io import write
+    from ase.io.formats import filetype
+
     # Separate kwargs for output_structs from kwargs for ase.io.write
     # This assumes values passed via kwargs have priority over passed parameters
     write_kwargs = write_kwargs if write_kwargs else {}

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -1,19 +1,24 @@
 """Utility functions for janus_core."""
 
+from __future__ import annotations
+
 from abc import ABC
 from collections.abc import Collection, Generator, Iterable, Sequence
 from io import StringIO
 from pathlib import Path
-from typing import Any, Literal, Optional, TextIO, get_args
+from typing import Any, get_args, Literal, Optional, TextIO, TYPE_CHECKING
 
 from spglib import get_spacegroup
 
-from janus_core.helpers.janus_types import (
-    ASEWriteArgs,
-    MaybeSequence,
-    PathLike,
-    Properties,
-)
+if TYPE_CHECKING:
+    from ase import Atoms
+
+    from janus_core.helpers.janus_types import (
+        ASEWriteArgs,
+        MaybeSequence,
+        PathLike,
+        Properties,
+    )
 
 
 class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-method)
@@ -41,7 +46,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
     def __init__(
         self,
-        struct: MaybeSequence["ase.Atoms"],
+        struct: MaybeSequence[Atoms],
         file_prefix: Optional[PathLike],
         *additional,
     ):
@@ -64,7 +69,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
     @staticmethod
     def _get_default_prefix(
-        file_prefix: Optional[PathLike], struct: MaybeSequence["ase.Atoms"], *additional
+        file_prefix: Optional[PathLike], struct: MaybeSequence[Atoms], *additional
     ) -> str:
         """
         Determine the default prefix from the structure  or provided file_prefix.
@@ -129,7 +134,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
 
 def spacegroup(
-    struct: "ase.Atoms", sym_tolerance: float = 0.001, angle_tolerance: float = -1.0
+    struct: Atoms, sym_tolerance: float = 0.001, angle_tolerance: float = -1.0
 ) -> str:
     """
     Determine the spacegroup for a structure.
@@ -215,7 +220,7 @@ def dict_remove_hyphens(dictionary: dict) -> dict:
 
 
 def results_to_info(
-    struct: "ase.Atoms",
+    struct: Atoms,
     *,
     properties: Collection[Properties] = (),
     invalidate_calc: bool = False,
@@ -233,6 +238,8 @@ def results_to_info(
         Whether to remove all calculator results after copying properties to info dict.
         Default is False.
     """
+    from janus_core.helpers.janus_types import Properties
+
     if not properties:
         properties = get_args(Properties)
 
@@ -255,7 +262,7 @@ def results_to_info(
 
 
 def output_structs(
-    images: MaybeSequence["ase.Atoms"],
+    images: MaybeSequence[Atoms],
     *,
     set_info: bool = True,
     write_results: bool = False,

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -6,7 +6,7 @@ from abc import ABC
 from collections.abc import Collection, Generator, Iterable, Sequence
 from io import StringIO
 from pathlib import Path
-from typing import Any, get_args, Literal, Optional, TextIO, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, Optional, TextIO, get_args
 
 from spglib import get_spacegroup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ sphinx = "^7.2.6"
 sphinxcontrib-contentui = "^0.2.5"
 sphinxcontrib-details-directive = "^0.1"
 sphinx-copybutton = "^0.5.2"
+sphinx-autodoc-typehints = "^2.2.3"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Fixes #267 

Had to do some nasty things here to get rid of the import overheads, but this seems to get the CLI to just-about-tolerable responsiveness. Lets see what can be done to keep this performance without hurting maintainability.

A fair bit of the remaining overhead could be `typer` itself 🤷 

If you would like to join in, my workhorse command for profiling data was

```
PYTHONPROFILEIMPORTTIME=1 janus --help 2> import_perf.log
```