### PR TITLE
Set consistent log and summary file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@ Options:
   --write-kwargs DICT  Keyword arguments to pass to ase.io.write when saving
                        results. Must be passed as a dictionary wrapped in
                        quotes, e.g. "{'key' : value}".  [default: "{}"]
-  --log PATH           Path to save logs to.  [default: singlepoint.log]
-  --summary PATH       Path to save summary of inputs and start/end time.
-                       [default: singlepoint_summary.yml]
+  --log PATH           Path to save logs to. Default is inferred from the name
+                       of the structure file.
+  --summary PATH       Path to save summary of inputs, start/end time, and
+                       carbon emissions. Default is inferred from the name of
+                       the structure file.
   --config TEXT        Configuration file.
   --help               Show this message and exit.
 ```

--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -75,9 +75,11 @@ prints the following:
       --write-kwargs DICT  Keyword arguments to pass to ase.io.write when saving
                            results. Must be passed as a dictionary wrapped in
                            quotes, e.g. "{'key' : value}".  [default: "{}"]
-      --log PATH           Path to save logs to.  [default: singlepoint.log]
-      --summary PATH       Path to save summary of inputs and start/end time.
-                           [default: singlepoint_summary.yml]
+      --log PATH           Path to save logs to. Default is inferred from the name
+                           of the structure file.
+      --summary PATH       Path to save summary of inputs, start/end time, and
+                           carbon emissions. Default is inferred from the name of
+                           the structure file.
       --config TEXT        Configuration file.
       --help               Show this message and exit.
 
@@ -92,7 +94,7 @@ Perform a single point calcuation (using the `MACE-MP <https://github.com/ACEsui
     janus singlepoint --struct tests/data/NaCl.cif --arch mace_mp --model-path small
 
 
-This will calculate the energy, stress and forces and save this in ``NaCl-results.extxyz``, in addition to generating a log file, ``singlepoint.log``, and summary of inputs, ``singlepoint_summary.yml``.
+This will calculate the energy, stress and forces and save this in ``NaCl-results.extxyz``, in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
 
 Additional options may be specified. For example:
 
