### PR TITLE
Update ALIGNN testing

### DIFF
--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -1,6 +1,7 @@
 """Test configuration of MLIP calculators."""
 
 from pathlib import Path
+from zipfile import BadZipFile
 
 from chgnet.model.model import CHGNet
 from matgl import load_model
@@ -119,12 +120,15 @@ def test_invalid_device(arch):
 )
 def test_extra_mlips(arch, device, kwargs):
     """Test extra MLIPs (alignn) can be configured."""
-    calculator = choose_calculator(
-        arch=arch,
-        device=device,
-        **kwargs,
-    )
-    assert calculator.parameters["version"] is not None
+    try:
+        calculator = choose_calculator(
+            arch=arch,
+            device=device,
+            **kwargs,
+        )
+        assert calculator.parameters["version"] is not None
+    except BadZipFile:
+        pytest.skip()
 
 
 @pytest.mark.extra_mlips

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -14,6 +14,7 @@ MODEL_PATH = Path(__file__).parent / "models"
 
 MACE_PATH = MODEL_PATH / "mace_mp_small.model"
 SEVENNET_PATH = MODEL_PATH / "sevennet_0.pth"
+ALIGNN_PATH = MODEL_PATH / "v5.27.2024"
 
 test_data = [
     (DATA_PATH / "benzene.xyz", -76.0605725422795, "energy", "energy", {}, None),
@@ -270,7 +271,12 @@ def test_mlips(arch, device, expected_energy):
 
 
 test_extra_mlips_data = [
-    ("alignn", "cpu", -11.148092269897461, {}),
+    (
+        "alignn",
+        "cpu",
+        -11.148092269897461,
+        {"model_path": ALIGNN_PATH / "best_model.pt"},
+    ),
     ("sevennet", "cpu", -27.061979293823242, {"model_path": SEVENNET_PATH}),
     ("sevennet", "cpu", -27.061979293823242, {}),
     ("sevennet", "cpu", -27.061979293823242, {"model_path": "SevenNet-0_11July2024"}),


### PR DESCRIPTION
Resolves #276

- Uses our saved copy of ALIGNN for singlepoint testing
- Adds skip to MLIP calculator test if a bad zip file is encountered, so the CI doesn't fail if the model download is an issue
  - If the remaining two tests are always skipped, we may want to revisit this, but from what I've seen it's rare that the error occurs for every version of Python, so we should still be testing these model inputs in general.
  - Tests also seem ok locally, so we should still be able to keep track of any breaking changes