### PR TITLE
Add file inputs to all calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ We recommend installing poetry for dependency management when developing for `ja
 git clone https://github.com/stfc/janus-core
 cd janus-core
 python3 -m pip install --upgrade pip
-poetry install --with pre-commit,dev,docs  # install extra dependencies
+poetry install --with pre-commit,dev,docs  # install with useful dev dependencies
 pre-commit install  # install pre-commit hooks
 pytest -v  # discover and run all tests
 ```

--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -114,6 +114,16 @@ janus\_core.cli.utils module
    :undoc-members:
    :show-inheritance:
 
+janus\_core.calculations.base module
+------------------------------------
+
+.. automodule:: janus_core.calculations.base
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
 janus\_core.calculations.single\_point module
 ---------------------------------------------
 

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -1,0 +1,126 @@
+"""Prepare structures for MLIP calculations."""
+
+from typing import Any, Optional
+
+from ase import Atoms
+
+from janus_core.helpers.janus_types import (
+    Architectures,
+    ASEReadArgs,
+    Devices,
+    MaybeSequence,
+    PathLike,
+)
+from janus_core.helpers.log import config_logger, config_tracker
+from janus_core.helpers.utils import FileNameMixin, input_structs, none_to_dict
+
+
+class BaseCalculation(FileNameMixin):
+    """
+    Prepare structures for MLIP calculations.
+
+    Parameters
+    ----------
+    struct : Optional[MaybeSequence[Atoms]]
+        ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
+        Default is None.
+    struct_path : Optional[PathLike]
+        Path of structure to simulate. Required if `struct` is None.
+        Default is None.
+    arch : Architectures
+        MLIP architecture to use for calculations. Default is "mace_mp".
+    device : Devices
+        Device to run model on. Default is "cpu".
+    model_path : Optional[PathLike]
+        Path to MLIP model. Default is `None`.
+    read_kwargs : ASEReadArgs
+        Keyword arguments to pass to ase.io.read. Default is {}.
+    sequence_allowed : bool
+        Whether a sequence of Atoms objects is allowed. Default is True.
+    calc_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to the selected calculator. Default is {}.
+    log_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_logger`. Default is {}.
+    tracker_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_tracker`. Default is {}.
+
+    Attributes
+    ----------
+    logger : Optional[logging.Logger]
+        Logger if log file has been specified.
+    tracker : Optional[OfflineEmissionsTracker]
+        Tracker if logging is enabled.
+    """
+
+    def __init__(
+        self,
+        *,
+        struct: Optional[MaybeSequence[Atoms]] = None,
+        struct_path: Optional[PathLike] = None,
+        arch: Architectures = "mace_mp",
+        device: Devices = "cpu",
+        model_path: Optional[PathLike] = None,
+        read_kwargs: Optional[ASEReadArgs] = None,
+        sequence_allowed: bool = True,
+        calc_kwargs: Optional[dict[str, Any]] = None,
+        log_kwargs: Optional[dict[str, Any]] = None,
+        tracker_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """
+        Read the structure being simulated and attach an MLIP calculator.
+
+        Parameters
+        ----------
+        struct : Optional[MaybeSequence[Atoms]]
+            ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
+            Default is None.
+        struct_path : Optional[PathLike]
+            Path of structure to simulate. Required if `struct` is None. Default is
+            None.
+        arch : Architectures
+            MLIP architecture to use for calculations. Default is "mace_mp".
+        device : Devices
+            Device to run MLIP model on. Default is "cpu".
+        model_path : Optional[PathLike]
+            Path to MLIP model. Default is `None`.
+        read_kwargs : Optional[ASEReadArgs]
+            Keyword arguments to pass to ase.io.read. Default is {}.
+        sequence_allowed : bool
+            Whether a sequence of Atoms objects is allowed. Default is True.
+        calc_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to the selected calculator. Default is {}.
+        log_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_logger`. Default is {}.
+        tracker_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_tracker`. Default is {}.
+        """
+        (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs) = none_to_dict(
+            (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs)
+        )
+
+        self.struct = struct
+        self.struct_path = struct_path
+        self.arch = arch
+        self.device = device
+        self.model_path = model_path
+        self.read_kwargs = read_kwargs
+        self.calc_kwargs = calc_kwargs
+
+        if not self.model_path and "model_path" in self.calc_kwargs:
+            raise ValueError("`model_path` must be passed explicitly")
+
+        # Configure logging
+        self.logger = config_logger(**log_kwargs)
+        self.tracker = config_tracker(self.logger, **tracker_kwargs)
+
+        self.struct = input_structs(
+            struct=self.struct,
+            struct_path=self.struct_path,
+            read_kwargs=self.read_kwargs,
+            sequence_allowed=sequence_allowed,
+            arch=self.arch,
+            device=self.device,
+            model_path=self.model_path,
+            calc_kwargs=self.calc_kwargs,
+            logger=self.logger,
+        )

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -39,6 +39,8 @@ class BaseCalculation(FileNameMixin):
         Whether a sequence of Atoms objects is allowed. Default is True.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
+    set_calc : Optional[bool]
+        Whether to set (new) calculators for structures. Default is None.
     log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -63,6 +65,7 @@ class BaseCalculation(FileNameMixin):
         read_kwargs: Optional[ASEReadArgs] = None,
         sequence_allowed: bool = True,
         calc_kwargs: Optional[dict[str, Any]] = None,
+        set_calc: Optional[bool] = None,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
@@ -89,6 +92,8 @@ class BaseCalculation(FileNameMixin):
             Whether a sequence of Atoms objects is allowed. Default is True.
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
+        set_calc : Optional[bool]
+            Whether to set (new) calculators for structures. Default is None.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -122,5 +127,6 @@ class BaseCalculation(FileNameMixin):
             device=self.device,
             model_path=self.model_path,
             calc_kwargs=self.calc_kwargs,
+            set_calc=set_calc,
             logger=self.logger,
         )

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -110,13 +110,15 @@ class BaseCalculation(FileNameMixin):
         self.model_path = model_path
         self.read_kwargs = read_kwargs
         self.calc_kwargs = calc_kwargs
+        self.log_kwargs = log_kwargs
+        self.tracker_kwargs = tracker_kwargs
 
         if not self.model_path and "model_path" in self.calc_kwargs:
             raise ValueError("`model_path` must be passed explicitly")
 
         # Configure logging
-        self.logger = config_logger(**log_kwargs)
-        self.tracker = config_tracker(self.logger, **tracker_kwargs)
+        self.logger = config_logger(**self.log_kwargs)
+        self.tracker = config_tracker(self.logger, **self.tracker_kwargs)
 
         self.struct = input_structs(
             struct=self.struct,

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -47,6 +47,10 @@ class BaseCalculation(FileNameMixin):
             Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
+    file_prefix : Optional[PathLike]
+        Prefix for output filenames. Default is None.
+    additional_prefix : Optional[str]
+        Component to add to default file_prefix (joined by hyphens). Default is None.
 
     Attributes
     ----------
@@ -71,6 +75,8 @@ class BaseCalculation(FileNameMixin):
         set_calc: Optional[bool] = None,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
+        file_prefix: Optional[PathLike] = None,
+        additional_prefix: Optional[str] = None,
     ) -> None:
         """
         Read the structure being simulated and attach an MLIP calculator.
@@ -103,6 +109,11 @@ class BaseCalculation(FileNameMixin):
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
+        file_prefix : Optional[PathLike]
+            Prefix for output filenames. Default is None.
+        additional_prefix : Optional[str]
+            Component to add to default file_prefix (joined by hyphens). Default is
+            None.
         """
         (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs) = none_to_dict(
             (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs)
@@ -140,4 +151,12 @@ class BaseCalculation(FileNameMixin):
             calc_kwargs=self.calc_kwargs,
             set_calc=set_calc,
             logger=self.logger,
+        )
+
+        FileNameMixin.__init__(
+            self,
+            self.struct,
+            self.struct_path,
+            file_prefix,
+            additional_prefix,
         )

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -21,6 +21,8 @@ class BaseCalculation(FileNameMixin):
 
     Parameters
     ----------
