### PR TITLE
Auto write results

### DIFF
--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -226,6 +226,8 @@ class Phonons(FileNameMixin):
             opt_file = self._build_filename("opt.extxyz")
             if "write_kwargs" in self.minimize_kwargs:
                 self.minimize_kwargs["write_kwargs"].setdefault("filename", opt_file)
+                # Assume if write_kwargs are specified that results should be written
+                self.minimize_kwargs.setdefault("write_results", True)
             else:
                 self.minimize_kwargs["write_kwargs"] = {"filename": opt_file}
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -584,3 +584,95 @@ def test_invalid_traj_input(tmp_path):
     )
     assert result.exit_code == 1
     assert isinstance(result.exception, ValueError)
+
+
+def test_minimize_kwargs_filename(tmp_path):
+    """Test passing filename via minimize kwargs to MD."""
+    file_prefix = tmp_path / "md"
+    opt_path = tmp_path / "test.extxyz"
+    traj_path = tmp_path / "md-traj.extxyz"
+    stats_path = tmp_path / "md-stats.dat"
+    final_path = tmp_path / "md-final.extxyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+
+    result = runner.invoke(
+        app,
+        [
+            "md",
+            "--ensemble",
+            "nvt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--file-prefix",
+            file_prefix,
+            "--steps",
+            2,
+            "--traj-every",
+            1,
+            "--stats-every",
+            1,
+            "--minimize",
+            "--minimize-kwargs",
+            f"{{'write_kwargs': {{'filename': '{opt_path}'}}}}",
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+
+    assert opt_path.exists()
+    assert traj_path.exists()
+    assert stats_path.exists()
+    assert final_path.exists()
+
+    atoms = read(opt_path)
+    assert isinstance(atoms, Atoms)
+
+
+def test_minimize_kwargs_write_results(tmp_path):
+    """Test passing write_results via minimize kwargs to MD."""
+    file_prefix = tmp_path / "md"
+    opt_path = tmp_path / "md-opt.extxyz"
+    traj_path = tmp_path / "md-traj.extxyz"
+    stats_path = tmp_path / "md-stats.dat"
+    final_path = tmp_path / "md-final.extxyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+
+    result = runner.invoke(
+        app,
+        [
+            "md",
+            "--ensemble",
+            "nvt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--file-prefix",
+            file_prefix,
+            "--steps",
+            2,
+            "--traj-every",
+            1,
+            "--stats-every",
+            1,
+            "--minimize",
+            "--minimize-kwargs",
+            "{'write_results': True}",
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+
+    assert opt_path.exists()
+    assert traj_path.exists()
+    assert stats_path.exists()
+    assert final_path.exists()
+
+    atoms = read(opt_path)
+    assert isinstance(atoms, Atoms)

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -354,10 +354,8 @@ def test_minimize_filename(tmp_path):
     file_prefix = tmp_path / "test"
     opt_path = tmp_path / "geomopt-opt.extxyz"
 
-    minimize_kwargs = (
-        "{'write_results': 'True', "
-        f"'write_kwargs': {{'filename': '{str(opt_path)}'}}}}"
-    )
+    # write_results should be set automatically
+    minimize_kwargs = f"{{'write_kwargs': {{'filename': '{str(opt_path)}'}}}}"
 
     result = runner.invoke(
         app,


### PR DESCRIPTION
Resolves #273

- Sets `write_results=True` in `minimize_kwargs` for MD and phonon calculations by default
- Also sets default filename for MD, mirroring existing phonon functionality (ensures -opt file prefix matches other MD output files by default)
- This isn't needed for EoS, since we have a separate `write_structures` option that is more general than writing the optimized structure, but performs the same roll

Also moves setting the MD logger filename for consistency 