@@ -127,7 +129,7 @@ Perform geometry optimization (using the `MACE-MP <https://github.com/ACEsuit/ma
     janus geomopt --struct tests/data/H2O.cif --arch mace_mp --model-path small
 
 
-This will optimize the atomic positions and save the resulting structure in ``H2O-opt.extxyz``, in addition to generating a log file, ``geomopt.log``, and summary of inputs, ``geomopt_summary.yml``.
+This will optimize the atomic positions and save the resulting structure in ``H2O-opt.extxyz``, in addition to generating a log file, ``H20-log.yml``, and summary of inputs, ``H20-summary.yml``.
 
 Additional options may be specified. This shares most options with ``singlepoint``, as well as a few additional options, such as:
 
@@ -166,8 +168,8 @@ This will generate several output files:
 - The structure trajectory every 100 steps, written to ``NaCl-npt-T300.0-p1.0-traj.extxyz``
 - The structure to be able to restart the dynamics every 1000 steps, written to ``NaCl-npt-T300.0-p1.0-res-1000.extxyz``
 - The final structure written to ``NaCl-npt-T300.0-p1.0-final.extxyz``
-- A log of the processes carried out, written to ``md.log``
-- A summary of the inputs and start/end time, written to ``md_summary.yml``.
+- A log of the processes carried out, written to ``NaCl-npt-T300.0-p1.0-log.yml``
+- A summary of the inputs and start/end time, written to ``NaCl-npt-T300.0-p1.0-summary.yml``.
 
 Additional options may be specified. For example:
 
@@ -176,7 +178,8 @@ Additional options may be specified. For example:
     janus md --ensemble nvt --struct tests/data/NaCl.cif --steps 1000 --timestep 0.5 --temp 300 --minimize --minimize-every 100 --rescale-velocities --remove-rot --rescale-every 100 --equil-steps 200
 
 
-This performs an NVT molecular dynamics simulation at 300K for 1000 steps (0.5 ps), including performing geometry optimization, rescaling velocities, and removing rotation, both before beginning dynamics and at steps 100 and 200 of the simulation.
+This performs an NVT molecular dynamics simulation at 300K for 1000 steps (0.5 ps), including performing geometry optimization, rescaling velocities, and removing rotation,
+both before beginning dynamics and at steps 100 and 200 of the simulation.
 
 
 .. code-block:: bash
@@ -184,7 +187,8 @@ This performs an NVT molecular dynamics simulation at 300K for 1000 steps (0.5 p
     janus md --ensemble nve --struct tests/data/NaCl.cif --steps 200 --temp 300 --traj-start 100 --traj-every 10 --traj-file "example-trajectory.extxyz" --stats-every 10 --stats-file "example-statistics.dat"
 
 
-This performs an NVE molecular dynamics simulation at 300K for 200 steps (0.2 ps), saving the trajectory every 10 steps after the first 100, and the thermodynamical statistics every 10 steps, as well as changing the output file names for both.
+This performs an NVE molecular dynamics simulation at 300K for 200 steps (0.2 ps), saving the trajectory every 10 steps after the first 100, and the thermodynamical statistics every 10 steps,
+as well as changing the output file names for both.
 
 
 For all options, run ``janus md --help``.
@@ -217,7 +221,8 @@ MD can also be carried out after heating using the same options as described in 
 
 This performs the same initial heating, before running a further 1000 steps (1 ps) at 300K.
 
-When MD is run with heating, the final, trajectory, and statistics files (``NaCl-nvt-T20.0-T300.0-T300.0-final.extxyz``, ``NaCl-nvt-T20.0-T300.0-T300.0-traj.extxyz``, and ``NaCl-nvt-T20.0-T300.0-T300.0-stats.dat``) indicate the heating range and MD temperature, which can differ. Each file contains data from both the heating and MD parts of the simulation.
+When MD is run with heating, the final, trajectory, and statistics files (``NaCl-nvt-T20.0-T300.0-T300.0-final.extxyz``, ``NaCl-nvt-T20.0-T300.0-T300.0-traj.extxyz``, and ``NaCl-nvt-T20.0-T300.0-T300.0-stats.dat``)
+indicate the heating range and MD temperature, which can differ. Each file contains data from both the heating and MD parts of the simulation.
 
 Additional settings for geometry optimization, such as enabling optimization of cell vectors by setting ``hydrostatic_strain = True`` for the ASE filter, can be set using the ``--minimize-kwargs`` option:
 
@@ -236,9 +241,11 @@ Fit the equation of state for a structure (using the `MACE-MP <https://github.co
     janus eos --struct tests/data/NaCl.cif --no-minimize --min-volume 0.9 --max-volume 1.1 --n-volumes 9 --arch mace_mp --model-path small
 
 
-This will save the energies and volumes for nine lattice constants in ``NaCl-eos-raw.dat``, and the fitted minimum energy, volume, and bulk modulus in ``NaCl-eos-fit.dat``, in addition to generating a log file, ``eos.log``, and summary of inputs, ``eos_summary.yml``.
+This will save the energies and volumes for nine lattice constants in ``NaCl-eos-raw.dat``, and the fitted minimum energy, volume, and bulk modulus in ``NaCl-eos-fit.dat``,
+in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
 
-By default, geometry optimization will be performed on the initial structure, before calculations are performed for the range of lattice constants consistent with minimum and maximum volumes supplied. Optimization at constant volume for all generated structures can also be performed (sharing the same maximum force convergence):
+By default, geometry optimization will be performed on the initial structure, before calculations are performed for the range of lattice constants consistent with minimum and maximum volumes supplied.
+Optimization at constant volume for all generated structures can also be performed (sharing the same maximum force convergence):
 
 .. code-block:: bash
 
@@ -258,7 +265,8 @@ Calculate phonons with a 2x2x2 supercell, after geometry optimization (using the
     janus phonons --struct tests/data/NaCl.cif --supercell 2x2x2 --minimize --arch mace_mp --model-path small
 
 
-This will save the Phonopy parameters, including displacements and force constants, to ``NaCl-phonopy.yml`` and ``NaCl-force_constants.hdf5``, in addition to generating a log file, ``phonons.log``, and summary of inputs, ``phonons_summary.yml``.
+This will save the Phonopy parameters, including displacements and force constants, to ``NaCl-phonopy.yml`` and ``NaCl-force_constants.hdf5``,
+in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
 
 Additionally, the ``--bands`` option can be added to calculate the band structure and save the results to ``NaCl-auto_bands.yml``:
 
@@ -276,7 +284,8 @@ Further calculations, including thermal properties, DOS, and PDOS, can also be c
     janus phonons --struct tests/data/NaCl.cif --supercell 2x3x4 --dos --pdos --thermal --temp-start 0 --temp-end 300 --temp-step 50
 
 
-This will create additional output files: ``NaCl-thermal.dat`` for the thermal properties (heat capacity, entropy, and free energy) between 0K and 300K, ``NaCl-dos.dat`` for the DOS, and ``NaCl-pdos.dat`` for the PDOS.
+This will create additional output files: ``NaCl-thermal.dat`` for the thermal properties (heat capacity, entropy, and free energy)
+between 0K and 300K, ``NaCl-dos.dat`` for the DOS, and ``NaCl-pdos.dat`` for the PDOS.
 
 For all options, run ``janus phonons --help``.
 
@@ -284,7 +293,8 @@ For all options, run ``janus phonons --help``.
 Using configuration files
 -------------------------
 
-Default values for all command line options may be specifed through a Yaml 1.1 formatted configuration file by adding the ``--config`` option. If an option is present in both the command line and configuration file, the command line value takes precedence.
+Default values for all command line options may be specifed through a Yaml 1.1 formatted configuration file by adding the ``--config`` option.
+If an option is present in both the command line and configuration file, the command line value takes precedence.
 
 For example, with the following configuration file and command:
 
@@ -327,6 +337,7 @@ Models can be trained by passing a configuration file to the MLIP's command line
     janus train --mlip-config /path/to/training/config.yml
 
 For MACE, this will create ``logs``, ``checkpoints`` and ``results`` directories, as well as saving the trained model, and a compiled version of the model.
+Additionally, a log file, ``train-log.yml``, and summary file, ``train-summary.yml``, will be generated.
 
 Foundational models can also be fine-tuned, by including the ``foundation_model`` option in your configuration file, and using ``--fine-tune`` option:
 
@@ -348,7 +359,8 @@ Descriptors of a structure can be calculated (using the `MACE-MP <https://github
     janus descriptors --struct tests/data/NaCl.cif --arch mace_mp --model-path small
 
 
-This will calculate the mean descriptor for this structure and save this as attached information (``mace_mp_descriptors``) in ``NaCl-descriptors.extxyz``, in addition to generating a log file, ``descriptors.log``, and summary of inputs, ``descriptors_summary.yml``.
+This will calculate the mean descriptor for this structure and save this as attached information (``mace_mp_descriptors``) in ``NaCl-descriptors.extxyz``,
+in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
 
 The mean descriptor per element can also be calculated, and all descriptors, rather than only the invariant part, can be used when calculating the means:
 

--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -94,7 +94,7 @@ Perform a single point calcuation (using the `MACE-MP <https://github.com/ACEsui
     janus singlepoint --struct tests/data/NaCl.cif --arch mace_mp --model-path small
 
 
-This will calculate the energy, stress and forces and save this in ``NaCl-results.extxyz``, in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
+This will calculate the energy, stress and forces and save this in ``NaCl-results.extxyz``, in addition to generating a log file, ``NaCl-singlepoint-log.yml``, and summary of inputs, ``NaCl-singlepoint-summary.yml``.
 
 Additional options may be specified. For example:
 
@@ -129,7 +129,7 @@ Perform geometry optimization (using the `MACE-MP <https://github.com/ACEsuit/ma
     janus geomopt --struct tests/data/H2O.cif --arch mace_mp --model-path small
 
 
-This will optimize the atomic positions and save the resulting structure in ``H2O-opt.extxyz``, in addition to generating a log file, ``H20-log.yml``, and summary of inputs, ``H20-summary.yml``.
+This will optimize the atomic positions and save the resulting structure in ``H2O-opt.extxyz``, in addition to generating a log file, ``H20-geomopt-log.yml``, and summary of inputs, ``H20-geomopt-summary.yml``.
 
 Additional options may be specified. This shares most options with ``singlepoint``, as well as a few additional options, such as:
 
@@ -168,8 +168,8 @@ This will generate several output files:
 - The structure trajectory every 100 steps, written to ``NaCl-npt-T300.0-p1.0-traj.extxyz``
 - The structure to be able to restart the dynamics every 1000 steps, written to ``NaCl-npt-T300.0-p1.0-res-1000.extxyz``
 - The final structure written to ``NaCl-npt-T300.0-p1.0-final.extxyz``
-- A log of the processes carried out, written to ``NaCl-npt-T300.0-p1.0-log.yml``
-- A summary of the inputs and start/end time, written to ``NaCl-npt-T300.0-p1.0-summary.yml``.
+- A log of the processes carried out, written to ``NaCl-npt-T300.0-p1.0-md-log.yml``
+- A summary of the inputs and start/end time, written to ``NaCl-npt-T300.0-p1.0-md-summary.yml``.
 
 Additional options may be specified. For example:
 
@@ -242,7 +242,7 @@ Fit the equation of state for a structure (using the `MACE-MP <https://github.co
 
 
 This will save the energies and volumes for nine lattice constants in ``NaCl-eos-raw.dat``, and the fitted minimum energy, volume, and bulk modulus in ``NaCl-eos-fit.dat``,
-in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
+in addition to generating a log file, ``NaCl-eos-log.yml``, and summary of inputs, ``NaCl-eos-summary.yml``.
 
 By default, geometry optimization will be performed on the initial structure, before calculations are performed for the range of lattice constants consistent with minimum and maximum volumes supplied.
 Optimization at constant volume for all generated structures can also be performed (sharing the same maximum force convergence):
@@ -266,7 +266,7 @@ Calculate phonons with a 2x2x2 supercell, after geometry optimization (using the
 
 
 This will save the Phonopy parameters, including displacements and force constants, to ``NaCl-phonopy.yml`` and ``NaCl-force_constants.hdf5``,
-in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
+in addition to generating a log file, ``NaCl-phonons-log.yml``, and summary of inputs, ``NaCl-phonons-summary.yml``.
 
 Additionally, the ``--bands`` option can be added to calculate the band structure and save the results to ``NaCl-auto_bands.yml``:
 
@@ -360,7 +360,7 @@ Descriptors of a structure can be calculated (using the `MACE-MP <https://github
 
 
 This will calculate the mean descriptor for this structure and save this as attached information (``mace_mp_descriptors``) in ``NaCl-descriptors.extxyz``,
-in addition to generating a log file, ``NaCl-log.yml``, and summary of inputs, ``NaCl-summary.yml``.
+in addition to generating a log file, ``NaCl-descriptors-log.yml``, and summary of inputs, ``NaCl-descriptors-summary.yml``.
 
 The mean descriptor per element can also be calculated, and all descriptors, rather than only the invariant part, can be used when calculating the means:
 

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -165,11 +165,14 @@ class BaseCalculation(FileNameMixin):
         )
 
         # Configure logging
+        # Extract command from module
+        # e.g janus_core.calculations.single_point -> singlepoint
+        log_suffix = f"{calc_name.split('.')[-1].replace('_', '')}-log.yml"
         if attach_logger:
             self.log_kwargs.setdefault(
                 "filename",
                 self._build_filename(
-                    "log.yml", param_prefix if file_prefix is None else ""
+                    log_suffix, param_prefix if file_prefix is None else ""
                 ).absolute(),
             )
         self.log_kwargs.setdefault("name", calc_name)

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -44,6 +44,8 @@ class Descriptors(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
         Whether to set (new) calculators for structures. Default is None.
+    attach_logger : bool
+        Whether to attach a logger. Default is False.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -76,6 +78,7 @@ class Descriptors(BaseCalculation):
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
         set_calc: Optional[bool] = None,
+        attach_logger: bool = False,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         invariants_only: bool = True,
@@ -108,6 +111,8 @@ class Descriptors(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : Optional[bool]
             Whether to set (new) calculators for structures. Default is None.
+        attach_logger : bool
+            Whether to attach a logger. Default is False.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -147,6 +152,7 @@ class Descriptors(BaseCalculation):
             sequence_allowed=True,
             calc_kwargs=calc_kwargs,
             set_calc=set_calc,
+            attach_logger=attach_logger,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
         )

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -47,6 +47,8 @@ class EoS(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
         Whether to set (new) calculators for structures. Default is None.
+    attach_logger : bool
+        Whether to attach a logger. Default is False.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -104,6 +106,7 @@ class EoS(BaseCalculation):
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
         set_calc: Optional[bool] = None,
+        attach_logger: bool = False,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         min_volume: float = 0.95,
@@ -142,6 +145,8 @@ class EoS(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : Optional[bool]
             Whether to set (new) calculators for structures. Default is None.
+        attach_logger : bool
+            Whether to attach a logger. Default is False.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -222,6 +227,7 @@ class EoS(BaseCalculation):
             sequence_allowed=False,
             calc_kwargs=calc_kwargs,
             set_calc=set_calc,
+            attach_logger=attach_logger,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
             file_prefix=file_prefix,
@@ -229,6 +235,13 @@ class EoS(BaseCalculation):
 
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
+
+        if self.minimize and self.logger:
+            self.minimize_kwargs["log_kwargs"] = {
+                "filename": self.log_kwargs["filename"],
+                "name": self.logger.name,
+                "filemode": "a",
+            }
 
         # Set output file
         self.write_kwargs.setdefault("filename", None)
@@ -254,11 +267,6 @@ class EoS(BaseCalculation):
         if self.minimize:
             if self.logger:
                 self.logger.info("Minimising initial structure")
-                self.minimize_kwargs["log_kwargs"] = {
-                    "filename": self.log_kwargs["filename"],
-                    "name": self.logger.name,
-                    "filemode": "a",
-                }
             optimizer = GeomOpt(self.struct, **self.minimize_kwargs)
             optimizer.run()
 

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -46,6 +46,8 @@ class GeomOpt(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
         Whether to set (new) calculators for structures. Default is None.
+    attach_logger : bool
+        Whether to attach a logger. Default is False.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -97,6 +99,7 @@ class GeomOpt(BaseCalculation):
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
         set_calc: Optional[bool] = None,
+        attach_logger: bool = False,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         fmax: float = 0.1,
@@ -135,6 +138,8 @@ class GeomOpt(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : Optional[bool]
             Whether to set (new) calculators for structures. Default is None.
+        attach_logger : bool
+            Whether to attach a logger. Default is False.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -210,6 +215,7 @@ class GeomOpt(BaseCalculation):
             sequence_allowed=False,
             calc_kwargs=calc_kwargs,
             set_calc=set_calc,
+            attach_logger=attach_logger,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
         )

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -70,6 +70,8 @@ class MolecularDynamics(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
         Whether to set (new) calculators for structures. Default is None.
+    attach_logger : bool
+        Whether to attach a logger. Default is False.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -179,6 +181,7 @@ class MolecularDynamics(BaseCalculation):
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
         set_calc: Optional[bool] = None,
+        attach_logger: bool = False,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         ensemble: Optional[Ensembles] = None,
@@ -238,6 +241,8 @@ class MolecularDynamics(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : Optional[bool]
             Whether to set (new) calculators for structures. Default is None.
+        attach_logger : bool
+            Whether to attach a logger. Default is False.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -419,6 +424,8 @@ class MolecularDynamics(BaseCalculation):
         # Read last image by default
         read_kwargs.setdefault("index", -1)
 
+        self.param_prefix = self._set_param_prefix(file_prefix)
+
         # Initialise structures and logging
         super().__init__(
             calc_name=__name__,
@@ -431,16 +438,16 @@ class MolecularDynamics(BaseCalculation):
             sequence_allowed=False,
             calc_kwargs=calc_kwargs,
             set_calc=set_calc,
+            attach_logger=attach_logger,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
             file_prefix=file_prefix,
             additional_prefix=self.ensemble,
+            param_prefix=self.param_prefix,
         )
 
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
-
-        self.param_prefix = self._set_param_prefix(file_prefix)
 
         # Set output file names
         self.final_file = self._build_filename(

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -48,6 +48,8 @@ class Phonons(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
         Whether to set (new) calculators for structures. Default is None.
+    attach_logger : bool
+        Whether to attach a logger. Default is False.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -130,6 +132,7 @@ class Phonons(BaseCalculation):
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
         set_calc: Optional[bool] = None,
+        attach_logger: bool = False,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         calcs: MaybeSequence[PhononCalcs] = (),
@@ -171,6 +174,8 @@ class Phonons(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : Optional[bool]
             Whether to set (new) calculators for structures. Default is None.
+        attach_logger : bool
+            Whether to attach a logger. Default is False.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -245,6 +250,7 @@ class Phonons(BaseCalculation):
             sequence_allowed=False,
             calc_kwargs=calc_kwargs,
             set_calc=set_calc,
+            attach_logger=attach_logger,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
             file_prefix=file_prefix,

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -47,6 +47,8 @@ class SinglePoint(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
         Whether to set (new) calculators for structures. Default is None.
+    attach_logger : bool
+        Whether to attach a logger. Default is False.
     log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -82,6 +84,7 @@ class SinglePoint(BaseCalculation):
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
         set_calc: Optional[bool] = None,
+        attach_logger: bool = False,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         properties: MaybeSequence[Properties] = (),
@@ -113,6 +116,8 @@ class SinglePoint(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : Optional[bool]
             Whether to set (new) calculators for structures. Default is None.
+        attach_logger : bool
+            Whether to attach a logger. Default is False.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -131,6 +136,7 @@ class SinglePoint(BaseCalculation):
         self.properties = properties
         self.write_results = write_results
         self.write_kwargs = write_kwargs
+        self.log_kwargs = log_kwargs
 
         # Read full trajectory by default
         read_kwargs.setdefault("index", ":")
@@ -147,6 +153,7 @@ class SinglePoint(BaseCalculation):
             sequence_allowed=True,
             calc_kwargs=calc_kwargs,
             set_calc=set_calc,
+            attach_logger=attach_logger,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
         )

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -64,8 +64,8 @@ def descriptors(
     read_kwargs: ReadKwargsAll = None,
     calc_kwargs: CalcKwargs = None,
     write_kwargs: WriteKwargs = None,
-    log: LogPath = "descriptors.log",
-    summary: Summary = "descriptors_summary.yml",
+    log: LogPath = None,
+    summary: Summary = None,
 ):
     """
     Calculate MLIP descriptors for the given structure(s).
@@ -100,10 +100,10 @@ def descriptors(
     write_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log : Optional[Path]
-        Path to write logs to. Default is "descriptors.log".
+        Path to write logs to. Default is inferred from the name of the structure file.
     summary : Path
-        Path to save summary of inputs and start/end time. Default is
-        descriptors_summary.yml.
+        Path to save summary of inputs, start/end time, and carbon emissions. Default
+        is inferred from the name of the structure file.
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -114,13 +114,17 @@ def descriptors(
         [read_kwargs, calc_kwargs, write_kwargs]
     )
 
-    # Check structure path not duplicated
+    # Check optimized structure path not duplicated
     if "filename" in write_kwargs:
         raise ValueError("'filename' must be passed through the --out option")
 
     # Set default filname for writing structure with descriptors if not specified
     if out:
         write_kwargs["filename"] = out
+
+    log_kwargs = {"filemode": "w"}
+    if log:
+        log_kwargs["filename"] = log
 
     # Dictionary of inputs for Descriptors class
     descriptors_kwargs = {
@@ -130,7 +134,8 @@ def descriptors(
         "model_path": model_path,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
-        "log_kwargs": {"filename": log, "filemode": "w"},
+        "attach_logger": True,
+        "log_kwargs": log_kwargs,
         "invariants_only": invariants_only,
         "calc_per_element": calc_per_element,
         "calc_per_atom": calc_per_atom,
@@ -140,6 +145,10 @@ def descriptors(
 
     # Initialise descriptors
     descript = Descriptors(**descriptors_kwargs)
+
+    # Set summary and log files
+    summary = descript._build_filename("summary.yml", filename=summary).absolute()
+    log = descript.log_kwargs["filename"]
 
     # Store inputs for yaml summary
     inputs = descriptors_kwargs.copy()

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -147,7 +147,9 @@ def descriptors(
     descript = Descriptors(**descriptors_kwargs)
 
     # Set summary and log files
-    summary = descript._build_filename("summary.yml", filename=summary).absolute()
+    summary = descript._build_filename(
+        "descriptors-summary.yml", filename=summary
+    ).absolute()
     log = descript.log_kwargs["filename"]
 
     # Store inputs for yaml summary

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -184,7 +184,7 @@ def eos(
 
     # Set summary and log files
     summary = equation_of_state._build_filename(
-        "summary.yml", filename=summary
+        "eos-summary.yml", filename=summary
     ).absolute()
     log = equation_of_state.log_kwargs["filename"]
 

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -78,8 +78,8 @@ def eos(
             ),
         ),
     ] = None,
-    log: LogPath = "eos.log",
-    summary: Summary = "eos_summary.yml",
+    log: LogPath = None,
+    summary: Summary = None,
 ):
     """
     Calculate equation of state and write out results.
@@ -128,9 +128,10 @@ def eos(
         Prefix for output filenames. Default is inferred from structure name, or
         chemical formula.
     log : Optional[Path]
-        Path to write logs to. Default is "eos.log".
+        Path to write logs to. Default is inferred from the name of the structure file.
     summary : Path
-        Path to save summary of inputs and start/end time. Default is eos.yml.
+        Path to save summary of inputs, start/end time, and carbon emissions. Default
+        is inferred from the name of the structure file.
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -152,6 +153,10 @@ def eos(
         raise ValueError("'fmax' must be passed through the --fmax option")
     minimize_kwargs["fmax"] = fmax
 
+    log_kwargs = {"filemode": "w"}
+    if log:
+        log_kwargs["filename"] = log
+
     # Dictionary of inputs for EoS class
     eos_kwargs = {
         "struct_path": struct,
@@ -160,7 +165,8 @@ def eos(
         "model_path": model_path,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
-        "log_kwargs": {"filename": log, "filemode": "w"},
+        "attach_logger": True,
+        "log_kwargs": log_kwargs,
         "min_volume": min_volume,
         "max_volume": max_volume,
         "n_volumes": n_volumes,
@@ -175,6 +181,12 @@ def eos(
 
     # Initialise EoS
     equation_of_state = EoS(**eos_kwargs)
+
+    # Set summary and log files
+    summary = equation_of_state._build_filename(
+        "summary.yml", filename=summary
+    ).absolute()
+    log = equation_of_state.log_kwargs["filename"]
 
     # Store inputs for yaml summary
     inputs = eos_kwargs.copy()

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -146,8 +146,8 @@ def geomopt(
     calc_kwargs: CalcKwargs = None,
     minimize_kwargs: MinimizeKwargs = None,
     write_kwargs: WriteKwargs = None,
-    log: LogPath = "geomopt.log",
-    summary: Summary = "geomopt_summary.yml",
+    log: LogPath = None,
+    summary: Summary = None,
 ):
     """
     Perform geometry optimization and save optimized structure to file.
@@ -201,10 +201,10 @@ def geomopt(
         Keyword arguments to pass to ase.io.write when saving optimized structure.
         Default is {}.
     log : Optional[Path]
-        Path to write logs to. Default is "geomopt.log".
+        Path to write logs to. Default is inferred from the name of the structure file.
     summary : Path
-        Path to save summary of inputs and start/end time. Default is
-        geomopt_summary.yml.
+        Path to save summary of inputs, start/end time, and carbon emissions. Default
+        is inferred from the name of the structure file.
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -218,7 +218,7 @@ def geomopt(
     # Read only first structure by default and ensure only one image is read
     set_read_kwargs_index(read_kwargs)
 
-    # Check optimized structure path not duplicated and set from out, if specified
+    # Check optimized structure path not duplicated
     if "filename" in write_kwargs:
         raise ValueError("'filename' must be passed through the --out option")
     if out:
@@ -238,6 +238,10 @@ def geomopt(
         # Override default filter function with None
         opt_cell_fully_dict = {"filter_func": None}
 
+    log_kwargs = {"filemode": "w"}
+    if log:
+        log_kwargs["filename"] = log
+
     # Dictionary of inputs for optimize function
     optimize_kwargs = {
         "struct_path": struct,
@@ -246,7 +250,8 @@ def geomopt(
         "model_path": model_path,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
-        "log_kwargs": {"filename": log, "filemode": "w"},
+        "attach_logger": True,
+        "log_kwargs": log_kwargs,
         "optimizer": optimizer,
         "fmax": fmax,
         "steps": steps,
@@ -258,6 +263,10 @@ def geomopt(
 
     # Set up geometry optimization
     optimizer = GeomOpt(**optimize_kwargs)
+
+    # Set summary and log files
+    summary = optimizer._build_filename("summary.yml", filename=summary).absolute()
+    log = optimizer.log_kwargs["filename"]
 
     # Store inputs for yaml summary
     inputs = optimize_kwargs.copy()

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -265,7 +265,9 @@ def geomopt(
     optimizer = GeomOpt(**optimize_kwargs)
 
     # Set summary and log files
-    summary = optimizer._build_filename("summary.yml", filename=summary).absolute()
+    summary = optimizer._build_filename(
+        "geomopt-summary.yml", filename=summary
+    ).absolute()
     log = optimizer.log_kwargs["filename"]
 
     # Store inputs for yaml summary

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -402,7 +402,7 @@ def md(
 
     # Set summary and log files
     summary = dyn._build_filename(
-        "summary.yml", dyn.param_prefix, filename=summary
+        "md-summary.yml", dyn.param_prefix, filename=summary
     ).absolute()
     log = dyn.log_kwargs["filename"]
 

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -121,8 +121,8 @@ def phonons(
             ),
         ),
     ] = None,
-    log: LogPath = "phonons.log",
-    summary: Summary = "phonons_summary.yml",
+    log: LogPath = None,
+    summary: Summary = None,
 ):
     """
     Perform phonon calculations and write out results.
@@ -187,10 +187,10 @@ def phonons(
         Prefix for output filenames. Default is inferred from structure name, or
         chemical formula.
     log : Optional[Path]
-        Path to write logs to. Default is "phonons.log".
+        Path to write logs to. Default is inferred from the name of the structure file.
     summary : Path
-        Path to save summary of inputs and start/end time. Default is
-        phonons.yml.
+        Path to save summary of inputs, start/end time, and carbon emissions. Default
+        is inferred from the name of the structure file.
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -230,6 +230,10 @@ def phonons(
     if pdos:
         calcs.append("pdos")
 
+    log_kwargs = {"filemode": "w"}
+    if log:
+        log_kwargs["filename"] = log
+
     # Dictionary of inputs for Phonons class
     phonons_kwargs = {
         "struct_path": struct,
@@ -238,24 +242,30 @@ def phonons(
         "model_path": model_path,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
-        "log_kwargs": {"filename": log, "filemode": "w"},
+        "attach_logger": True,
+        "log_kwargs": log_kwargs,
         "calcs": calcs,
         "supercell": supercell,
         "displacement": displacement,
+        "t_step": temp_step,
         "t_min": temp_start,
         "t_max": temp_end,
-        "t_step": temp_step,
+        "symmetrize": symmetrize,
         "minimize": minimize,
         "minimize_kwargs": minimize_kwargs,
-        "file_prefix": file_prefix,
         "force_consts_to_hdf5": hdf5,
         "plot_to_file": plot_to_file,
-        "symmetrize": symmetrize,
+        "write_results": True,
         "write_full": write_full,
+        "file_prefix": file_prefix,
     }
 
     # Initialise phonons
     phonon = Phonons(**phonons_kwargs)
+
+    # Set summary and log files
+    summary = phonon._build_filename("summary.yml", filename=summary).absolute()
+    log = phonon.log_kwargs["filename"]
 
     # Store inputs for yaml summary
     inputs = phonons_kwargs.copy()

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -264,7 +264,7 @@ def phonons(
     phonon = Phonons(**phonons_kwargs)
 
     # Set summary and log files
-    summary = phonon._build_filename("summary.yml", filename=summary).absolute()
+    summary = phonon._build_filename("phonons-summary.yml", filename=summary).absolute()
     log = phonon.log_kwargs["filename"]
 
     # Store inputs for yaml summary

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -61,8 +61,8 @@ def singlepoint(
     read_kwargs: ReadKwargsAll = None,
     calc_kwargs: CalcKwargs = None,
     write_kwargs: WriteKwargs = None,
-    log: LogPath = "singlepoint.log",
-    summary: Summary = "singlepoint_summary.yml",
+    log: LogPath = None,
+    summary: Summary = None,
 ):
     """
     Perform single point calculations and save to file.
@@ -93,10 +93,10 @@ def singlepoint(
     write_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log : Optional[Path]
-        Path to write logs to. Default is "singlepoint.log".
+        Path to write logs to. Default is inferred from the name of the structure file.
     summary : Path
-        Path to save summary of inputs and start/end time. Default is
-        singlepoint_summary.yml.
+        Path to save summary of inputs, start/end time, and carbon emissions. Default
+        is inferred from the name of the structure file.
     config : Path
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -110,10 +110,12 @@ def singlepoint(
     # Check filename for results not duplicated
     if "filename" in write_kwargs:
         raise ValueError("'filename' must be passed through the --out option")
-
-    # Default filname for saving results determined in SinglePoint if not specified
     if out:
         write_kwargs["filename"] = out
+
+    log_kwargs = {"filemode": "w"}
+    if log:
+        log_kwargs["filename"] = log
 
     singlepoint_kwargs = {
         "struct_path": struct,
@@ -125,14 +127,19 @@ def singlepoint(
         "model_path": model_path,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
-        "log_kwargs": {"filename": log, "filemode": "w"},
+        "attach_logger": True,
+        "log_kwargs": log_kwargs,
     }
 
     # Initialise singlepoint structure and calculator
     s_point = SinglePoint(**singlepoint_kwargs)
 
     # Store inputs for yaml summary
-    inputs = singlepoint_kwargs.copy()
+    summary = s_point._build_filename("summary.yml", filename=summary).absolute()
+    log = s_point.log_kwargs["filename"]
+
+    # Store only filename as filemode is not set by user
+    inputs = {"log": log}
 
     # Add structure, MLIP information, and log to inputs
     save_struct_calc(

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -135,7 +135,9 @@ def singlepoint(
     s_point = SinglePoint(**singlepoint_kwargs)
 
     # Store inputs for yaml summary
-    summary = s_point._build_filename("summary.yml", filename=summary).absolute()
+    summary = s_point._build_filename(
+        "singlepoint-summary.yml", filename=summary
+    ).absolute()
     log = s_point.log_kwargs["filename"]
 
     # Store only filename as filemode is not set by user

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -6,7 +6,6 @@ from typing import Annotated
 from typer import Option, Typer
 import yaml
 
-from janus_core.cli.types import LogPath, Summary
 from janus_core.cli.utils import carbon_summary, end_summary, start_summary
 from janus_core.helpers.train import train as run_train
 
@@ -21,8 +20,15 @@ def train(
     fine_tune: Annotated[
         bool, Option(help="Whether to fine-tune a foundational model.")
     ] = False,
-    log: LogPath = "train.log",
-    summary: Summary = "train_summary.yml",
+    log: Annotated[Path, Option(help="Path to save logs to.")] = Path("train-log.yml"),
+    summary: Annotated[
+        Path,
+        Option(
+            help=(
+                "Path to save summary of inputs, start/end time, and carbon emissions."
+            )
+        ),
+    ] = Path("train-summary.yml"),
 ):
     """
     Run training for MLIP by passing a configuration file to the MLIP's CLI.
@@ -34,10 +40,10 @@ def train(
     fine_tune : bool
         Whether to fine-tune a foundational model. Default is False.
     log : Optional[Path]
-        Path to write logs to. Default is "train.log".
+        Path to write logs to. Default is Path("train-log.yml").
     summary : Path
-        Path to save summary of inputs and start/end time. Default is
-        train_summary.yml.
+        Path to save summary of inputs, start/end time, and carbon emissions. Default
+        is Path("train-summary.yml").
     """
     with open(mlip_config, encoding="utf8") as config_file:
         config = yaml.safe_load(config_file)
@@ -67,7 +73,9 @@ def train(
     start_summary(command="train", summary=summary, inputs=inputs)
 
     # Run training
-    run_train(mlip_config, log_kwargs={"filename": log, "filemode": "w"})
+    run_train(
+        mlip_config, attach_logger=True, log_kwargs={"filename": log, "filemode": "w"}
+    )
 
     carbon_summary(summary=summary, log=log)
 

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -181,8 +181,22 @@ PostProcessKwargs = Annotated[
     ),
 ]
 
-LogPath = Annotated[Path, Option(help="Path to save logs to.")]
+LogPath = Annotated[
+    Path,
+    Option(
+        help=(
+            "Path to save logs to. Default is inferred from the name of the structure "
+            "file."
+        )
+    ),
+]
 
 Summary = Annotated[
-    Path, Option(help="Path to save summary of inputs and start/end time.")
+    Path,
+    Option(
+        help=(
+            "Path to save summary of inputs, start/end time, and carbon emissions. "
+            "Default is inferred from the name of the structure file."
+        )
+    ),
 ]

--- a/janus_core/helpers/train.py
+++ b/janus_core/helpers/train.py
@@ -41,6 +41,7 @@ def check_files_exist(config: dict, req_file_keys: list[PathLike]) -> None:
 def train(
     mlip_config: PathLike,
     req_file_keys: Optional[list[PathLike]] = None,
+    attach_logger: bool = False,
     log_kwargs: Optional[dict[str, Any]] = None,
     tracker_kwargs: Optional[dict[str, Any]] = None,
 ) -> None:
@@ -57,6 +58,8 @@ def train(
     req_file_keys : Optional[list[PathLike]]
         List of files that must exist if defined in the configuration file.
         Default is ["train_file", "test_file", "valid_file", "statistics_file"].
+    attach_logger : bool
+        Whether to attach a logger. Default is False.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -73,6 +76,8 @@ def train(
     check_files_exist(options, req_file_keys)
 
     # Configure logging
+    if attach_logger:
+        log_kwargs.setdefault("filename", "train-log.yml")
     log_kwargs.setdefault("name", __name__)
     logger = config_logger(**log_kwargs)
     tracker = config_tracker(logger, **tracker_kwargs)

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli.janus import app
-from tests.utils import assert_log_contains, strip_ansi_codes
+from tests.utils import assert_log_contains, clear_log_handlers, strip_ansi_codes
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -82,6 +82,7 @@ def test_descriptors():
         out_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        clear_log_handlers()
 
 
 def test_calc_per_element(tmp_path):

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -25,8 +25,8 @@ def test_help():
 def test_descriptors():
     """Test calculating MLIP descriptors."""
     out_path = Path("./NaCl-descriptors.extxyz").absolute()
-    log_path = Path("./NaCl-log.yml").absolute()
-    summary_path = Path("./NaCl-summary.yml").absolute()
+    log_path = Path("./NaCl-descriptors-log.yml").absolute()
+    summary_path = Path("./NaCl-descriptors-summary.yml").absolute()
 
     assert not out_path.exists()
     assert not log_path.exists()

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -22,77 +22,85 @@ def test_help():
     assert "Usage: janus eos [OPTIONS]" in strip_ansi_codes(result.stdout)
 
 
-def test_eos(tmp_path):
+def test_eos():
     """Test calculating the equation of state."""
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
-    eos_raw_path = tmp_path / "NaCl-eos-raw.dat"
-    eos_fit_path = tmp_path / "NaCl-eos-fit.dat"
-    result = runner.invoke(
-        app,
-        [
-            "eos",
-            "--struct",
-            DATA_PATH / "NaCl.cif",
-            "--file-prefix",
-            tmp_path / "NaCl",
-            "--log",
+    eos_raw_path = Path("./NaCl-eos-raw.dat").absolute()
+    eos_fit_path = Path("./NaCl-eos-fit.dat").absolute()
+    log_path = Path("./NaCl-log.yml").absolute()
+    summary_path = Path("./NaCl-summary.yml").absolute()
+
+    assert not eos_raw_path.exists()
+    assert not eos_fit_path.exists()
+    assert not log_path.exists()
+    assert not summary_path.exists()
+
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "eos",
+                "--struct",
+                DATA_PATH / "NaCl.cif",
+            ],
+        )
+        assert result.exit_code == 0
+
+        assert eos_raw_path.exists()
+        assert eos_fit_path.exists()
+        assert log_path.exists()
+        assert summary_path.exists()
+
+        # Check contents of raw data file
+        with open(eos_raw_path, encoding="utf8") as eos_raw_file:
+            lines = eos_raw_file.readlines()
+
+        assert len(lines) == 8
+        assert lines[0] == "#Lattice Scalar | Energy [eV] | Volume [Å^3] \n"
+        assert lines[4].split()[0] == "1.0"
+        assert float(lines[4].split()[1]) == pytest.approx(-27.046359959669214)
+        assert float(lines[4].split()[2]) == pytest.approx(184.05884033013012)
+
+        # Check contents of fitted data file
+        with open(eos_fit_path, encoding="utf8") as eos_fit_file:
+            lines = eos_fit_file.readlines()
+
+        assert len(lines) == 2
+        assert lines[0] == "#Bulk modulus [GPa] | Energy [eV] | Volume [Å^3] \n"
+        assert float(lines[1].split()[0]) == pytest.approx(27.186555689697165)
+        assert float(lines[1].split()[1]) == pytest.approx(-27.046361904823204)
+        assert float(lines[1].split()[2]) == pytest.approx(184.22281215770133)
+
+        # Check only initial structure is minimized
+        assert_log_contains(
             log_path,
-            "--summary",
-            summary_path,
-        ],
-    )
-    assert result.exit_code == 0
-    assert eos_raw_path.exists()
-    assert eos_fit_path.exists()
+            includes=["Minimising initial structure"],
+            excludes=["Minimising lattice scalar = 1.0"],
+        )
 
-    # Check contents of raw data file
-    with open(eos_raw_path, encoding="utf8") as eos_raw_file:
-        lines = eos_raw_file.readlines()
+        # Read eos summary file
+        with open(summary_path, encoding="utf8") as file:
+            eos_summary = yaml.safe_load(file)
 
-    assert len(lines) == 8
-    assert lines[0] == "#Lattice Scalar | Energy [eV] | Volume [Å^3] \n"
-    assert lines[4].split()[0] == "1.0"
-    assert float(lines[4].split()[1]) == pytest.approx(-27.046359959669214)
-    assert float(lines[4].split()[2]) == pytest.approx(184.05884033013012)
+        assert "command" in eos_summary
+        assert "janus eos" in eos_summary["command"]
+        assert "start_time" in eos_summary
+        assert "inputs" in eos_summary
+        assert "end_time" in eos_summary
 
-    # Check contents of fitted data file
-    with open(eos_fit_path, encoding="utf8") as eos_fit_file:
-        lines = eos_fit_file.readlines()
+        assert "emissions" in eos_summary
+        assert eos_summary["emissions"] > 0
 
-    assert len(lines) == 2
-    assert lines[0] == "#Bulk modulus [GPa] | Energy [eV] | Volume [Å^3] \n"
-    assert float(lines[1].split()[0]) == pytest.approx(27.186555689697165)
-    assert float(lines[1].split()[1]) == pytest.approx(-27.046361904823204)
-    assert float(lines[1].split()[2]) == pytest.approx(184.22281215770133)
-
-    # Check only initial structure is minimized
-    assert_log_contains(
-        log_path,
-        includes=["Minimising initial structure"],
-        excludes=["Minimising lattice scalar = 1.0"],
-    )
-
-    # Read eos summary file
-    assert summary_path.exists()
-    with open(summary_path, encoding="utf8") as file:
-        eos_summary = yaml.safe_load(file)
-
-    assert "command" in eos_summary
-    assert "janus eos" in eos_summary["command"]
-    assert "start_time" in eos_summary
-    assert "inputs" in eos_summary
-    assert "end_time" in eos_summary
-
-    assert "emissions" in eos_summary
-    assert eos_summary["emissions"] > 0
+    finally:
+        eos_raw_path.unlink(missing_ok=True)
+        eos_fit_path.unlink(missing_ok=True)
+        log_path.unlink(missing_ok=True)
 
 
 def test_setting_lattice(tmp_path):
     """Test setting the lattice constants."""
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
-    eos_raw_path = tmp_path / "NaCl-eos-raw.dat"
+    file_prefix = tmp_path / "example"
+    eos_raw_path = tmp_path / "example-eos-raw.dat"
+
     result = runner.invoke(
         app,
         [
@@ -106,11 +114,7 @@ def test_setting_lattice(tmp_path):
             "--n-volumes",
             5,
             "--file-prefix",
-            tmp_path / "NaCl",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
+            file_prefix,
         ],
     )
     assert result.exit_code == 0
@@ -125,14 +129,13 @@ def test_setting_lattice(tmp_path):
     assert float(lines[5].split()[0]) == pytest.approx(1.2 ** (1 / 3))
 
 
-test_data = [("--min-volume", 1), ("--max-volume", 0.9), ("--n-volumes", 0)]
-
-
-@pytest.mark.parametrize("option, value", test_data)
+@pytest.mark.parametrize(
+    "option, value", [("--min-volume", 1), ("--max-volume", 0.9), ("--n-volumes", 0)]
+)
 def test_invalid_lattice(option, value, tmp_path):
     """Test setting the invalid lattice constants."""
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "NaCl"
+
     result = runner.invoke(
         app,
         [
@@ -142,11 +145,7 @@ def test_invalid_lattice(option, value, tmp_path):
             option,
             value,
             "--file-prefix",
-            tmp_path / "NaCl",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
+            file_prefix,
         ],
     )
     assert result.exit_code == 1
@@ -155,8 +154,9 @@ def test_invalid_lattice(option, value, tmp_path):
 
 def test_minimising_all(tmp_path):
     """Test minimising structures with different lattice constants."""
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "NaCl"
+    log_path = tmp_path / "NaCl-log.yml"
+
     result = runner.invoke(
         app,
         [
@@ -165,11 +165,7 @@ def test_minimising_all(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--minimize-all",
             "--file-prefix",
-            tmp_path / "NaCl",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
+            file_prefix,
         ],
     )
     assert result.exit_code == 0
@@ -189,8 +185,6 @@ def test_writing_structs(tmp_path):
     """Test writing out generated structures."""
     file_prefix = tmp_path / "test" / "example"
     generated_path = tmp_path / "test" / "example-generated.extxyz"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -203,10 +197,6 @@ def test_writing_structs(tmp_path):
             "--file-prefix",
             file_prefix,
             "--write-structures",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -217,8 +207,6 @@ def test_writing_structs(tmp_path):
 
 def test_error_write_geomopt(tmp_path):
     """Test an error is raised if trying to write via geomopt."""
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
     file_prefix = tmp_path / "example"
 
     minimize_kwargs = "{'write_results': True}"
@@ -236,10 +224,6 @@ def test_error_write_geomopt(tmp_path):
             "--minimize",
             "--minimize-kwargs",
             minimize_kwargs,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 1
@@ -249,10 +233,9 @@ def test_error_write_geomopt(tmp_path):
 @pytest.mark.parametrize("read_kwargs", ["{'index': 1}", "{}"])
 def test_valid_traj_input(read_kwargs, tmp_path):
     """Test valid trajectory input structure handled."""
+    file_prefix = tmp_path / "traj"
     eos_raw_path = tmp_path / "traj-eos-raw.dat"
     eos_fit_path = tmp_path / "traj-eos-fit.dat"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -263,11 +246,7 @@ def test_valid_traj_input(read_kwargs, tmp_path):
             "--read-kwargs",
             read_kwargs,
             "--file-prefix",
-            tmp_path / "traj",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
+            file_prefix,
         ],
     )
     assert result.exit_code == 0
@@ -277,8 +256,7 @@ def test_valid_traj_input(read_kwargs, tmp_path):
 
 def test_invalid_traj_input(tmp_path):
     """Test invalid trajectory input structure handled."""
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "traj"
 
     result = runner.invoke(
         app,
@@ -289,11 +267,7 @@ def test_invalid_traj_input(tmp_path):
             "--read-kwargs",
             "{'index': ':'}",
             "--file-prefix",
-            tmp_path / "traj",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
+            file_prefix,
         ],
     )
     assert result.exit_code == 1

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli.janus import app
-from tests.utils import assert_log_contains, strip_ansi_codes
+from tests.utils import assert_log_contains, clear_log_handlers, strip_ansi_codes
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -94,6 +94,8 @@ def test_eos():
         eos_raw_path.unlink(missing_ok=True)
         eos_fit_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
+        summary_path.unlink(missing_ok=True)
+        clear_log_handlers()
 
 
 def test_setting_lattice(tmp_path):

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -26,8 +26,8 @@ def test_eos():
     """Test calculating the equation of state."""
     eos_raw_path = Path("./NaCl-eos-raw.dat").absolute()
     eos_fit_path = Path("./NaCl-eos-fit.dat").absolute()
-    log_path = Path("./NaCl-log.yml").absolute()
-    summary_path = Path("./NaCl-summary.yml").absolute()
+    log_path = Path("./NaCl-eos-log.yml").absolute()
+    summary_path = Path("./NaCl-eos-summary.yml").absolute()
 
     assert not eos_raw_path.exists()
     assert not eos_fit_path.exists()
@@ -157,7 +157,7 @@ def test_invalid_lattice(option, value, tmp_path):
 def test_minimising_all(tmp_path):
     """Test minimising structures with different lattice constants."""
     file_prefix = tmp_path / "NaCl"
-    log_path = tmp_path / "NaCl-log.yml"
+    log_path = tmp_path / "NaCl-eos-log.yml"
 
     result = runner.invoke(
         app,

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -9,7 +9,12 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli.janus import app
-from tests.utils import assert_log_contains, read_atoms, strip_ansi_codes
+from tests.utils import (
+    assert_log_contains,
+    clear_log_handlers,
+    read_atoms,
+    strip_ansi_codes,
+)
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -52,9 +57,10 @@ def test_geomopt():
 
     finally:
         # Ensure files deleted if command fails
+        read_atoms(results_path)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
-        read_atoms(results_path)
+        clear_log_handlers()
 
 
 def test_log(tmp_path):

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -31,8 +31,8 @@ def test_help():
 def test_geomopt():
     """Test geomopt calculation."""
     results_path = Path("./NaCl-opt.extxyz").absolute()
-    log_path = Path("./NaCl-log.yml").absolute()
-    summary_path = Path("./NaCl-summary.yml").absolute()
+    log_path = Path("./NaCl-geomopt-log.yml").absolute()
+    summary_path = Path("./NaCl-geomopt-summary.yml").absolute()
 
     assert not results_path.exists()
     assert not log_path.exists()

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -23,30 +23,38 @@ def test_help():
     assert "Usage: janus geomopt [OPTIONS]" in strip_ansi_codes(result.stdout)
 
 
-def test_geomopt(tmp_path):
+def test_geomopt():
     """Test geomopt calculation."""
     results_path = Path("./NaCl-opt.extxyz").absolute()
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    log_path = Path("./NaCl-log.yml").absolute()
+    summary_path = Path("./NaCl-summary.yml").absolute()
 
     assert not results_path.exists()
+    assert not log_path.exists()
+    assert not summary_path.exists()
 
-    result = runner.invoke(
-        app,
-        [
-            "geomopt",
-            "--struct",
-            DATA_PATH / "NaCl.cif",
-            "--fmax",
-            "0.2",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
-        ],
-    )
-    read_atoms(results_path)
-    assert result.exit_code == 0
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "geomopt",
+                "--struct",
+                DATA_PATH / "NaCl.cif",
+                "--fmax",
+                "0.2",
+            ],
+        )
+        assert result.exit_code == 0
+
+        assert results_path.exists()
+        assert log_path.exists()
+        assert summary_path.exists()
+
+    finally:
+        # Ensure files deleted if command fails
+        log_path.unlink(missing_ok=True)
+        summary_path.unlink(missing_ok=True)
+        read_atoms(results_path)
 
 
 def test_log(tmp_path):

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -51,8 +51,8 @@ def test_md(ensemble):
     traj_path = Path(f"{file_prefix[ensemble]}traj.extxyz").absolute()
     rdf_path = Path(f"{file_prefix[ensemble]}rdf.dat").absolute()
     vaf_path = Path(f"{file_prefix[ensemble]}vaf.dat").absolute()
-    log_path = Path(f"{file_prefix[ensemble]}log.yml").absolute()
-    summary_path = Path(f"{file_prefix[ensemble]}summary.yml").absolute()
+    log_path = Path(f"{file_prefix[ensemble]}md-log.yml").absolute()
+    summary_path = Path(f"{file_prefix[ensemble]}md-summary.yml").absolute()
 
     assert not final_path.exists()
     assert not restart_path.exists()
@@ -116,7 +116,7 @@ def test_log(tmp_path):
     """Test log correctly written for MD."""
     file_prefix = tmp_path / "NaCl"
     stats_path = tmp_path / "NaCl-stats.dat"
-    log_path = tmp_path / "NaCl-log.yml"
+    log_path = tmp_path / "NaCl-md-log.yml"
 
     result = runner.invoke(
         app,
@@ -227,8 +227,8 @@ def test_seed(tmp_path):
 
 def test_summary(tmp_path):
     """Test summary file can be read correctly."""
-    file_prefix = tmp_path / "nvt-T300"
-    summary_path = tmp_path / "nvt-T300-summary.yml"
+    file_prefix = tmp_path / "nvt"
+    summary_path = tmp_path / "nvt-md-summary.yml"
 
     result = runner.invoke(
         app,
@@ -269,9 +269,9 @@ def test_summary(tmp_path):
 
 def test_config(tmp_path):
     """Test passing a config file with ."""
-    file_prefix = tmp_path / "nvt-T300"
-    log_path = tmp_path / "nvt-T300-log.yml"
-    summary_path = tmp_path / "nvt-T300-summary.yml"
+    file_prefix = tmp_path / "nvt"
+    log_path = tmp_path / "nvt-md-log.yml"
+    summary_path = tmp_path / "nvt-md-summary.yml"
 
     result = runner.invoke(
         app,

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -10,7 +10,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli.janus import app
-from tests.utils import assert_log_contains, strip_ansi_codes
+from tests.utils import assert_log_contains, clear_log_handlers, strip_ansi_codes
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -109,6 +109,7 @@ def test_md(ensemble):
         vaf_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        clear_log_handlers()
 
 
 def test_log(tmp_path):

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -51,8 +51,8 @@ def test_md(ensemble):
     traj_path = Path(f"{file_prefix[ensemble]}traj.extxyz").absolute()
     rdf_path = Path(f"{file_prefix[ensemble]}rdf.dat").absolute()
     vaf_path = Path(f"{file_prefix[ensemble]}vaf.dat").absolute()
-    log_path = Path("./log.yml").absolute()
-    summary_path = Path("./summary.yml").absolute()
+    log_path = Path(f"{file_prefix[ensemble]}log.yml").absolute()
+    summary_path = Path(f"{file_prefix[ensemble]}summary.yml").absolute()
 
     assert not final_path.exists()
     assert not restart_path.exists()
@@ -82,10 +82,6 @@ def test_md(ensemble):
                 2,
                 "--post-process-kwargs",
                 "{'rdf_compute': True, 'vaf_compute': True}",
-                "--log",
-                log_path,
-                "--summary",
-                summary_path,
             ],
         )
 
@@ -117,9 +113,9 @@ def test_md(ensemble):
 
 def test_log(tmp_path):
     """Test log correctly written for MD."""
-    file_prefix = tmp_path / "nvt-T300"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    file_prefix = tmp_path / "NaCl"
+    stats_path = tmp_path / "NaCl-stats.dat"
+    log_path = tmp_path / "NaCl-log.yml"
 
     result = runner.invoke(
         app,
@@ -129,24 +125,21 @@ def test_log(tmp_path):
             "nvt",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            "--file-prefix",
-            file_prefix,
             "--steps",
             20,
             "--stats-every",
             1,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
+            "--file-prefix",
+            file_prefix,
         ],
     )
     assert result.exit_code == 0
 
     assert_log_contains(log_path, includes=["Starting molecular dynamics simulation"])
 
-    with open(tmp_path / "nvt-T300-stats.dat", encoding="utf8") as stats_file:
+    with open(stats_path, encoding="utf8") as stats_file:
         lines = stats_file.readlines()
+
         # Includes step 0
         assert len(lines) == 22
 
@@ -169,8 +162,6 @@ def test_seed(tmp_path):
     """Test seed enables reproducable results for NVT."""
     file_prefix = tmp_path / "nvt-T300"
     stats_path = tmp_path / "nvt-T300-stats.dat"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result_1 = runner.invoke(
         app,
@@ -188,10 +179,6 @@ def test_seed(tmp_path):
             20,
             "--seed",
             42,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result_1.exit_code == 0
@@ -221,10 +208,6 @@ def test_seed(tmp_path):
             20,
             "--seed",
             42,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result_2.exit_code == 0
@@ -244,8 +227,7 @@ def test_seed(tmp_path):
 def test_summary(tmp_path):
     """Test summary file can be read correctly."""
     file_prefix = tmp_path / "nvt-T300"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    summary_path = tmp_path / "nvt-T300-summary.yml"
 
     result = runner.invoke(
         app,
@@ -261,10 +243,6 @@ def test_summary(tmp_path):
             2,
             "--traj-every",
             1,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
 
@@ -291,8 +269,8 @@ def test_summary(tmp_path):
 def test_config(tmp_path):
     """Test passing a config file with ."""
     file_prefix = tmp_path / "nvt-T300"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    log_path = tmp_path / "nvt-T300-log.yml"
+    summary_path = tmp_path / "nvt-T300-summary.yml"
 
     result = runner.invoke(
         app,
@@ -307,10 +285,6 @@ def test_config(tmp_path):
             "--steps",
             2,
             "--minimize",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
             "--config",
             DATA_PATH / "md_config.yml",
         ],
@@ -338,8 +312,6 @@ def test_config(tmp_path):
 def test_heating(tmp_path):
     """Test heating before MD."""
     file_prefix = tmp_path / "nvt-T300"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -363,10 +335,6 @@ def test_heating(tmp_path):
             50,
             "--temp-time",
             0.05,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -396,8 +364,6 @@ def test_ensemble_kwargs(tmp_path):
     file_prefix = tmp_path / "test" / "md"
     final_path = tmp_path / "test" / "md-final.extxyz"
     stats_path = tmp_path / "test" / "md-stats.dat"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     ensemble_kwargs = "{'mask' : (0, 1, 0)}"
 
@@ -417,10 +383,6 @@ def test_ensemble_kwargs(tmp_path):
             ensemble_kwargs,
             "--stats-every",
             1,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
 
@@ -444,8 +406,6 @@ def test_ensemble_kwargs(tmp_path):
 def test_invalid_ensemble_kwargs(tmp_path):
     """Test passing invalid key to ensemble-kwargs."""
     file_prefix = tmp_path / "npt-T300"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     # Not an option for NVT
     ensemble_kwargs = "{'mask': (0, 1, 0)}"
@@ -466,10 +426,6 @@ def test_invalid_ensemble_kwargs(tmp_path):
             ensemble_kwargs,
             "--traj-every",
             1,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
 
@@ -483,8 +439,7 @@ def test_final_name(tmp_path):
     stats_path = tmp_path / "npt-stats.dat"
     traj_path = tmp_path / "npt-traj.extxyz"
     final_path = tmp_path / "example.extxyz"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+
     result = runner.invoke(
         app,
         [
@@ -503,10 +458,6 @@ def test_final_name(tmp_path):
             file_prefix,
             "--final-file",
             final_path,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -521,8 +472,6 @@ def test_write_kwargs(tmp_path):
     file_prefix = tmp_path / "md"
     final_path = tmp_path / "md-final.extxyz"
     traj_path = tmp_path / "md-traj.extxyz"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     write_kwargs = (
         "{'invalidate_calc': False, 'columns': ['symbols', 'positions', 'masses']}"
@@ -544,10 +493,6 @@ def test_write_kwargs(tmp_path):
             write_kwargs,
             "--traj-every",
             1,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
 
@@ -575,8 +520,6 @@ def test_valid_traj_input(read_kwargs, tmp_path):
     """Test valid trajectory input structure handled."""
     file_prefix = tmp_path / "traj"
     final_path = tmp_path / "traj-final.extxyz"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -592,10 +535,6 @@ def test_valid_traj_input(read_kwargs, tmp_path):
             2,
             "--read-kwargs",
             read_kwargs,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -606,8 +545,6 @@ def test_valid_traj_input(read_kwargs, tmp_path):
 def test_invalid_traj_input(tmp_path):
     """Test invalid trajectory input structure handled."""
     file_prefix = tmp_path / "traj"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -623,10 +560,6 @@ def test_invalid_traj_input(tmp_path):
             2,
             "--read-kwargs",
             "{'index': ':'}",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 1
@@ -640,8 +573,6 @@ def test_minimize_kwargs_filename(tmp_path):
     traj_path = tmp_path / "test" / "md-traj.extxyz"
     stats_path = tmp_path / "test" / "md-stats.dat"
     final_path = tmp_path / "test" / "md-final.extxyz"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -662,10 +593,6 @@ def test_minimize_kwargs_filename(tmp_path):
             "--minimize",
             "--minimize-kwargs",
             f"{{'write_kwargs': {{'filename': '{opt_path}'}}}}",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 0
@@ -686,8 +613,6 @@ def test_minimize_kwargs_write_results(tmp_path):
     traj_path = tmp_path / "test" / "md-traj.extxyz"
     stats_path = tmp_path / "test" / "md-stats.dat"
     final_path = tmp_path / "test" / "md-final.extxyz"
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
 
     result = runner.invoke(
         app,
@@ -708,10 +633,6 @@ def test_minimize_kwargs_write_results(tmp_path):
             "--minimize",
             "--minimize-kwargs",
             "{'write_results': True}",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
         ],
     )
     assert result.exit_code == 0

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -7,7 +7,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli.janus import app
-from tests.utils import assert_log_contains, strip_ansi_codes
+from tests.utils import assert_log_contains, clear_log_handlers, strip_ansi_codes
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -69,6 +69,7 @@ def test_phonons():
         bands_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        clear_log_handlers()
 
 
 def test_bands_simple(tmp_path):

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -25,8 +25,8 @@ def test_phonons():
     """Test calculating force constants and band structure."""
     phonopy_path = Path("./NaCl-phonopy.yml").absolute()
     bands_path = Path("./NaCl-auto_bands.yml").absolute()
-    log_path = Path("./NaCl-log.yml").absolute()
-    summary_path = Path("./NaCl-summary.yml").absolute()
+    log_path = Path("./NaCl-phonons-log.yml").absolute()
+    summary_path = Path("./NaCl-phonons-summary.yml").absolute()
 
     assert not phonopy_path.exists()
     assert not bands_path.exists()
@@ -76,7 +76,7 @@ def test_bands_simple(tmp_path):
     """Test calculating force constants and reduced bands information."""
     file_prefix = tmp_path / "NaCl"
     autoband_results = tmp_path / "NaCl-auto_bands.yml"
-    summary_path = tmp_path / "NaCl-summary.yml"
+    summary_path = tmp_path / "NaCl-phonons-summary.yml"
 
     result = runner.invoke(
         app,
@@ -194,11 +194,11 @@ def test_pdos(tmp_path):
 def test_plot(tmp_path):
     """Test for ploting routines."""
     file_prefix = tmp_path / "NaCl"
-    summary_path = tmp_path / "NaCl-summary.yml"
     pdos_results = tmp_path / "NaCl-pdos.dat"
     dos_results = tmp_path / "NaCl-dos.dat"
     hdf5_results = tmp_path / "NaCl-force_constants.hdf5"
     autoband_results = tmp_path / "NaCl-auto_bands.yml"
+    summary_path = tmp_path / "NaCl-phonons-summary.yml"
     svgs = [
         tmp_path / "NaCl-dos.svg",
         tmp_path / "NaCl-pdos.svg",
@@ -298,8 +298,8 @@ def test_invalid_supercell(supercell, tmp_path):
 def test_minimize_kwargs(tmp_path):
     """Test setting optimizer function and writing optimized structure."""
     file_prefix = tmp_path / "test"
-    log_path = tmp_path / "test-log.yml"
     opt_path = tmp_path / "test-opt.extxyz"
+    log_path = tmp_path / "test-phonons-log.yml"
 
     minimize_kwargs = "{'optimizer': 'FIRE', 'write_results': True}"
 

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -30,8 +30,8 @@ def test_singlepoint_help():
 def test_singlepoint():
     """Test singlepoint calculation."""
     results_path = Path("./NaCl-results.extxyz").absolute()
-    log_path = Path("./NaCl-log.yml").absolute()
-    summary_path = Path("./NaCl-summary.yml").absolute()
+    log_path = Path("./NaCl-singlepoint-log.yml").absolute()
+    summary_path = Path("./NaCl-singlepoint-summary.yml").absolute()
 
     assert not results_path.exists()
     assert not log_path.exists()
@@ -44,10 +44,6 @@ def test_singlepoint():
                 "singlepoint",
                 "--struct",
                 DATA_PATH / "NaCl.cif",
-                "--log",
-                log_path,
-                "--summary",
-                summary_path,
             ],
         )
         assert result.exit_code == 0

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -22,30 +22,44 @@ def test_singlepoint_help():
     assert "Usage: janus singlepoint [OPTIONS]" in strip_ansi_codes(result.stdout)
 
 
-def test_singlepoint(tmp_path):
+def test_singlepoint():
     """Test singlepoint calculation."""
     results_path = Path("./NaCl-results.extxyz").absolute()
-    log_path = tmp_path / "test.log"
-    summary_path = tmp_path / "summary.yml"
+    log_path = Path("./NaCl-log.yml").absolute()
+    summary_path = Path("./NaCl-summary.yml").absolute()
 
-    result = runner.invoke(
-        app,
-        [
-            "singlepoint",
-            "--struct",
-            DATA_PATH / "NaCl.cif",
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
-        ],
-    )
+    assert not results_path.exists()
+    assert not log_path.exists()
+    assert not summary_path.exists()
 
-    # Check atoms can read read, then delete file
-    atoms = read_atoms(results_path)
-    assert result.exit_code == 0
-    assert "mace_mp_energy" in atoms.info
-    assert "mace_mp_forces" in atoms.arrays
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "singlepoint",
+                "--struct",
+                DATA_PATH / "NaCl.cif",
+                "--log",
+                log_path,
+                "--summary",
+                summary_path,
+            ],
+        )
+        assert result.exit_code == 0
+
+        assert results_path.exists()
+        assert log_path.exists()
+        assert summary_path.exists
+
+    finally:
+        # Ensure files deleted if command fails
+        log_path.unlink(missing_ok=True)
+        summary_path.unlink(missing_ok=True)
+
+        # Check atoms can read read, then delete file
+        atoms = read_atoms(results_path)
+        assert "mace_mp_energy" in atoms.info
+        assert "mace_mp_forces" in atoms.arrays
 
 
 def test_properties(tmp_path):
@@ -235,6 +249,7 @@ def test_config(tmp_path):
     results_path = tmp_path / "benzene-traj-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
+
     result = runner.invoke(
         app,
         [

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -8,7 +8,12 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli.janus import app
-from tests.utils import assert_log_contains, read_atoms, strip_ansi_codes
+from tests.utils import (
+    assert_log_contains,
+    clear_log_handlers,
+    read_atoms,
+    strip_ansi_codes,
+)
 
 DATA_PATH = Path(__file__).parent / "data"
 
@@ -52,14 +57,15 @@ def test_singlepoint():
         assert summary_path.exists
 
     finally:
-        # Ensure files deleted if command fails
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
-
         # Check atoms can read read, then delete file
         atoms = read_atoms(results_path)
         assert "mace_mp_energy" in atoms.info
         assert "mace_mp_forces" in atoms.arrays
+
+        # Ensure files deleted if command fails
+        log_path.unlink(missing_ok=True)
+        summary_path.unlink(missing_ok=True)
+        clear_log_handlers()
 
 
 def test_properties(tmp_path):

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 import yaml
 
 from janus_core.cli.janus import app
-from tests.utils import assert_log_contains, strip_ansi_codes
+from tests.utils import assert_log_contains, clear_log_handlers, strip_ansi_codes
 
 DATA_PATH = Path(__file__).parent / "data"
 MODEL_PATH = Path(__file__).parent / "models"
@@ -133,11 +133,7 @@ def test_train(tmp_path):
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
 
-        # Clean up logger
-        logger = logging.getLogger()
-        logger.handlers = [
-            h for h in logger.handlers if not isinstance(h, logging.FileHandler)
-        ]
+        clear_log_handlers()
 
 
 def test_train_with_foundation(tmp_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for tests."""
 
+import logging
 from pathlib import Path
 import re
 from typing import Union
@@ -101,3 +102,11 @@ def strip_ansi_codes(output: str) -> str:
         re.VERBOSE,
     )
     return ansi_escape.sub("", output)
+
+
+def clear_log_handlers():
+    """Clear all log handlers."""
+    logger = logging.getLogger()
+    logger.handlers = [
+        h for h in logger.handlers if not isinstance(h, logging.FileHandler)
+    ]


### PR DESCRIPTION
Resolves #132

As mentioned in the issue, sharing the summary is relatively straightforward, but extra changes were needed to use the `FileNameMixin` to set the log filename to be consistent with other output files.

Since the default filename moves into the Python, I added an additional flag that controls the logging, so a filename isn't required. 

Loosely depends on fixing #279, for correct documentation, and tests will then require updating following a fix.