+    calc_name : str
+        Name of calculation being run, used for name of logger. Default is "base".
     struct : Optional[MaybeSequence[Atoms]]
         ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
         Default is None.
@@ -57,6 +59,7 @@ class BaseCalculation(FileNameMixin):
     def __init__(
         self,
         *,
+        calc_name: str = "base",
         struct: Optional[MaybeSequence[Atoms]] = None,
         struct_path: Optional[PathLike] = None,
         arch: Architectures = "mace_mp",
@@ -74,6 +77,8 @@ class BaseCalculation(FileNameMixin):
 
         Parameters
         ----------
+        calc_name : str
+            Name of calculation being run, used for name of logger. Default is "base".
         struct : Optional[MaybeSequence[Atoms]]
             ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
             Default is None.
@@ -116,7 +121,11 @@ class BaseCalculation(FileNameMixin):
         if not self.model_path and "model_path" in self.calc_kwargs:
             raise ValueError("`model_path` must be passed explicitly")
 
+        if log_kwargs and "filename" not in log_kwargs:
+            raise ValueError("'filename' must be included in `log_kwargs`")
+
         # Configure logging
+        log_kwargs.setdefault("name", calc_name)
         self.logger = config_logger(**self.log_kwargs)
         self.tracker = config_tracker(self.logger, **self.tracker_kwargs)
 

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -16,7 +16,7 @@ from janus_core.helpers.janus_types import (
     MaybeSequence,
     PathLike,
 )
-from janus_core.helpers.utils import FileNameMixin, none_to_dict
+from janus_core.helpers.utils import none_to_dict
 
 
 class Descriptors(BaseCalculation):
@@ -159,7 +159,6 @@ class Descriptors(BaseCalculation):
             raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, self.struct_path, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("descriptors.extxyz").absolute(),

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -7,19 +7,47 @@ from ase import Atoms
 from ase.io import write
 import numpy as np
 
-from janus_core.helpers.janus_types import ASEWriteArgs, MaybeSequence
-from janus_core.helpers.log import config_logger, config_tracker
+from janus_core.calculations.base import BaseCalculation
+from janus_core.helpers.janus_types import (
+    Architectures,
+    ASEReadArgs,
+    ASEWriteArgs,
+    Devices,
+    MaybeSequence,
+    PathLike,
+)
 from janus_core.helpers.utils import FileNameMixin, none_to_dict
 
 
-class Descriptors(FileNameMixin):
+class Descriptors(BaseCalculation):
     """
     Prepare and calculate MLIP descriptors for structures.
 
     Parameters
     ----------
-    struct : MaybeSequence[Atoms]
-        Structure(s) to calculate descriptors for.
+    struct : Optional[MaybeSequence[Atoms]]
+        ASE Atoms structure(s) to calculate descriptors for. Required if `struct_path`
+        is None. Default is None.
+    struct_path : Optional[PathLike]
+        Path of structure to calculate descriptors for. Required if `struct` is None.
+        Default is None.
+    arch : Architectures
+        MLIP architecture to use for calculations. Default is "mace_mp".
+    device : Devices
+        Device to run MLIP model on. Default is "cpu".
+    model_path : Optional[PathLike]
+        Path to MLIP model. Default is `None`.
+    read_kwargs : Optional[ASEReadArgs]
+        Keyword arguments to pass to ase.io.read. By default,
+        read_kwargs["index"] is -1.
+    calc_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to the selected calculator. Default is {}.
+    set_calc : Optional[bool]
+        Whether to set (new) calculators for structures. Default is None.
+    log_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to `config_logger`. Default is {}.
+    tracker_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to `config_tracker`. Default is {}.
     invariants_only : bool
         Whether only the invariant descriptors should be returned. Default is True.
     calc_per_element : bool
@@ -31,17 +59,6 @@ class Descriptors(FileNameMixin):
     write_kwargs : Optional[ASEWriteArgs],
         Keyword arguments to pass to ase.io.write if saving structure with
         results of calculations. Default is {}.
-    log_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to `config_logger`. Default is {}.
-    tracker_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to `config_tracker`. Default is {}.
-
-    Attributes
-    ----------
-    logger : Optional[logging.Logger]
-        Logger if log file has been specified.
-    tracker : Optional[OfflineEmissionsTracker]
-        Tracker if logging is enabled.
 
     Methods
     -------
@@ -51,22 +68,50 @@ class Descriptors(FileNameMixin):
 
     def __init__(
         self,
-        struct: MaybeSequence[Atoms],
+        struct: Optional[MaybeSequence[Atoms]] = None,
+        struct_path: Optional[PathLike] = None,
+        arch: Architectures = "mace_mp",
+        device: Devices = "cpu",
+        model_path: Optional[PathLike] = None,
+        read_kwargs: Optional[ASEReadArgs] = None,
+        calc_kwargs: Optional[dict[str, Any]] = None,
+        set_calc: Optional[bool] = None,
+        log_kwargs: Optional[dict[str, Any]] = None,
+        tracker_kwargs: Optional[dict[str, Any]] = None,
         invariants_only: bool = True,
         calc_per_element: bool = False,
         calc_per_atom: bool = False,
         write_results: bool = False,
         write_kwargs: Optional[ASEWriteArgs] = None,
-        log_kwargs: Optional[dict[str, Any]] = None,
-        tracker_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Initialise class.
 
         Parameters
         ----------
-        struct : MaybeSequence[Atoms]
-            Structure(s) to calculate descriptors for.
+        struct : Optional[MaybeSequence[Atoms]]
+            ASE Atoms structure(s) to calculate descriptors for. Required if
+            `struct_path` is None. Default is None.
+        struct_path : Optional[PathLike]
+            Path of structure to calculate descriptors for. Required if `struct` is
+            None. Default is None.
+        arch : Architectures
+            MLIP architecture to use for calculations. Default is "mace_mp".
+        device : Devices
+            Device to run MLIP model on. Default is "cpu".
+        model_path : Optional[PathLike]
+            Path to MLIP model. Default is `None`.
+        read_kwargs : Optional[ASEReadArgs]
+            Keyword arguments to pass to ase.io.read. By default,
+            read_kwargs["index"] is -1.
+        calc_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to the selected calculator. Default is {}.
+        set_calc : Optional[bool]
+            Whether to set (new) calculators for structures. Default is None.
+        log_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_logger`. Default is {}.
+        tracker_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_tracker`. Default is {}.
         invariants_only : bool
             Whether only the invariant descriptors should be returned. Default is True.
         calc_per_element : bool
@@ -78,39 +123,59 @@ class Descriptors(FileNameMixin):
         write_kwargs : Optional[ASEWriteArgs],
             Keyword arguments to pass to ase.io.write if saving structure with
             results of calculations. Default is {}.
-        log_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to `config_logger`. Default is {}.
-        tracker_kwargs : Optional[dict[str, Any]]
-                Keyword arguments to pass to `config_tracker`. Default is {}.
         """
-        (write_kwargs, log_kwargs, tracker_kwargs) = none_to_dict(
-            (write_kwargs, log_kwargs, tracker_kwargs)
+        (
+            read_kwargs,
+            calc_kwargs,
+            log_kwargs,
+            tracker_kwargs,
+            write_kwargs,
+        ) = none_to_dict(
+            (
+                read_kwargs,
+                calc_kwargs,
+                log_kwargs,
+                tracker_kwargs,
+                write_kwargs,
+            )
         )
 
-        self.struct = struct
         self.invariants_only = invariants_only
         self.calc_per_element = calc_per_element
         self.calc_per_atom = calc_per_atom
         self.write_results = write_results
         self.write_kwargs = write_kwargs
 
-        # Validate parameters
-        if isinstance(self.struct, Sequence):
-            if any(not image.calc for image in struct):
-                raise ValueError(
-                    "Please attach a calculator to all images in `struct`."
-                )
-        else:
-            if not self.struct.calc:
-                raise ValueError("Please attach a calculator to `struct`.")
+        # Read last image by default
+        read_kwargs.setdefault("index", ":")
 
-        # Configure logging
+        # Set log name
         log_kwargs.setdefault("name", __name__)
-        self.logger = config_logger(**log_kwargs)
-        self.tracker = config_tracker(self.logger, **tracker_kwargs)
+
+        # Initialise structures and logging
+        super().__init__(
+            struct=struct,
+            struct_path=struct_path,
+            arch=arch,
+            device=device,
+            model_path=model_path,
+            read_kwargs=read_kwargs,
+            sequence_allowed=True,
+            calc_kwargs=calc_kwargs,
+            set_calc=set_calc,
+            log_kwargs=log_kwargs,
+            tracker_kwargs=tracker_kwargs,
+        )
+
+        if isinstance(self.struct, Atoms) and not self.struct.calc:
+            raise ValueError("Please attach a calculator to `struct`.")
+        if isinstance(self.struct, Sequence) and not any(
+            image.calc for image in self.struct
+        ):
+            raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file
-        FileNameMixin.__init__(self, struct, None)
+        FileNameMixin.__init__(self, self.struct, self.struct_path, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("descriptors.extxyz").absolute(),

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -124,21 +124,7 @@ class Descriptors(BaseCalculation):
             Keyword arguments to pass to ase.io.write if saving structure with
             results of calculations. Default is {}.
         """
-        (
-            read_kwargs,
-            calc_kwargs,
-            log_kwargs,
-            tracker_kwargs,
-            write_kwargs,
-        ) = none_to_dict(
-            (
-                read_kwargs,
-                calc_kwargs,
-                log_kwargs,
-                tracker_kwargs,
-                write_kwargs,
-            )
-        )
+        (read_kwargs, write_kwargs) = none_to_dict((read_kwargs, write_kwargs))
 
         self.invariants_only = invariants_only
         self.calc_per_element = calc_per_element
@@ -149,11 +135,9 @@ class Descriptors(BaseCalculation):
         # Read last image by default
         read_kwargs.setdefault("index", ":")
 
-        # Set log name
-        log_kwargs.setdefault("name", __name__)
-
         # Initialise structures and logging
         super().__init__(
+            calc_name=__name__,
             struct=struct,
             struct_path=struct_path,
             arch=arch,

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -19,7 +19,7 @@ from janus_core.helpers.janus_types import (
     OutputKwargs,
     PathLike,
 )
-from janus_core.helpers.utils import FileNameMixin, none_to_dict, output_structs
+from janus_core.helpers.utils import none_to_dict, output_structs
 
 
 class EoS(BaseCalculation):
@@ -224,13 +224,13 @@ class EoS(BaseCalculation):
             set_calc=set_calc,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
+            file_prefix=file_prefix,
         )
 
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, self.struct_path, file_prefix)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("generated.extxyz").absolute(),

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -173,22 +173,8 @@ class EoS(BaseCalculation):
             Prefix for output filenames. Default is inferred from structure name, or
             chemical formula of the structure.
         """
-        (
-            read_kwargs,
-            calc_kwargs,
-            log_kwargs,
-            tracker_kwargs,
-            minimize_kwargs,
-            write_kwargs,
-        ) = none_to_dict(
-            (
-                read_kwargs,
-                calc_kwargs,
-                log_kwargs,
-                tracker_kwargs,
-                minimize_kwargs,
-                write_kwargs,
-            )
+        (read_kwargs, minimize_kwargs, write_kwargs) = none_to_dict(
+            (read_kwargs, minimize_kwargs, write_kwargs)
         )
 
         self.min_volume = min_volume
@@ -224,11 +210,9 @@ class EoS(BaseCalculation):
         # Read last image by default
         read_kwargs.setdefault("index", -1)
 
-        # Set log name
-        log_kwargs.setdefault("name", __name__)
-
         # Initialise structures and logging
         super().__init__(
+            calc_name=__name__,
             struct=struct,
             struct_path=struct_path,
             arch=arch,

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -47,6 +47,8 @@ class GeomOpt(BaseCalculation):
         read_kwargs["index"] is -1.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
+    set_calc : Optional[bool]
+        Whether to set (new) calculators for structures. Default is Nonw.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -97,6 +99,7 @@ class GeomOpt(BaseCalculation):
         model_path: Optional[PathLike] = None,
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
+        set_calc: Optional[bool] = None,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         fmax: float = 0.1,
@@ -133,6 +136,8 @@ class GeomOpt(BaseCalculation):
             read_kwargs["index"] is -1.
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
+        set_calc : Optional[bool]
+            Whether to set (new) calculators for structures. Default is None.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -228,6 +233,7 @@ class GeomOpt(BaseCalculation):
             read_kwargs=read_kwargs,
             sequence_allowed=False,
             calc_kwargs=calc_kwargs,
+            set_calc=set_calc,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
         )

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -169,25 +169,9 @@ class GeomOpt(BaseCalculation):
             Keyword arguments to pass to ase.io.write to save optimization trajectory.
             Must include "filename" keyword. Default is {}.
         """
-        (
-            read_kwargs,
-            calc_kwargs,
-            log_kwargs,
-            tracker_kwargs,
-            filter_kwargs,
-            opt_kwargs,
-            write_kwargs,
-            traj_kwargs,
-        ) = none_to_dict(
-            (
-                read_kwargs,
-                calc_kwargs,
-                log_kwargs,
-                tracker_kwargs,
-                filter_kwargs,
-                opt_kwargs,
-                write_kwargs,
-                traj_kwargs,
+        (read_kwargs, filter_kwargs, opt_kwargs, write_kwargs, traj_kwargs) = (
+            none_to_dict(
+                (read_kwargs, filter_kwargs, opt_kwargs, write_kwargs, traj_kwargs)
             )
         )
 
@@ -212,17 +196,12 @@ class GeomOpt(BaseCalculation):
                 "'trajectory' must be a key in `opt_kwargs` to save the trajectory."
             )
 
-        if log_kwargs and "filename" not in log_kwargs:
-            raise ValueError("'filename' must be included in `log_kwargs`")
-
         # Read last image by default
         read_kwargs.setdefault("index", -1)
 
-        # Set log name
-        log_kwargs.setdefault("name", __name__)
-
         # Initialise structures and logging
         super().__init__(
+            calc_name=__name__,
             struct=struct,
             struct_path=struct_path,
             arch=arch,

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -30,7 +30,7 @@ class GeomOpt(BaseCalculation):
     Parameters
     ----------
     struct : Optional[Atoms]
-        ASE Atoms structure(s) to optimize geometry for. Required if `struct_path` is
+        ASE Atoms structure to optimize geometry for. Required if `struct_path` is
         None. Default is None.
     struct_path : Optional[PathLike]
         Path of structure to optimize. Required if `struct` is None. Default is None.
@@ -118,8 +118,8 @@ class GeomOpt(BaseCalculation):
         Parameters
         ----------
         struct : Optional[Atoms]
-            ASE Atoms structure(s) to optimize geometry for. Required if `struct_path`
-            is None. Default is None.
+            ASE Atoms structure to optimize geometry for. Required if `struct_path` is
+            None. Default is None.
         struct_path : Optional[PathLike]
             Path of structure to optimize. Required if `struct` is None. Default is
             None.

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -1,7 +1,5 @@
 """Prepare and run geometry optimization."""
 
-from collections.abc import Sequence
-from pathlib import Path
 from typing import Any, Callable, Optional, Union
 import warnings
 
@@ -238,20 +236,11 @@ class GeomOpt(BaseCalculation):
             tracker_kwargs=tracker_kwargs,
         )
 
-        if not isinstance(self.struct, Atoms):
-            if isinstance(self.struct, Sequence) and isinstance(self.struct[0], Atoms):
-                raise NotImplementedError(
-                    "Only one Atoms object at a time can currently be optimized"
-                )
-            raise ValueError("`struct` must be an ASE Atoms object")
-
-        # If structure given as path, set file_prefix
-        file_prefix = None
-        if self.struct_path:
-            file_prefix = Path(self.struct_path).stem
+        if not self.struct.calc:
+            raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, file_prefix)
+        FileNameMixin.__init__(self, self.struct, self.struct_path, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("opt.extxyz").absolute(),

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -31,7 +31,7 @@ class GeomOpt(BaseCalculation):
 
     Parameters
     ----------
-    struct : Optional[[Atoms]
+    struct : Optional[Atoms]
         ASE Atoms structure(s) to optimize geometry for. Required if `struct_path` is
         None. Default is None.
     struct_path : Optional[PathLike]
@@ -48,7 +48,7 @@ class GeomOpt(BaseCalculation):
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
-        Whether to set (new) calculators for structures. Default is Nonw.
+        Whether to set (new) calculators for structures. Default is None.
     log_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -119,7 +119,7 @@ class GeomOpt(BaseCalculation):
 
         Parameters
         ----------
-        struct : Optional[[Atoms]
+        struct : Optional[Atoms]
             ASE Atoms structure(s) to optimize geometry for. Required if `struct_path`
             is None. Default is None.
         struct_path : Optional[PathLike]
@@ -220,7 +220,7 @@ class GeomOpt(BaseCalculation):
         # Read last image by default
         read_kwargs.setdefault("index", -1)
 
-        # Configure logging
+        # Set log name
         log_kwargs.setdefault("name", __name__)
 
         # Initialise structures and logging

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -16,7 +16,6 @@ from janus_core.helpers.utils import (
     Architectures,
     ASEReadArgs,
     Devices,
-    FileNameMixin,
     none_to_dict,
     output_structs,
     spacegroup,
@@ -218,8 +217,6 @@ class GeomOpt(BaseCalculation):
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
 
-        # Set output file
-        FileNameMixin.__init__(self, self.struct, self.struct_path, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("opt.extxyz").absolute(),

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -38,7 +38,6 @@ from janus_core.helpers.utils import (
     Architectures,
     ASEReadArgs,
     Devices,
-    FileNameMixin,
     none_to_dict,
     output_structs,
     write_table,
@@ -434,15 +433,14 @@ class MolecularDynamics(BaseCalculation):
             set_calc=set_calc,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
+            file_prefix=file_prefix,
+            additional_prefix=self.ensemble,
         )
 
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file names
-        FileNameMixin.__init__(
-            self, self.struct, self.struct_path, file_prefix, self.ensemble
-        )
         self.final_file = self._build_filename(
             "final.extxyz",
             self._parameter_prefix if file_prefix is None else "",

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -314,19 +314,12 @@ class MolecularDynamics(BaseCalculation):
             Keyword arguments to control post-processing operations.
         correlation_kwargs : Optional[list[CorrelationKwargs]]
             Keyword arguments to control on-the-fly correlations.
-        log_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to `config_logger`. Default is None.
-        tracker_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to `config_tracker`. Default is None.
         seed : Optional[int]
             Random seed used by numpy.random and random functions, such as in Langevin.
             Default is None.
         """
         (
             read_kwargs,
-            calc_kwargs,
-            log_kwargs,
-            tracker_kwargs,
             minimize_kwargs,
             write_kwargs,
             post_process_kwargs,
@@ -334,9 +327,6 @@ class MolecularDynamics(BaseCalculation):
         ) = none_to_dict(
             (
                 read_kwargs,
-                calc_kwargs,
-                log_kwargs,
-                tracker_kwargs,
                 minimize_kwargs,
                 write_kwargs,
                 post_process_kwargs,
@@ -378,9 +368,6 @@ class MolecularDynamics(BaseCalculation):
 
         if "append" in self.write_kwargs:
             raise ValueError("`append` cannot be specified when writing files")
-
-        if log_kwargs and "filename" not in log_kwargs:
-            raise ValueError("'filename' must be included in `log_kwargs`")
 
         # Check temperatures for heating differ
         if self.temp_start is not None and self.temp_start == self.temp_end:
@@ -433,11 +420,9 @@ class MolecularDynamics(BaseCalculation):
         # Read last image by default
         read_kwargs.setdefault("index", -1)
 
-        # Set log name
-        log_kwargs.setdefault("name", __name__)
-
         # Initialise structures and logging
         super().__init__(
+            calc_name=__name__,
             struct=struct,
             struct_path=struct_path,
             arch=arch,

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -20,7 +20,7 @@ from janus_core.helpers.janus_types import (
     PathLike,
     PhononCalcs,
 )
-from janus_core.helpers.utils import FileNameMixin, none_to_dict, write_table
+from janus_core.helpers.utils import none_to_dict, write_table
 
 
 class Phonons(BaseCalculation):
@@ -90,7 +90,7 @@ class Phonons(BaseCalculation):
     Attributes
     ----------
     calc : ase.calculators.calculator.Calculator
-        ASE Calculator attached to strucutre.
+        ASE Calculator attached to structure.
     results : dict
         Results of phonon calculations.
 
@@ -247,13 +247,11 @@ class Phonons(BaseCalculation):
             set_calc=set_calc,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
+            file_prefix=file_prefix,
         )
 
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
-
-        # Set output file prefix
-        FileNameMixin.__init__(self, self.struct, self.struct_path, file_prefix)
 
         if self.minimize:
             if self.logger:

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -9,25 +9,49 @@ import phonopy
 from phonopy.file_IO import write_force_constants_to_hdf5
 from phonopy.structure.atoms import PhonopyAtoms
 
+from janus_core.calculations.base import BaseCalculation
 from janus_core.calculations.geom_opt import GeomOpt
 from janus_core.helpers.janus_types import (
+    Architectures,
+    ASEReadArgs,
+    Devices,
     MaybeList,
     MaybeSequence,
     PathLike,
     PhononCalcs,
 )
-from janus_core.helpers.log import config_logger, config_tracker
 from janus_core.helpers.utils import FileNameMixin, none_to_dict, write_table
 
 
-class Phonons(FileNameMixin):
+class Phonons(BaseCalculation):
     """
     Configure, perform phonon calculations and write out results.
 
     Parameters
     ----------
-    struct : Atoms
-        Structrure to calculate phonons for.
+    struct : Optional[Atoms]
+        ASE Atoms structure to calculate phonons for. Required if `struct_path` is
+        None. Default is None.
+    struct_path : Optional[PathLike]
+        Path of structure to calculate phonons for. Required if `struct` is None.
+        Default is None.
+    arch : Architectures
+        MLIP architecture to use for calculations. Default is "mace_mp".
+    device : Devices
+        Device to run MLIP model on. Default is "cpu".
+    model_path : Optional[PathLike]
+        Path to MLIP model. Default is `None`.
+    read_kwargs : Optional[ASEReadArgs]
+        Keyword arguments to pass to ase.io.read. By default,
+        read_kwargs["index"] is -1.
+    calc_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to the selected calculator. Default is {}.
+    set_calc : Optional[bool]
+        Whether to set (new) calculators for structures. Default is None.
+    log_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to `config_logger`. Default is {}.
+    tracker_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to `config_tracker`. Default is {}.
     calcs : Optional[MaybeSequence[PhononCalcs]]
         Phonon calculations to run. Default calculates force constants only.
     supercell : MaybeList[int]
@@ -62,10 +86,6 @@ class Phonons(FileNameMixin):
     file_prefix : Optional[PathLike]
         Prefix for output filenames. Default is inferred from chemical formula of the
         structure.
-    log_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to `config_logger`. Default is {}.
-    tracker_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to `config_tracker`. Default is {}.
 
     Attributes
     ----------
@@ -73,10 +93,6 @@ class Phonons(FileNameMixin):
         ASE Calculator attached to strucutre.
     results : dict
         Results of phonon calculations.
-    logger : Optional[logging.Logger]
-        Logger if log file has been specified.
-    tracker : Optional[OfflineEmissionsTracker]
-        Tracker if logging is enabled.
 
     Methods
     -------
@@ -106,7 +122,16 @@ class Phonons(FileNameMixin):
 
     def __init__(
         self,
-        struct: Atoms,
+        struct: Optional[Atoms] = None,
+        struct_path: Optional[PathLike] = None,
+        arch: Architectures = "mace_mp",
+        device: Devices = "cpu",
+        model_path: Optional[PathLike] = None,
+        read_kwargs: Optional[ASEReadArgs] = None,
+        calc_kwargs: Optional[dict[str, Any]] = None,
+        set_calc: Optional[bool] = None,
+        log_kwargs: Optional[dict[str, Any]] = None,
+        tracker_kwargs: Optional[dict[str, Any]] = None,
         calcs: MaybeSequence[PhononCalcs] = (),
         supercell: MaybeList[int] = 2,
         displacement: float = 0.01,
@@ -121,16 +146,35 @@ class Phonons(FileNameMixin):
         write_full: bool = True,
         minimize_kwargs: Optional[dict[str, Any]] = None,
         file_prefix: Optional[PathLike] = None,
-        log_kwargs: Optional[dict[str, Any]] = None,
-        tracker_kwargs: Optional[dict[str, Any]] = None,
     ) -> None:
         """
         Initialise Phonons class.
 
         Parameters
         ----------
-        struct : Atoms
-            Structrure to calculate phonons for.
+        struct : Optional[Atoms]
+            ASE Atoms structure to calculate phonons for. Required if `struct_path` is
+            None. Default is None.
+        struct_path : Optional[PathLike]
+            Path of structure to calculate phonons for. Required if `struct` is None.
+            Default is None.
+        arch : Architectures
+            MLIP architecture to use for calculations. Default is "mace_mp".
+        device : Devices
+            Device to run MLIP model on. Default is "cpu".
+        model_path : Optional[PathLike]
+            Path to MLIP model. Default is `None`.
+        read_kwargs : Optional[ASEReadArgs]
+            Keyword arguments to pass to ase.io.read. By default,
+            read_kwargs["index"] is -1.
+        calc_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to the selected calculator. Default is {}.
+        set_calc : Optional[bool]
+            Whether to set (new) calculators for structures. Default is None.
+        log_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_logger`. Default is {}.
+        tracker_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to `config_tracker`. Default is {}.
         calcs : Optional[MaybeSequence[PhononCalcs]]
             Phonon calculations to run. Default calculates force constants only.
         supercell : MaybeList[int]
@@ -170,11 +214,22 @@ class Phonons(FileNameMixin):
         tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
         """
-        (minimize_kwargs, log_kwargs, tracker_kwargs) = none_to_dict(
-            (minimize_kwargs, log_kwargs, tracker_kwargs)
+        (
+            read_kwargs,
+            calc_kwargs,
+            log_kwargs,
+            tracker_kwargs,
+            minimize_kwargs,
+        ) = none_to_dict(
+            (
+                read_kwargs,
+                calc_kwargs,
+                log_kwargs,
+                tracker_kwargs,
+                minimize_kwargs,
+            )
         )
 
-        self.struct = struct
         self.calcs = calcs
         self.displacement = displacement
         self.t_step = t_step
@@ -187,32 +242,38 @@ class Phonons(FileNameMixin):
         self.write_results = write_results
         self.write_full = write_full
         self.minimize_kwargs = minimize_kwargs
-        self.log_kwargs = log_kwargs
-
-        # Validate parameters
-        if not isinstance(struct, Atoms):
-            if isinstance(struct, Sequence) and isinstance(struct[0], Atoms):
-                raise NotImplementedError(
-                    "Phonons can only be calculated for one Atoms object at a time "
-                    "currently"
-                )
-            raise ValueError("`struct` must be an ASE Atoms object")
-
-        if not self.struct.calc:
-            raise ValueError("Please attach a calculator to `struct`.")
 
         # Ensure supercell is a valid list
         self.supercell = [supercell] * 3 if isinstance(supercell, int) else supercell
         if len(self.supercell) != 3:
             raise ValueError("`supercell` must be an integer, or list of length 3")
 
-        # Configure logging
-        self.log_kwargs.setdefault("name", __name__)
-        self.logger = config_logger(**self.log_kwargs)
-        self.tracker = config_tracker(self.logger, **tracker_kwargs)
+        # Read last image by default
+        read_kwargs.setdefault("index", -1)
+
+        # Set log name
+        log_kwargs.setdefault("name", __name__)
+
+        # Initialise structures and logging
+        super().__init__(
+            struct=struct,
+            struct_path=struct_path,
+            arch=arch,
+            device=device,
+            model_path=model_path,
+            read_kwargs=read_kwargs,
+            sequence_allowed=False,
+            calc_kwargs=calc_kwargs,
+            set_calc=set_calc,
+            log_kwargs=log_kwargs,
+            tracker_kwargs=tracker_kwargs,
+        )
+
+        if not self.struct.calc:
+            raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file prefix
-        FileNameMixin.__init__(self, self.struct, file_prefix)
+        FileNameMixin.__init__(self, self.struct, self.struct_path, file_prefix)
 
         if self.minimize:
             if self.logger:

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -209,26 +209,8 @@ class Phonons(BaseCalculation):
         file_prefix : Optional[PathLike]
             Prefix for output filenames. Default is inferred from structure name, or
             chemical formula of the structure.
-        log_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to `config_logger`. Default is {}.
-        tracker_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to `config_tracker`. Default is {}.
         """
-        (
-            read_kwargs,
-            calc_kwargs,
-            log_kwargs,
-            tracker_kwargs,
-            minimize_kwargs,
-        ) = none_to_dict(
-            (
-                read_kwargs,
-                calc_kwargs,
-                log_kwargs,
-                tracker_kwargs,
-                minimize_kwargs,
-            )
-        )
+        (read_kwargs, minimize_kwargs) = none_to_dict((read_kwargs, minimize_kwargs))
 
         self.calcs = calcs
         self.displacement = displacement
@@ -251,11 +233,9 @@ class Phonons(BaseCalculation):
         # Read last image by default
         read_kwargs.setdefault("index", -1)
 
-        # Set log name
-        log_kwargs.setdefault("name", __name__)
-
         # Initialise structures and logging
         super().__init__(
+            calc_name=__name__,
             struct=struct,
             struct_path=struct_path,
             arch=arch,

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -1,14 +1,13 @@
 """Prepare and perform single point calculations."""
 
 from collections.abc import Sequence
-from copy import copy
 from pathlib import Path
 from typing import Any, Optional, get_args
 
 from ase import Atoms
-from ase.io import read
 from numpy import ndarray
 
+from janus_core.calculations.base import BaseCalculation
 from janus_core.helpers.janus_types import (
     Architectures,
     ASEReadArgs,
@@ -20,12 +19,10 @@ from janus_core.helpers.janus_types import (
     PathLike,
     Properties,
 )
-from janus_core.helpers.log import config_logger, config_tracker
-from janus_core.helpers.mlip_calculators import choose_calculator
 from janus_core.helpers.utils import FileNameMixin, none_to_dict, output_structs
 
 
-class SinglePoint(FileNameMixin):
+class SinglePoint(BaseCalculation):
     """
     Prepare and perform single point calculations.
 
@@ -37,11 +34,6 @@ class SinglePoint(FileNameMixin):
     struct_path : Optional[PathLike]
         Path of structure to simulate. Required if `struct` is None.
         Default is None.
-    properties : MaybeSequence[Properties]
-        Physical properties to calculate. If not specified, "energy",
-        "forces", and "stress" will be returned.
-    write_results : bool
-        True to write out structure with results of calculations. Default is False.
     arch : Architectures
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
@@ -54,13 +46,18 @@ class SinglePoint(FileNameMixin):
         read_kwargs["index"] is ":".
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
-    write_kwargs : Optional[OutputKwargs]
-        Keyword arguments to pass to ase.io.write if saving structure with results of
-        calculations. Default is {}.
     log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
+    properties : MaybeSequence[Properties]
+        Physical properties to calculate. If not specified, "energy",
+        "forces", and "stress" will be returned.
+    write_results : bool
+        True to write out structure with results of calculations. Default is False.
+    write_kwargs : Optional[OutputKwargs]
+        Keyword arguments to pass to ase.io.write if saving structure with results of
+        calculations. Default is {}.
 
     Attributes
     ----------
@@ -73,28 +70,25 @@ class SinglePoint(FileNameMixin):
 
     Methods
     -------
-    read_structure()
-        Read structure and structure name.
-    set_calculator()
-        Configure calculator and attach to structure.
     run()
         Run single point calculations.
     """
 
     def __init__(
         self,
+        *,
         struct: Optional[MaybeSequence[Atoms]] = None,
         struct_path: Optional[PathLike] = None,
-        properties: MaybeSequence[Properties] = (),
-        write_results: bool = False,
         arch: Architectures = "mace_mp",
         device: Devices = "cpu",
         model_path: Optional[PathLike] = None,
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
-        write_kwargs: Optional[OutputKwargs] = None,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
+        properties: MaybeSequence[Properties] = (),
+        write_results: bool = False,
+        write_kwargs: Optional[OutputKwargs] = None,
     ) -> None:
         """
         Read the structure being simulated and attach an MLIP calculator.
@@ -107,11 +101,6 @@ class SinglePoint(FileNameMixin):
         struct_path : Optional[PathLike]
             Path of structure to simulate. Required if `struct` is None.
             Default is None.
-        properties : MaybeSequence[Properties]
-            Physical properties to calculate. If not specified, "energy",
-            "forces", and "stress" will be returned.
-        write_results : bool
-            True to write out structure with results of calculations. Default is False.
         arch : Architectures
             MLIP architecture to use for single point calculations.
             Default is "mace_mp".
@@ -124,68 +113,59 @@ class SinglePoint(FileNameMixin):
             read_kwargs["index"] is ":".
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
-        write_kwargs : Optional[OutputKwargs],
-            Keyword arguments to pass to ase.io.write if saving structure with results
-            of calculations. Default is {}.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_tracker`. Default is {}.
+        properties : MaybeSequence[Properties]
+            Physical properties to calculate. If not specified, "energy",
+            "forces", and "stress" will be returned.
+        write_results : bool
+            True to write out structure with results of calculations. Default is False.
+        write_kwargs : Optional[OutputKwargs],
+            Keyword arguments to pass to ase.io.write if saving structure with results
+            of calculations. Default is {}.
         """
-        (read_kwargs, calc_kwargs, write_kwargs, log_kwargs, tracker_kwargs) = (
+        (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs, write_kwargs) = (
             none_to_dict(
-                (read_kwargs, calc_kwargs, write_kwargs, log_kwargs, tracker_kwargs)
+                (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs, write_kwargs)
             )
         )
 
-        self.struct = struct
-        self.struct_path = struct_path
         self.properties = properties
         self.write_results = write_results
-        self.arch = arch
-        self.device = device
-        self.model_path = model_path
-        self.read_kwargs = read_kwargs
-        self.calc_kwargs = calc_kwargs
         self.write_kwargs = write_kwargs
-
-        # Validate parameters
-        if not self.struct and not self.struct_path:
-            raise ValueError(
-                "Please specify either the ASE Atoms structure (`struct`) "
-                "or a path to the structure file (`struct_path`)"
-            )
-
-        if self.struct and self.struct_path:
-            raise ValueError(
-                "You cannot specify both the ASE Atoms structure (`struct`) "
-                "and a path to the structure file (`struct_path`)"
-            )
 
         if log_kwargs and "filename" not in log_kwargs:
             raise ValueError("'filename' must be included in `log_kwargs`")
 
-        if not self.model_path and "model_path" in self.calc_kwargs:
+        if not model_path and "model_path" in calc_kwargs:
             raise ValueError("`model_path` must be passed explicitly")
 
         # Read full trajectory by default
-        self.read_kwargs.setdefault("index", ":")
+        read_kwargs.setdefault("index", ":")
 
-        # Read structure if given as path
+        # Set log name
+        log_kwargs.setdefault("name", __name__)
+
+        # Initialise structures and logging
+        super().__init__(
+            struct=struct,
+            struct_path=struct_path,
+            arch=arch,
+            device=device,
+            model_path=model_path,
+            read_kwargs=read_kwargs,
+            sequence_allowed=True,
+            calc_kwargs=calc_kwargs,
+            log_kwargs=log_kwargs,
+            tracker_kwargs=tracker_kwargs,
+        )
+
+        # If structure given as path, set file_prefix
         file_prefix = None
         if self.struct_path:
-            self.read_structure()
             file_prefix = Path(self.struct_path).stem
-
-        # Configure logging
-        log_kwargs.setdefault("name", __name__)
-        self.logger = config_logger(**log_kwargs)
-        self.tracker = config_tracker(self.logger, **tracker_kwargs)
-
-        # Configure calculator
-        self.set_calculator()
-        if self.logger:
-            self.logger.info("Single point calculator configured")
 
         # Set output file
         FileNameMixin.__init__(self, self.struct, file_prefix)
@@ -195,38 +175,6 @@ class SinglePoint(FileNameMixin):
         )
 
         self.results = {}
-
-    def read_structure(self) -> None:
-        """
-        Read structure and structure name.
-
-        If the file contains multiple structures, only the last configuration
-        will be read by default.
-        """
-        if not self.struct_path:
-            raise ValueError("`struct_path` must be defined")
-
-        self.struct = read(self.struct_path, **self.read_kwargs)
-
-    def set_calculator(self) -> None:
-        """Configure calculator and attach to structure."""
-        calculator = choose_calculator(
-            arch=self.arch,
-            device=self.device,
-            model_path=self.model_path,
-            **self.calc_kwargs,
-        )
-        if self.struct is None:
-            self.read_structure(**self.read_kwargs)
-
-        if isinstance(self.struct, Sequence):
-            for struct in self.struct:
-                struct.calc = copy(calculator)
-            # Return single Atoms object if only one image in list
-            if len(self.struct) == 1:
-                self.struct = self.struct[0]
-        else:
-            self.struct.calc = calculator
 
     @property
     def properties(self) -> Sequence[Properties]:

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -18,7 +18,7 @@ from janus_core.helpers.janus_types import (
     PathLike,
     Properties,
 )
-from janus_core.helpers.utils import FileNameMixin, none_to_dict, output_structs
+from janus_core.helpers.utils import none_to_dict, output_structs
 
 
 class SinglePoint(BaseCalculation):
@@ -64,10 +64,6 @@ class SinglePoint(BaseCalculation):
     ----------
     results : CalcResults
         Dictionary of calculated results, with keys from `properties`.
-    logger : Optional[logging.Logger]
-        Logger if log file has been specified.
-    tracker : Optional[OfflineEmissionsTracker]
-        Tracker if logging is enabled.
 
     Methods
     -------
@@ -156,7 +152,6 @@ class SinglePoint(BaseCalculation):
         )
 
         # Set output file
-        FileNameMixin.__init__(self, self.struct, self.struct_path, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("results.extxyz").absolute(),

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -46,6 +46,8 @@ class SinglePoint(BaseCalculation):
         read_kwargs["index"] is ":".
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
+    set_calc : Optional[bool]
+        Whether to set (new) calculators for structures. Default is None.
     log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
     tracker_kwargs : Optional[dict[str, Any]]
@@ -84,6 +86,7 @@ class SinglePoint(BaseCalculation):
         model_path: Optional[PathLike] = None,
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
+        set_calc: Optional[bool] = None,
         log_kwargs: Optional[dict[str, Any]] = None,
         tracker_kwargs: Optional[dict[str, Any]] = None,
         properties: MaybeSequence[Properties] = (),
@@ -113,6 +116,8 @@ class SinglePoint(BaseCalculation):
             read_kwargs["index"] is ":".
         calc_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to the selected calculator. Default is {}.
+        set_calc : Optional[bool]
+            Whether to set (new) calculators for structures. Default is None.
         log_kwargs : Optional[dict[str, Any]]
             Keyword arguments to pass to `config_logger`. Default is {}.
         tracker_kwargs : Optional[dict[str, Any]]
@@ -158,6 +163,7 @@ class SinglePoint(BaseCalculation):
             read_kwargs=read_kwargs,
             sequence_allowed=True,
             calc_kwargs=calc_kwargs,
+            set_calc=set_calc,
             log_kwargs=log_kwargs,
             tracker_kwargs=tracker_kwargs,
         )

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -1,7 +1,6 @@
 """Prepare and perform single point calculations."""
 
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any, Optional, get_args
 
 from ase import Atoms
@@ -168,13 +167,8 @@ class SinglePoint(BaseCalculation):
             tracker_kwargs=tracker_kwargs,
         )
 
-        # If structure given as path, set file_prefix
-        file_prefix = None
-        if self.struct_path:
-            file_prefix = Path(self.struct_path).stem
-
         # Set output file
-        FileNameMixin.__init__(self, self.struct, file_prefix)
+        FileNameMixin.__init__(self, self.struct, self.struct_path, None)
         self.write_kwargs.setdefault(
             "filename",
             self._build_filename("results.extxyz").absolute(),

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -130,30 +130,18 @@ class SinglePoint(BaseCalculation):
             Keyword arguments to pass to ase.io.write if saving structure with results
             of calculations. Default is {}.
         """
-        (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs, write_kwargs) = (
-            none_to_dict(
-                (read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs, write_kwargs)
-            )
-        )
+        (read_kwargs, write_kwargs) = none_to_dict((read_kwargs, write_kwargs))
 
         self.properties = properties
         self.write_results = write_results
         self.write_kwargs = write_kwargs
 
-        if log_kwargs and "filename" not in log_kwargs:
-            raise ValueError("'filename' must be included in `log_kwargs`")
-
-        if not model_path and "model_path" in calc_kwargs:
-            raise ValueError("`model_path` must be passed explicitly")
-
         # Read full trajectory by default
         read_kwargs.setdefault("index", ":")
 
-        # Set log name
-        log_kwargs.setdefault("name", __name__)
-
         # Initialise structures and logging
         super().__init__(
+            calc_name=__name__,
             struct=struct,
             struct_path=struct_path,
             arch=arch,

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -14,7 +14,7 @@ from janus_core.cli.types import (
     LogPath,
     MinimizeKwargs,
     ModelPath,
-    ReadKwargsFirst,
+    ReadKwargsLast,
     StructPath,
     Summary,
     WriteKwargs,
@@ -143,7 +143,7 @@ def geomopt(
         str,
         Option(help="Path if saving optimization frames.  [default: None]"),
     ] = None,
-    read_kwargs: ReadKwargsFirst = None,
+    read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
     minimize_kwargs: MinimizeKwargs = None,
     write_kwargs: WriteKwargs = None,
@@ -247,6 +247,7 @@ def geomopt(
         "model_path": model_path,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,
+        "log_kwargs": {"filename": log, "filemode": "w"},
         "optimizer": optimizer,
         "fmax": fmax,
         "steps": steps,
@@ -254,8 +255,10 @@ def geomopt(
         **minimize_kwargs,
         "write_results": True,
         "write_kwargs": write_kwargs,
-        "log_kwargs": {"filename": log, "filemode": "w"},
     }
+
+    # Set up geometry optimization
+    optimizer = GeomOpt(**optimize_kwargs)
 
     # Store inputs for yaml summary
     inputs = optimize_kwargs.copy()
@@ -263,9 +266,6 @@ def geomopt(
     # Store only filename as filemode is not set by user
     del inputs["log_kwargs"]
     inputs["log"] = log
-
-    # Set up geometry optimization
-    optimizer = GeomOpt(**optimize_kwargs)
 
     # Add structure and MLIP information to inputs
     save_struct_calc(

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -193,7 +193,7 @@ def geomopt(
         Path if saving optimization frames. Default is None.
     read_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to ase.io.read. By default,
-            read_kwargs["index"] is 0.
+            read_kwargs["index"] is -1.
     calc_kwargs : Optional[dict[str, Any]]
         Keyword arguments to pass to the selected calculator. Default is {}.
     minimize_kwargs : Optional[dict[str, Any]]

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -132,13 +132,19 @@ def singlepoint(
     # Initialise singlepoint structure and calculator
     s_point = SinglePoint(**singlepoint_kwargs)
 
-    # Store inputs for yaml summary
-
     # Store only filename as filemode is not set by user
     inputs = {"log": log}
 
+    # Add structure and MLIP information to inputs
     save_struct_calc(
-        inputs, s_point, arch, device, model_path, read_kwargs, calc_kwargs
+        inputs=inputs,
+        struct=s_point.struct,
+        struct_path=struct,
+        arch=arch,
+        device=device,
+        model_path=model_path,
+        read_kwargs=read_kwargs,
+        calc_kwargs=calc_kwargs,
     )
 
     inputs["run"] = {
@@ -155,6 +161,7 @@ def singlepoint(
     # Run singlepoint calculation
     s_point.run()
 
+    # Save carbon summary
     carbon_summary(summary=summary, log=log)
 
     # Save time after simulation has finished

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -81,14 +81,14 @@ ReadKwargsAll = Annotated[
     ),
 ]
 
-ReadKwargsFirst = Annotated[
+ReadKwargsLast = Annotated[
     TyperDict,
     Option(
         parser=parse_dict_class,
         help=(
             """
             Keyword arguments to pass to ase.io.read. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}".  [default: "{'index': 0}"]
+            wrapped in quotes, e.g. "{'key' : value}".  [default: "{'index': -1}"]
             """
         ),
         metavar="DICT",

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -11,9 +11,13 @@ from typer import Context
 from typer_config import conf_callback_factory, yaml_loader
 import yaml
 
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import TyperDict
-from janus_core.helpers.janus_types import Architectures, ASEReadArgs, Devices
+from janus_core.helpers.janus_types import (
+    Architectures,
+    ASEReadArgs,
+    Devices,
+    MaybeSequence,
+)
 from janus_core.helpers.utils import dict_remove_hyphens
 
 
@@ -156,8 +160,10 @@ def end_summary(summary: Path) -> None:
 
 
 def save_struct_calc(
+    *,
     inputs: dict,
-    s_point: SinglePoint,
+    struct: MaybeSequence[Atoms],
+    struct_path: Path,
     arch: Architectures,
     device: Devices,
     model_path: str,
@@ -171,8 +177,10 @@ def save_struct_calc(
     ----------
     inputs : dict
         Inputs dictionary to add information to.
-    s_point : SinglePoint
-        SinglePoint object storing structure with attached calculator.
+    struct : MaybeSequence[Atoms]
+        Structure to be simulated.
+    struct_path : Path
+        Path of structure file.
     arch : Architectures
         MLIP architecture.
     device : Devices
@@ -187,19 +195,19 @@ def save_struct_calc(
     # Remove duplicate struct if already in inputs:
     inputs.pop("struct", None)
 
-    if isinstance(s_point.struct, Atoms):
+    if isinstance(struct, Atoms):
         inputs["struct"] = {
-            "n_atoms": len(s_point.struct),
-            "struct_path": s_point.struct_path,
-            "formula": s_point.struct.get_chemical_formula(),
+            "n_atoms": len(struct),
+            "struct_path": struct_path,
+            "formula": struct.get_chemical_formula(),
         }
-    elif isinstance(s_point.struct, Sequence):
+    elif isinstance(struct, Sequence):
         inputs["traj"] = {
-            "length": len(s_point.struct),
-            "struct_path": s_point.struct_path,
+            "length": len(struct),
+            "struct_path": struct_path,
             "struct": {
-                "n_atoms": len(s_point.struct[0]),
-                "formula": s_point.struct[0].get_chemical_formula(),
+                "n_atoms": len(struct[0]),
+                "formula": struct[0].get_chemical_formula(),
             },
         }
 

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -23,7 +23,7 @@ from janus_core.helpers.utils import dict_remove_hyphens
 
 def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
     """
-    Set default read_kwargs["index"] and check its value is an integer.
+    Set default read_kwargs["index"] to final image and check its value is an integer.
 
     To ensure only a single Atoms object is read, slices such as ":" are forbidden.
 
@@ -32,9 +32,9 @@ def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
     read_kwargs : dict[str, Any]
         Keyword arguments to be passed to ase.io.read. If specified,
         read_kwargs["index"] must be an integer, and if not, a default value
-        of 0 is set.
+        of -1 is set.
     """
-    read_kwargs.setdefault("index", 0)
+    read_kwargs.setdefault("index", -1)
     try:
         int(read_kwargs["index"])
     except ValueError as e:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -406,10 +406,10 @@ def input_structs(
             set_calc = True
 
         if isinstance(struct, Atoms):
-            set_calc = True if struct.calc is None else False
+            set_calc = struct.calc is None
 
         if isinstance(struct, Sequence):
-            set_calc = True if any(image.calc is None for image in struct) else False
+            set_calc = any(image.calc is None for image in struct)
 
     if set_calc:
         if logger:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -39,7 +39,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
     file_prefix : Optional[PathLike]
         Default prefix to use.
     *additional
-        Components to add to file_prefix (joined by hyphens).
+        Components to add to default file_prefix (joined by hyphens).
 
     Methods
     -------
@@ -70,7 +70,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
         file_prefix : Optional[PathLike]
             Default prefix to use.
         *additional
-            Components to add to file_prefix (joined by hyphens).
+            Components to add to default file_prefix (joined by hyphens).
         """
         self.file_prefix = Path(
             self._get_default_prefix(file_prefix, struct, struct_path, *additional)
@@ -96,7 +96,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
         struct_path : Optional[PathLike]
             Path to file containing structures.
         *additional
-            Components to add to file_prefix (joined by hyphens).
+            Components to add to default file_prefix (joined by hyphens).
 
         Returns
         -------
@@ -114,7 +114,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
         else:
             struct_name = struct.get_chemical_formula()
 
-        return "-".join((struct_name, *additional))
+        return "-".join((struct_name, *filter(None, additional)))
 
     def _build_filename(
         self,

--- a/tests/test_filenamemixin.py
+++ b/tests/test_filenamemixin.py
@@ -23,13 +23,17 @@ class DummyFileHandler(FileNameMixin):
     "params,file_prefix",
     (
         # Defaults to structure atoms from ASE
-        ((STRUCT, None), "C6H6"),
+        ((STRUCT, None, None), "C6H6"),
+        # Defaults to stem over ASE structure
+        ((STRUCT, "mybenzene", None), "mybenzene"),
         # file_prefix just sets itself
-        ((STRUCT, "benzene"), "benzene"),
+        ((STRUCT, "mybenzene", "benzene"), "benzene"),
         # file_prefix ignores additional
-        ((STRUCT, "benzene", "wowzers"), "benzene"),
+        ((STRUCT, None, "benzene", "wowzers"), "benzene"),
         # Additional only applies where no file_prefix
-        ((STRUCT, None, "wowzers"), "C6H6-wowzers"),
+        ((STRUCT, None, None, "wowzers"), "C6H6-wowzers"),
+        # Additional only applies where no file_prefix
+        ((STRUCT, "mybenzene", None, "wowzers"), "mybenzene-wowzers"),
     ),
 )
 def test_file_name_mixin_init(params, file_prefix):
@@ -42,46 +46,65 @@ def test_file_name_mixin_init(params, file_prefix):
 @pytest.mark.parametrize(
     "mixin_params,file_args,file_kwargs,file_name",
     (
-        ((STRUCT, None), ("data.xyz",), {}, "C6H6-data.xyz"),
-        ((STRUCT, "benzene"), ("data.xyz",), {}, "benzene-data.xyz"),
-        ((STRUCT, "benzene", "wowzers"), ("data.xyz",), {}, "benzene-data.xyz"),
-        ((STRUCT, None, "wowzers"), ("data.xyz",), {}, "C6H6-wowzers-data.xyz"),
+        ((STRUCT, None, None), ("data.xyz",), {}, "C6H6-data.xyz"),
+        ((STRUCT, None, "benzene"), ("data.xyz",), {}, "benzene-data.xyz"),
+        ((STRUCT, None, "benzene", "wowzers"), ("data.xyz",), {}, "benzene-data.xyz"),
+        ((STRUCT, None, None, "wowzers"), ("data.xyz",), {}, "C6H6-wowzers-data.xyz"),
         # Additional stacks with base
         (
-            (STRUCT, None, "wowzers"),
+            (STRUCT, None, None, "wowzers"),
             ("data.xyz", "beef"),
             {},
             "C6H6-wowzers-beef-data.xyz",
         ),
+        (
+            (STRUCT, "mybenzene", None, "wowzers"),
+            ("data.xyz", "beef"),
+            {},
+            "mybenzene-wowzers-beef-data.xyz",
+        ),
+        # but not file_prefix
+        (
+            (STRUCT, "mybenzene", "benzene", "wowzers"),
+            ("data.xyz", "beef"),
+            {},
+            "benzene-beef-data.xyz",
+        ),
         # Prefix override ignores class options
         (
-            (STRUCT, None, "wowzers"),
+            (STRUCT, None, None, "wowzers"),
             ("data.xyz",),
             {"prefix_override": "beef"},
             "beef-data.xyz",
         ),
         # But not additional
         (
-            (STRUCT, None, "wowzers"),
+            (STRUCT, None, None, "wowzers"),
             ("data.xyz", "tasty"),
             {"prefix_override": "beef"},
             "beef-tasty-data.xyz",
         ),
         # Filename overrides everything
         (
-            (STRUCT, None, "wowzers"),
+            (STRUCT, None, None, "wowzers"),
             ("data.xyz",),
             {"filename": "hello.xyz"},
             "hello.xyz",
         ),
         (
-            (STRUCT, None, "wowzers"),
+            (STRUCT, None, None, "wowzers"),
             ("data.xyz",),
             {"prefix_override": "beef", "filename": "hello.xyz"},
             "hello.xyz",
         ),
         (
-            (STRUCT, None, "wowzers"),
+            (STRUCT, None, None, "wowzers"),
+            ("data.xyz", "tasty"),
+            {"prefix_override": "beef", "filename": "hello.xyz"},
+            "hello.xyz",
+        ),
+        (
+            (STRUCT, "mybenzene", "benzene", "wowzers"),
             ("data.xyz", "tasty"),
             {"prefix_override": "beef", "filename": "hello.xyz"},
             "hello.xyz",

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -37,23 +37,18 @@ test_data = [
 def test_md(ensemble):
     """Test all MD simulations are able to run."""
     # Expected default file prefix for each ensemble
-    if ensemble == "nvt":
-        file_prefix = "NaCl-nvt-T300.0-"
-    elif ensemble == "nve":
-        file_prefix = "NaCl-nve-T300.0-"
-    elif ensemble == "npt":
-        file_prefix = "NaCl-npt-T300.0-p0.0-"
-    elif ensemble == "nvt-nh":
-        file_prefix = "NaCl-nvt-nh-T300.0-"
-    elif ensemble == "nph":
-        file_prefix = "NaCl-nph-T300.0-p0.0-"
-    else:
-        raise NotImplementedError("Ensemble not currently supported")
+    file_prefix = {
+        "nvt": "NaCl-nvt-T300.0-",
+        "nve": "NaCl-nve-T300.0-",
+        "npt": "NaCl-npt-T300.0-p0.0-",
+        "nvt-nh": "NaCl-nvt-nh-T300.0-",
+        "nph": "NaCl-nph-T300.0-p0.0-",
+    }
 
-    final_path = Path(f"{file_prefix}final.extxyz").absolute()
-    restart_path = Path(f"{file_prefix}res-2.extxyz").absolute()
-    stats_path = Path(f"{file_prefix}stats.dat").absolute()
-    traj_path = Path(f"{file_prefix}traj.extxyz").absolute()
+    final_path = Path(f"{file_prefix[ensemble]}final.extxyz").absolute()
+    restart_path = Path(f"{file_prefix[ensemble]}res-2.extxyz").absolute()
+    stats_path = Path(f"{file_prefix[ensemble]}stats.dat").absolute()
+    traj_path = Path(f"{file_prefix[ensemble]}traj.extxyz").absolute()
     log_path = Path("./log.yml").absolute()
     summary_path = Path("./summary.yml").absolute()
 


### PR DESCRIPTION
Resolves #279

- Moves parsing of `struct`/`struct_path` and attaching calculators to new base class, which all calculations inherit from
  - Provides access to file stems within (hence resolving #279)
  - Also means we don't need to do everything via SinglePoint

To do:

- [x] Add tests 
  - Mostly covered via CLIs, which all use `struct_path`, but we can update MD, for example, to ensure #279 is actually resolved
  - `test_filenamemixin` needs updating
- [x] Check docs are up to date
  - API list needs updating  