### PR TITLE
Adds Velocity, ShearStress, StressDiagonal, observables

### DIFF
--- a/docs/source/apidoc/janus_core.rst
+++ b/docs/source/apidoc/janus_core.rst
@@ -278,6 +278,7 @@ janus\_core.processing.observables module
    :private-members:
    :undoc-members:
    :show-inheritance:
+   :inherited-members:
 
 janus\_core.processing.post\_process module
 -------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -210,6 +210,5 @@ nitpick_ignore = [
     ("py:class", "Context"),
     ("py:class", "Path"),
     ("py:obj", "dimension"),
-    ("py:obj", "allowed_components"),
     ("py:obj", "janus_core.processing.observables.Stress.value_count")
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -203,9 +203,13 @@ nitpick_ignore = [
     ("py:class", "Architectures"),
     ("py:class", "Devices"),
     ("py:class", "MaybeSequence"),
+    ("py:class", "SliceLike"),
     ("py:class", "PathLike"),
     ("py:class", "Atoms"),
     ("py:class", "Calculator"),
     ("py:class", "Context"),
     ("py:class", "Path"),
+    ("py:obj", "dimension"),
+    ("py:obj", "allowed_components"),
+    ("py:obj", "janus_core.processing.observables.Stress.value_count")
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,6 +209,4 @@ nitpick_ignore = [
     ("py:class", "Calculator"),
     ("py:class", "Context"),
     ("py:class", "Path"),
-    ("py:obj", "dimension"),
-    ("py:obj", "janus_core.processing.observables.Stress.value_count")
 ]

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -187,23 +187,23 @@ Alternatively, using ``tox``::
 Adding a new Observable
 =======================
 
-A ``janus_core.processing.observables.Observable`` abstracts obtaining a quantity derived from ``Atoms``. They may be used as kernels for input into analysis such as a correlation.
+A :class:`janus_core.processing.observables.Observable` abstracts obtaining a quantity derived from ``Atoms``. They may be used as kernels for input into analysis such as a correlation.
 
-Additional built-in observable quantities may be added for use by the ``janus_core.processing.correlator.Correlation`` class. These should extend ``janus_core.processing.observables.Observable`` and are implemented within the ``janus_core.processing.observables`` module.
+Additional built-in observable quantities may be added for use by the :class:`janus_core.processing.correlator.Correlation` class. These should extend :class:`janus_core.processing.observables.Observable` and are implemented within the :py:mod:`janus_core.processing.observables` module.
 
-The abstract method ``__call__`` should be implemented to obtain the values of the observed quantity from an ``Atoms`` object. When used as part of a ``janus_core.processing.correlator.Correlation``, each value will be correlated and the results averaged.
+The abstract method ``__call__`` should be implemented to obtain the values of the observed quantity from an ``Atoms`` object. When used as part of a :class:`janus_core.processing.correlator.Correlation`, each value will be correlated and the results averaged.
 
-As an example of building a new ``Observable`` consider the ``janus_core.processing.observables.Stress`` built-in. The following steps may be taken:
+As an example of building a new ``Observable`` consider the :class:`janus_core.processing.observables.Stress` built-in. The following steps may be taken:
 
 1. Defining the observable.
 ---------------------------
 
-The stress tensor may be computed on an atoms object using ``Atoms.get_stress``. A user may wish to obtain a particular component, or perhaps only compute the stress on some subset of ``Atoms``. For example during a ``janus_core.calculations.md.MolecularDynamics`` run a user may wish to correlate only the off-diagonal components (shear stress), computed across all atoms.
+The stress tensor may be computed on an atoms object using ``Atoms.get_stress``. A user may wish to obtain a particular component, or perhaps only compute the stress on some subset of ``Atoms``. For example during a :class:`janus_core.calculations.md.MolecularDynamics` run a user may wish to correlate only the off-diagonal components (shear stress), computed across all atoms.
 
 2. Writing the ``__call__`` method.
 -----------------------------------
 
-In the call method we can use the base ``janus_core.processing.observables.Observable``'s optional atom selector ``atoms_slice`` to first define the subset of atoms to compute the stress for:
+In the call method we can use the base :class:`janus_core.processing.observables.Observable`'s optional atom selector ``atoms_slice`` to first define the subset of atoms to compute the stress for:
 
 .. code-block:: python
 
@@ -223,7 +223,7 @@ Next the stresses may be obtained from:
             / units.GPa
         )
 
-Finally, to facilitate handling components in a symbolic way, ``janus_core.processing.observables.ComponentMixin`` exists to parse ``str`` symbolic components to ``int`` indices by defining a suitable mapping. For the stress tensor (and the format of ``Atoms.get_stress``) a suitable mapping is defined in ``janus_core.processing.observables.Stress``'s ``__init__`` method:
+Finally, to facilitate handling components in a symbolic way, :class:`janus_core.processing.observables.ComponentMixin` exists to parse ``str`` symbolic components to ``int`` indices by defining a suitable mapping. For the stress tensor (and the format of ``Atoms.get_stress``) a suitable mapping is defined in :class:`janus_core.processing.observables.Stress`'s ``__init__`` method:
 
 .. code-block:: python
 
@@ -242,7 +242,7 @@ Finally, to facilitate handling components in a symbolic way, ``janus_core.proce
             },
         )
 
-This then concludes the ``__call__`` method for ``janus_core.processing.observables.Stress`` by using ``janus_core.processing.observables.ComponentMixin``'s
+This then concludes the ``__call__`` method for :class:`janus_core.processing.observables.Stress` by using :class:`janus_core.processing.observables.ComponentMixin`'s
 pre-calculated indices:
 
 .. code-block:: python
@@ -263,9 +263,9 @@ Since usually total system stresses are required we can define two built-ins to 
     StressHydrostatic = Stress(components=["xx", "yy", "zz"])
     StressShear = Stress(components=["xy", "yz", "zx"])
 
-Where by default ``janus_core.processing.observables.Observable``'s ``atoms_slice`` is ``slice(0, None, 1)``, which expands to all atoms in an ``Atoms``.
+Where by default :class:`janus_core.processing.observables.Observable`'s ``atoms_slice`` is ``slice(0, None, 1)``, which expands to all atoms in an ``Atoms``.
 
-For comparison the ``janus_core.processing.observables.Velocity`` built-in's ``__call__`` not only returns atom velocity for the requested components, but also returns them for every tracked atom i.e:
+For comparison the :class:`janus_core.processing.observables.Velocity` built-in's ``__call__`` not only returns atom velocity for the requested components, but also returns them for every tracked atom i.e:
 
 .. code-block:: python
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -698,7 +698,9 @@ class MolecularDynamics(BaseCalculation):
     def _parse_correlations(self) -> None:
         """Parse correlation kwargs into Correlations."""
         if self.correlation_kwargs:
-            self._correlations = [Correlation(**cor) for cor in self.correlation_kwargs]
+            self._correlations = [
+                Correlation(self.n_atoms, **cor) for cor in self.correlation_kwargs
+            ]
         else:
             self._correlations = ()
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -698,10 +698,7 @@ class MolecularDynamics(BaseCalculation):
     def _parse_correlations(self) -> None:
         """Parse correlation kwargs into Correlations."""
         if self.correlation_kwargs:
-            self._correlations = [
-                Correlation(n_atoms=self.n_atoms, **cor)
-                for cor in self.correlation_kwargs
-            ]
+            self._correlations = [Correlation(**cor) for cor in self.correlation_kwargs]
         else:
             self._correlations = ()
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -699,7 +699,8 @@ class MolecularDynamics(BaseCalculation):
         """Parse correlation kwargs into Correlations."""
         if self.correlation_kwargs:
             self._correlations = [
-                Correlation(self.n_atoms, **cor) for cor in self.correlation_kwargs
+                Correlation(n_atoms=self.n_atoms, **cor)
+                for cor in self.correlation_kwargs
             ]
         else:
             self._correlations = ()

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -79,6 +79,7 @@ class PostProcessKwargs(TypedDict, total=False):
     vaf_step: int
     vaf_output_file: PathLike | None
 
+
 class CorrelationKwargs(TypedDict, total=True):
     """Arguments for on-the-fly correlations <ab>."""
 

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -13,8 +13,6 @@ from ase.eos import EquationOfState
 import numpy as np
 from numpy.typing import NDArray
 
-from janus_core.processing.observables import Observable
-
 # General
 
 T = TypeVar("T")
@@ -98,6 +96,28 @@ class CorrelationKwargs(TypedDict, total=True):
     update_frequency: int
 
 
+class CorrelationKwargs(TypedDict, total=True):
+    """Arguments for on-the-fly correlations <ab>."""
+
+    # imported here to prevent circular imports.
+    from janus_core.processing.observables import Observable
+
+    #: observable a in <ab>, with optional args and kwargs
+    a: Union[Observable, tuple[Observable, tuple, dict]]
+    #: observable b in <ab>, with optional args and kwargs
+    b: Union[Observable, tuple[Observable, tuple, dict]]
+    #: name used for correlation in output
+    name: str
+    #: blocks used in multi-tau algorithm
+    blocks: int
+    #: points per block
+    points: int
+    #: averaging between blocks
+    averaging: int
+    #: frequency to update the correlation (steps)
+    update_frequency: int
+
+
 # eos_names from ase.eos
 EoSNames = Literal[
     "sj",
@@ -155,22 +175,3 @@ class EoSResults(TypedDict, total=False):
     bulk_modulus: float
     v_0: float
     e_0: float
-
-
-class CorrelationKwargs(TypedDict, total=True):
-    """Arguments for on-the-fly correlations <ab>."""
-
-    #: observable a in <ab>
-    a: Observable
-    #: observable b in <ab>
-    b: Observable
-    #: name used for correlation in output
-    name: str
-    #: blocks used in multi-tau algorithm
-    blocks: int
-    #: points per block
-    points: int
-    #: averaging between blocks
-    averaging: int
-    #: frequency to update the correlation (steps)
-    update_frequency: int

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -159,10 +159,10 @@ class EoSResults(TypedDict, total=False):
 class CorrelationKwargs(TypedDict, total=True):
     """Arguments for on-the-fly correlations <ab>."""
 
-    #: observable a in <ab>, with optional args and kwargs
-    a: Union[Observable, tuple[Observable, tuple, dict]]
-    #: observable b in <ab>, with optional args and kwargs
-    b: Union[Observable, tuple[Observable, tuple, dict]]
+    #: observable a in <ab>
+    a: Observable
+    #: observable b in <ab>
+    b: Observable
     #: name used for correlation in output
     name: str
     #: blocks used in multi-tau algorithm

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -6,21 +6,14 @@ from collections.abc import Collection, Sequence
 from enum import Enum
 import logging
 from pathlib import Path, PurePath
-from typing import (
-    IO,
-    Literal,
-    Optional,
-    Protocol,
-    TypedDict,
-    TypeVar,
-    Union,
-    runtime_checkable,
-)
+from typing import IO, Literal, Optional, TypedDict, TypeVar, Union
 
 from ase import Atoms
 from ase.eos import EquationOfState
 import numpy as np
 from numpy.typing import NDArray
+
+from janus_core.helpers.observables import Observable
 
 # General
 
@@ -84,25 +77,6 @@ class PostProcessKwargs(TypedDict, total=False):
     vaf_stop: int | None
     vaf_step: int
     vaf_output_file: PathLike | None
-
-
-@runtime_checkable
-class Observable(Protocol):
-    """Signature for correlation observable getter."""
-
-    def __call__(self, atoms: Atoms, *args, **kwargs) -> float:
-        """
-        Call the getter.
-
-        Parameters
-        ----------
-        atoms : Atoms
-            Atoms object to extract values from.
-        *args : tuple
-            Additional positional arguments passed to getter.
-        **kwargs : dict
-            Additional kwargs passed getter.
-        """
 
 
 class CorrelationKwargs(TypedDict, total=True):

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -13,7 +13,7 @@ from ase.eos import EquationOfState
 import numpy as np
 from numpy.typing import NDArray
 
-from janus_core.helpers.observables import Observable
+from janus_core.processing.observables import Observable
 
 # General
 

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -6,12 +6,15 @@ from collections.abc import Collection, Sequence
 from enum import Enum
 import logging
 from pathlib import Path, PurePath
-from typing import IO, Literal, Optional, TypedDict, TypeVar, Union
+from typing import IO, TYPE_CHECKING, Literal, Optional, TypedDict, TypeVar, Union
 
 from ase import Atoms
 from ase.eos import EquationOfState
 import numpy as np
 from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from janus_core.processing.observables import Observable
 
 # General
 
@@ -76,36 +79,13 @@ class PostProcessKwargs(TypedDict, total=False):
     vaf_step: int
     vaf_output_file: PathLike | None
 
-
 class CorrelationKwargs(TypedDict, total=True):
     """Arguments for on-the-fly correlations <ab>."""
 
     #: observable a in <ab>, with optional args and kwargs
-    a: Observable | tuple[Observable, tuple, dict]
+    a: Observable
     #: observable b in <ab>, with optional args and kwargs
-    b: Observable | tuple[Observable, tuple, dict]
-    #: name used for correlation in output
-    name: str
-    #: blocks used in multi-tau algorithm
-    blocks: int
-    #: points per block
-    points: int
-    #: averaging between blocks
-    averaging: int
-    #: frequency to update the correlation (steps)
-    update_frequency: int
-
-
-class CorrelationKwargs(TypedDict, total=True):
-    """Arguments for on-the-fly correlations <ab>."""
-
-    # imported here to prevent circular imports.
-    from janus_core.processing.observables import Observable
-
-    #: observable a in <ab>, with optional args and kwargs
-    a: Union[Observable, tuple[Observable, tuple, dict]]
-    #: observable b in <ab>, with optional args and kwargs
-    b: Union[Observable, tuple[Observable, tuple, dict]]
+    b: Observable
     #: name used for correlation in output
     name: str
     #: blocks used in multi-tau algorithm

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -13,6 +13,8 @@ from ase.eos import EquationOfState
 import numpy as np
 from numpy.typing import NDArray
 
+from janus_core.helpers.observables import Observable
+
 # General
 
 T = TypeVar("T")
@@ -152,106 +154,6 @@ class EoSResults(TypedDict, total=False):
     bulk_modulus: float
     v_0: float
     e_0: float
-
-
-# pylint: disable=too-few-public-methods
-class Observable:
-    """
-    Observable data that may be correlated.
-
-    Parameters
-    ----------
-    dimension : int
-        The dimension of the observed data.
-    getter : Optional[callable]
-        An optional callable to construct the Observable from.
-    """
-
-    def __init__(self, dimension: int = 1, *, getter: Optional[callable] = None):
-        """
-        Initialise an observable with a given dimensionality.
-
-        Parameters
-        ----------
-        dimension : int
-            The dimension of the observed data.
-        getter : Optional[callable]
-            An optional callable to construct the Observable from.
-        """
-        self._dimension = dimension
-        self._getter = getter
-        self.atoms = None
-
-    def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
-        """
-        Call the user supplied getter if it exits.
-
-        Parameters
-        ----------
-        atoms : Atoms
-            Atoms object to extract values from.
-        *args : tuple
-            Additional positional arguments passed to getter.
-        **kwargs : dict
-            Additional kwargs passed getter.
-
-        Returns
-        -------
-        list[float]
-            The observed value, with dimensions atoms by self.dimension.
-
-        Raises
-        ------
-        ValueError
-            If user supplied getter is None.
-        """
-        if self._getter:
-            value = self._getter(atoms, *args, **kwargs)
-            if not isinstance(value, list):
-                return [value]
-            return value
-        raise ValueError("No user getter supplied")
-
-    @property
-    def dimension(self):
-        """
-        Dimension of the observable. Commensurate with self.__call__.
-
-        Returns
-        -------
-        int
-            Observables dimension.
-        """
-        return self._dimension
-
-    def atom_count(self, n_atoms: int):
-        """
-        Atom count to average over.
-
-        Parameters
-        ----------
-        n_atoms : int
-            Total possible atoms.
-
-        Returns
-        -------
-        int
-            Atom count averaged over.
-        """
-        if self.atoms:
-            if isinstance(self.atoms, list):
-                return len(self.atoms)
-            if isinstance(self.atoms, int):
-                return 1
-
-            start = self.atoms.start
-            stop = self.atoms.stop
-            step = self.atoms.step
-            start = start if start is None else 0
-            stop = stop if stop is None else n_atoms
-            step = step if step is None else 1
-            return len(range(start, stop, step))
-        return 0
 
 
 class CorrelationKwargs(TypedDict, total=True):

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -23,6 +23,7 @@ MaybeSequence = Union[T, Sequence[T]]
 PathLike = Union[str, Path]
 StartStopStep = tuple[Optional[int], Optional[int], int]
 SliceLike = Union[slice, range, int, StartStopStep]
+
 # ASE Arg types
 
 

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -18,7 +18,13 @@ from rich.progress import (
 )
 from rich.style import Style
 
-from janus_core.helpers.janus_types import MaybeSequence, PathLike, SliceLike, StartStopStep
+from janus_core.helpers.janus_types import (
+    MaybeSequence,
+    PathLike,
+    SliceLike,
+    StartStopStep,
+)
+
 
 class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-method)
     """

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -462,26 +462,27 @@ def slicelike_to_startstopstep(index: SliceLike) -> StartStopStep:
     return index
 
 
-def slicelike_len_for(slc: SliceLike, sliceable_length: int) -> int:
+def selector_len(slc: Union[SliceLike, list], selectable_length: int) -> int:
     """
-    Calculate the length of a SliceLike applied to a sliceable of a given length.
+    Calculate the length of a selector applied to an indexable of a given length.
 
     Parameters
     ----------
-    slc : SliceLike
-        The applied SliceLike.
-    sliceable_length : int
-        The length of the sliceable object.
+    slc : Union[SliceLike, list]
+        The applied SliceLike or list for selection.
+    selectable_length : int
+        The length of the selectable object.
 
     Returns
     -------
     int
         Length of the result of applying slc.
     """
+    if isinstance(slc, int):
+        return 1
+    if isinstance(slc, list):
+        return len(slc)
     start, stop, step = slicelike_to_startstopstep(slc)
     if stop is None:
-        stop = sliceable_length
-    # start = start if start is None else 0
-    # stop = stop if stop is None else sliceable_length
-    # step = step if step is None else 1
+        stop = selectable_length
     return len(range(start, stop, step))

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -437,6 +437,34 @@ def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:
         if not Path(config[file_key]).exists():
             raise FileNotFoundError(f"{config[file_key]} does not exist")
 
+def validate_slicelike(maybe_slicelike: SliceLike):
+    """
+    Raise an exception if slc is not a valid SliceLike.
+
+    Parameters
+    ----------
+    maybe_slicelike : SliceLike
+        Candidate to test.
+
+    Raises
+    ------
+    ValueError
+        If maybe_slicelike is not SliceLike.
+    """
+    if isinstance(maybe_slicelike, (slice, range, int)):
+        return
+    if isinstance(maybe_slicelike, tuple) and len(maybe_slicelike) == 3:
+        start, stop, step = maybe_slicelike
+        if (
+            (start is None or isinstance(start, int))
+            and (stop is None or isinstance(stop, int))
+            and isinstance(step, int)
+        ):
+            return
+
+    raise ValueError(f"{maybe_slicelike} is not a valid SliceLike")
+
+
 def slicelike_to_startstopstep(index: SliceLike) -> StartStopStep:
     """
     Standarize `SliceLike`s into tuple of `start`, `stop`, `step`.
@@ -451,6 +479,7 @@ def slicelike_to_startstopstep(index: SliceLike) -> StartStopStep:
     StartStopStep
         Standardized `SliceLike` as `start`, `stop`, `step` triplet.
     """
+    validate_slicelike(index)
     if isinstance(index, int):
         if index == -1:
             return (index, None, 1)
@@ -462,7 +491,7 @@ def slicelike_to_startstopstep(index: SliceLike) -> StartStopStep:
     return index
 
 
-def selector_len(slc: Union[SliceLike, list], selectable_length: int) -> int:
+def selector_len(slc: SliceLike | list, selectable_length: int) -> int:
     """
     Calculate the length of a selector applied to an indexable of a given length.
 

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -415,6 +415,7 @@ def track_progress(sequence: Sequence | Iterable, description: str) -> Iterable:
     with progress:
         yield from progress.track(sequence, description=description)
 
+
 def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:
     """
     Check files specified in a dictionary read from a configuration file exist.
@@ -436,6 +437,7 @@ def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:
         # Only check if file key is in the configuration file
         if not Path(config[file_key]).exists():
             raise FileNotFoundError(f"{config[file_key]} does not exist")
+
 
 def validate_slicelike(maybe_slicelike: SliceLike) -> None:
     """

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -437,7 +437,7 @@ def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:
         if not Path(config[file_key]).exists():
             raise FileNotFoundError(f"{config[file_key]} does not exist")
 
-def validate_slicelike(maybe_slicelike: SliceLike):
+def validate_slicelike(maybe_slicelike: SliceLike) -> None:
     """
     Raise an exception if slc is not a valid SliceLike.
 

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -242,11 +242,8 @@ class Correlation:
             raise ValueError("Observables have inconsistent sizes")
         self._values = a_values
 
-        self._correlators = []
-        for _ in range(self._values):
-            self._correlators.append(
-                Correlator(blocks=blocks, points=points, averaging=averaging)
-            )
+        self._correlators = [Correlator(blocks=blocks, points=points, averaging=averaging)
+                             for _ in range(self._values)]
         self._update_frequency = update_frequency
 
     @property
@@ -270,13 +267,9 @@ class Correlation:
         atoms : Atoms
             Atoms object to observe values from.
         """
-        for i, values in enumerate(
-            zip(
-                self._get_a(atoms),
-                self._get_b(atoms),
-            )
-        ):
-            self._correlators[i].update(*values)
+        atom_pairs = zip(self._get_a(atoms), self._get_b(atoms))
+        for corr, values in zip(self._correlators, atom_pairs):
+            corr.update(*values)
 
     def get(self) -> tuple[Iterable[float], Iterable[float]]:
         """
@@ -291,7 +284,7 @@ class Correlation:
         """
         if self._correlators:
             _, lags = self._correlators[0].get()
-            avg_value = sum([cor.get()[0] for cor in self._correlators]) / self._values
+            avg_value = np.mean(cor.get()[0] for cor in self._correlators)
             return avg_value, lags
         return [], []
 

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -242,8 +242,10 @@ class Correlation:
             raise ValueError("Observables have inconsistent sizes")
         self._values = a_values
 
-        self._correlators = [Correlator(blocks=blocks, points=points, averaging=averaging)
-                             for _ in range(self._values)]
+        self._correlators = [
+            Correlator(blocks=blocks, points=points, averaging=averaging)
+            for _ in range(self._values)
+        ]
         self._update_frequency = update_frequency
 
     @property
@@ -284,8 +286,7 @@ class Correlation:
         """
         if self._correlators:
             _, lags = self._correlators[0].get()
-            avg_value = np.mean(cor.get()[0] for cor in self._correlators)
-            return avg_value, lags
+            return np.mean([cor.get()[0] for cor in self._correlators], axis=0), lags
         return [], []
 
     def __str__(self) -> str:

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -181,10 +181,10 @@ class Correlation:
     ----------
     n_atoms : int
         Number of possible atoms to track.
-    a : Union[Observable, tuple[Observable, tuple, dict]]
-        Getter for a and kwargs.
-    b : Union[Observable, tuple[Observable, tuple, dict]]
-        Getter for b and kwargs.
+    a : Observable
+        Observable for a.
+    b : Observable
+        Observable for b.
     name : str
         Name of correlation.
     blocks : int
@@ -201,8 +201,8 @@ class Correlation:
         self,
         *,
         n_atoms: int,
-        a: Observable | tuple[Observable, tuple, dict],
-        b: Observable | tuple[Observable, tuple, dict],
+        a: Observable,
+        b: Observable,
         name: str,
         blocks: int,
         points: int,
@@ -216,10 +216,10 @@ class Correlation:
         ----------
         n_atoms : int
             Number of possible atoms to track.
-        a : Union[Observable, tuple[Observable, tuple, dict]]
-            Getter for a and kwargs.
-        b : Union[Observable, tuple[Observable, tuple, dict]]
-            Getter for b and kwargs.
+        a : Observable
+            Observable for a.
+        b : Observable
+            Observable for b.
         name : str
             Name of correlation.
         blocks : int
@@ -232,17 +232,8 @@ class Correlation:
             Frequency to update the correlation, md steps.
         """
         self.name = name
-        if isinstance(a, tuple):
-            self._get_a, self._a_args, self._a_kwargs = a
-        else:
-            self._get_a = a
-            self._a_args, self._a_kwargs = (), {}
-
-        if isinstance(b, tuple):
-            self._get_b, self._b_args, self._b_kwargs = b
-        else:
-            self._get_b = b
-            self._b_args, self._b_kwargs = (), {}
+        self._get_a = a
+        self._get_b = b
 
         a_values = self._get_a.value_count(n_atoms)
         b_values = self._get_b.value_count(n_atoms)
@@ -281,8 +272,8 @@ class Correlation:
         """
         for i, values in enumerate(
             zip(
-                self._get_a(atoms, *self._a_args, **self._a_kwargs),
-                self._get_b(atoms, *self._b_args, **self._b_kwargs),
+                self._get_a(atoms),
+                self._get_b(atoms),
             )
         ):
             self._correlators[i].update(*values)

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -181,9 +181,9 @@ class Correlation:
     ----------
     n_atoms : int
         Number of possible atoms to track.
-    a : tuple[Observable, dict]
+    a : Union[Observable, tuple[Observable, tuple, dict]]
         Getter for a and kwargs.
-    b : tuple[Observable, dict]
+    b : Union[Observable, tuple[Observable, tuple, dict]]
         Getter for b and kwargs.
     name : str
         Name of correlation.
@@ -199,6 +199,7 @@ class Correlation:
 
     def __init__(
         self,
+        *,
         n_atoms: int,
         a: Observable | tuple[Observable, tuple, dict],
         b: Observable | tuple[Observable, tuple, dict],
@@ -215,9 +216,9 @@ class Correlation:
         ----------
         n_atoms : int
             Number of possible atoms to track.
-        a : tuple[Observable, tuple, dict]
+        a : Union[Observable, tuple[Observable, tuple, dict]]
             Getter for a and kwargs.
-        b : tuple[Observable, tuple, dict]
+        b : Union[Observable, tuple[Observable, tuple, dict]]
             Getter for b and kwargs.
         name : str
             Name of correlation.

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -179,6 +179,8 @@ class Correlation:
 
     Parameters
     ----------
+    n_atoms : int
+        Number of possible atoms to track.
     a : tuple[Observable, dict]
         Getter for a and kwargs.
     b : tuple[Observable, dict]
@@ -197,6 +199,7 @@ class Correlation:
 
     def __init__(
         self,
+        n_atoms: int,
         a: Observable | tuple[Observable, tuple, dict],
         b: Observable | tuple[Observable, tuple, dict],
         name: str,
@@ -210,6 +213,8 @@ class Correlation:
 
         Parameters
         ----------
+        n_atoms : int
+            Number of possible atoms to track.
         a : tuple[Observable, tuple, dict]
             Getter for a and kwargs.
         b : tuple[Observable, tuple, dict]
@@ -238,11 +243,14 @@ class Correlation:
             self._get_b = b
             self._b_args, self._b_kwargs = (), {}
 
+        self._a_atoms = self._get_a.atom_count(n_atoms)
+        self._b_atoms = self._get_b.atom_count(n_atoms)
+
         self._correlators = []
         for _ in zip(range(self._get_a.dimension), range(self._get_b.dimension)):
             for _ in zip(
-                range(max(1, self._get_a.atom_count)),
-                range(max(1, self._get_b.atom_count)),
+                range(max(1, self._a_atoms)),
+                range(max(1, self._b_atoms)),
             ):
                 self._correlators.append(
                     Correlator(blocks=blocks, points=points, averaging=averaging)
@@ -294,9 +302,7 @@ class Correlation:
             for cor in self._correlators[1:]:
                 value, _ = cor.get()
                 avg_value += value
-            return avg_value / max(
-                1, min(self._get_a.atom_count, self._get_b.atom_count)
-            ), lags
+            return avg_value / max(1, min(self._a_atoms, self._b_atoms)), lags
         return [], []
 
     def __str__(self) -> str:

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -179,8 +179,6 @@ class Correlation:
 
     Parameters
     ----------
-    n_atoms : int
-        Number of possible atoms to track.
     a : Observable
         Observable for a.
     b : Observable
@@ -200,7 +198,6 @@ class Correlation:
     def __init__(
         self,
         *,
-        n_atoms: int,
         a: Observable,
         b: Observable,
         name: str,
@@ -214,8 +211,6 @@ class Correlation:
 
         Parameters
         ----------
-        n_atoms : int
-            Number of possible atoms to track.
         a : Observable
             Observable for a.
         b : Observable

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from ase import Atoms
 import numpy as np
 
-from janus_core.helpers.observables import Observable
+from janus_core.processing.observables import Observable
 
 
 class Correlator:

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 from ase import Atoms, units
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
 
 
 # pylint: disable=too-few-public-methods
-class Observable:
+class Observable(ABC):
     """
     Observable data that may be correlated.
 
@@ -33,6 +34,7 @@ class Observable:
         """
         self._dimension = dimension
 
+    @abstractmethod
     def __call__(self, atoms: Atoms) -> list[float]:
         """
         Signature for returning observed value from atoms.

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -180,7 +180,14 @@ class Stress(Observable, ComponentMixin):
         -------
         list[float]
             The stress components in GPa units.
+
+        Raises
+        ------
+        ValueError
+            If atoms is not an Atoms object.
         """
+        if not isinstance(atoms, Atoms):
+            raise ValueError("atoms should be an Atoms object")
         sliced_atoms = atoms[self.atoms_slice]
         # must be re-attached after slicing for get_stress
         sliced_atoms.calc = atoms.calc

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -147,7 +147,6 @@ class ComponentMixin:
 
 # pylint: disable=too-few-public-methods
 class Stress(Observable, ComponentMixin):
-    __module__ = "observables"
     """
     Observable for stress components.
 
@@ -160,6 +159,8 @@ class Stress(Observable, ComponentMixin):
     include_ideal_gas : bool
         Calculate with the ideal gas contribution.
     """
+
+    __module__ = "observables"
 
     def __init__(
         self,
@@ -234,7 +235,6 @@ ShearStress = Stress(components=["xy", "yz", "zx"])
 
 # pylint: disable=too-few-public-methods
 class Velocity(Observable, ComponentMixin):
-    __module__ = "observables"
     """
     Observable for per atom velocity components.
 
@@ -245,6 +245,8 @@ class Velocity(Observable, ComponentMixin):
     atoms_slice : list[int] | SliceLike | None = None
         List or slice of atoms to observe velocities from.
     """
+
+    __module__ = "observables"
 
     def __init__(
         self,

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -9,7 +9,7 @@ from ase import Atoms, units
 
 if TYPE_CHECKING:
     from janus_core.helpers.janus_types import SliceLike
-    from janus_core.helpers.utils import slicelike_len_for
+    from janus_core.helpers.utils import selector_len
 
 
 # pylint: disable=too-few-public-methods
@@ -287,6 +287,4 @@ class Velocity(Observable, ComponentMixin):
         int
             The number of values returned by __call__.
         """
-        if isinstance(self.atoms_slice, list):
-            return len(self.atoms_slice) * self.dimension
-        return slicelike_len_for(self.atoms_slice, self.n_atoms) * self.dimension
+        return selector_len(self.atoms_slice, self.n_atoms) * self.dimension

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -33,7 +33,7 @@ class Observable:
         """
         self._dimension = dimension
 
-    def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
+    def __call__(self, atoms: Atoms) -> list[float]:
         """
         Signature for returning observed value from atoms.
 
@@ -41,10 +41,6 @@ class Observable:
         ----------
         atoms : Atoms
             Atoms object to extract values from.
-        *args : tuple
-            Additional positional arguments passed to getter.
-        **kwargs : dict
-            Additional kwargs passed getter.
 
         Returns
         -------
@@ -207,7 +203,7 @@ class Stress(Observable, ComponentMixin):
         Observable.__init__(self, len(components))
         self.include_ideal_gas = include_ideal_gas
 
-    def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
+    def __call__(self, atoms: Atoms) -> list[float]:
         """
         Get the stress components.
 
@@ -215,10 +211,6 @@ class Stress(Observable, ComponentMixin):
         ----------
         atoms : Atoms
             Atoms object to extract values from.
-        *args : tuple
-            Additional positional arguments passed to getter.
-        **kwargs : dict
-            Additional kwargs passed getter.
 
         Returns
         -------
@@ -278,7 +270,7 @@ class Velocity(Observable, ComponentMixin):
         else:
             self.atoms_slice = slice(0, None, 1)
 
-    def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
+    def __call__(self, atoms: Atoms) -> list[float]:
         """
         Get the velocity components for correlated atoms.
 
@@ -286,10 +278,6 @@ class Velocity(Observable, ComponentMixin):
         ----------
         atoms : Atoms
             Atoms object to extract values from.
-        *args : tuple
-            Additional positional arguments passed to getter.
-        **kwargs : dict
-            Additional kwargs passed getter.
 
         Returns
         -------

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -1,10 +1,12 @@
 """Module for built-in correlation observables."""
 
 from __future__ import annotations
-from typing import Optional
+
+from typing import Optional, Union
 
 from ase import Atoms, units
 
+from janus_core.helpers.janus_types import Observable, SliceLike
 
 # pylint: disable=too-few-public-methods
 class Observable:
@@ -89,7 +91,6 @@ class Observable:
         if self.atoms:
             return len(self.atoms)
         return 0
-
 
 class ComponentMixin:
     """
@@ -239,11 +240,15 @@ class Velocity(Observable, ComponentMixin):
     ----------
     components : list[str]
         Symbols for velocity components, x, y, z.
-    atoms : list[int]
-        List of atoms to observe velocities from.
+    atoms : Optional[Union[list[int], SliceLike]]
+        List or slice of atoms to observe velocities from.
     """
 
-    def __init__(self, components: list[str], atoms: list[int]):
+    def __init__(
+        self,
+        components: list[str],
+        atoms: Optional[Union[list[int], SliceLike]] = None,
+    ):
         """
         Initialise the observable from a symbolic str component and atom index.
 
@@ -251,14 +256,17 @@ class Velocity(Observable, ComponentMixin):
         ----------
         components : list[str]
             Symbols for tensor components, x, y, and z.
-        atoms : list[int]
-            List of atoms to observe velocities from.
+        atoms : Union[list[int], SliceLike]
+            List or slice of atoms to observe velocities from.
         """
         ComponentMixin.__init__(self, components={"x": 0, "y": 1, "z": 2})
         self._set_components(components)
 
         Observable.__init__(self, len(components))
-        self.atoms = atoms
+        if atoms:
+            self.atoms = atoms
+        else:
+            atoms = slice(None, None, None)
 
     def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
         """

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -105,7 +105,7 @@ class ComponentMixin:
 
         Returns
         -------
-        Dict[str, int]
+        dict[str, int]
             The allowed components and associated indices.
         """
         return self._components

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -1,56 +1,42 @@
 """Module for built-in correlation observables."""
 
 from __future__ import annotations
+from typing import Optional
 
 from ase import Atoms, units
 
 
-class Stress:
+# pylint: disable=too-few-public-methods
+class Observable:
     """
-    Observable for stress components.
+    Observable data that may be correlated.
 
     Parameters
     ----------
-    component : str
-        Symbol for tensor components, xx, yy, etc.
+    dimension : int
+        The dimension of the observed data.
     include_ideal_gas : bool
-        Calculate with the ideal gas contribution.
+            Calculate with the ideal gas contribution.
     """
 
     def __init__(self, component: str, *, include_ideal_gas: bool = True) -> None:
         """
-        Initialise the observables from a symbolic str component.
+        Initialise an observable with a given dimensionality.
 
         Parameters
         ----------
-        component : str
-            Symbol for tensor components, xx, yy, etc.
+        dimension : int
+            The dimension of the observed data.
         include_ideal_gas : bool
             Calculate with the ideal gas contribution.
         """
-        components = {
-            "xx": 0,
-            "yy": 1,
-            "zz": 2,
-            "yz": 3,
-            "zy": 3,
-            "xz": 4,
-            "zx": 4,
-            "xy": 5,
-            "yx": 5,
-        }
-        if component not in components:
-            raise ValueError(
-                f"'{component}' invalid, must be '{', '.join(list(components.keys()))}'"
-            )
+        self._dimension = dimension
+        self._getter = getter
+        self.atoms = None
 
-        self.component = component
-        self._index = components[self.component]
-        self.include_ideal_gas = include_ideal_gas
-
-    def __call__(self, atoms: Atoms, *args, **kwargs) -> float:
+    def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
         """
-        Get the stress component.
+        Call the user supplied getter if it exits.
 
         Parameters
         ----------
@@ -63,12 +49,233 @@ class Stress:
 
         Returns
         -------
-        float
-            The stress component in GPa units.
+        list[float]
+            The observed value, with dimensions atoms by self.dimension.
+
+        Raises
+        ------
+        ValueError
+            If user supplied getter is None.
+        """
+        if self._getter:
+            value = self._getter(atoms, *args, **kwargs)
+            if not isinstance(value, list):
+                return [value]
+            return value
+        raise ValueError("No user getter supplied")
+
+    @property
+    def dimension(self):
+        """
+        Dimension of the observable. Commensurate with self.__call__.
+
+        Returns
+        -------
+        int
+            Observables dimension.
+        """
+        return self._dimension
+
+    @property
+    def atom_count(self):
+        """
+        Atom count to average over.
+
+        Returns
+        -------
+        int
+            Atom count averaged over.
+        """
+        if self.atoms:
+            return len(self.atoms)
+        return 0
+
+
+class ComponentMixin:
+    """
+    Mixin to handle Observables with components.
+
+    Parameters
+    ----------
+    components : dict[str, int]
+        Symbolic components mapped to indices.
+    """
+
+    def __init__(self, components: dict[str, int]):
+        """
+        Initialise the mixin with components.
+
+        Parameters
+        ----------
+        components : dict[str, int]
+            Symbolic components mapped to indices.
+        """
+        self._components = components
+
+    @property
+    def allowed_components(self) -> dict[str, int]:
+        """
+        Allowed symbolic components with associated indices.
+
+        Returns
+        -------
+        Dict[str, int]
+            The allowed components and associated indices.
+        """
+        return self._components
+
+    @property
+    def _indices(self) -> list[int]:
+        """
+        Get indices associated with self._components.
+
+        Returns
+        -------
+        list[int]
+            The indices for each self._components.
+        """
+        return [self._components[c] for c in self.components]
+
+    def _set_components(self, components: list[str]):
+        """
+        Check if components are valid, if so set them.
+
+        Parameters
+        ----------
+        components : str
+            The component symbols to check.
+
+        Raises
+        ------
+        ValueError
+            If any component is invalid.
+        """
+        for component in components:
+            if component not in self.allowed_components:
+                component_names = list(self._components.keys())
+                raise ValueError(
+                    f"'{component}' invalid, must be '{', '.join(component_names)}'"
+                )
+        self.components = components
+
+
+# pylint: disable=too-few-public-methods
+class Stress(Observable, ComponentMixin):
+    """
+    Observable for stress components.
+
+    Parameters
+    ----------
+    components : list[str]
+        Symbols for correlated tensor components, xx, yy, etc.
+    include_ideal_gas : bool
+        Calculate with the ideal gas contribution.
+    """
+
+    def __init__(self, components: list[str], *, include_ideal_gas: bool = True):
+        """
+        Initialise the observable from a symbolic str component.
+
+        Parameters
+        ----------
+        components : list[str]
+            Symbols for tensor components, xx, yy, etc.
+        include_ideal_gas : bool
+            Calculate with the ideal gas contribution.
+        """
+        ComponentMixin.__init__(
+            self,
+            components={
+                "xx": 0,
+                "yy": 1,
+                "zz": 2,
+                "yz": 3,
+                "zy": 3,
+                "xz": 4,
+                "zx": 4,
+                "xy": 5,
+                "yx": 5,
+            },
+        )
+        self._set_components(components)
+
+        Observable.__init__(self, len(components))
+        self.include_ideal_gas = include_ideal_gas
+
+    def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
+        """
+        Get the stress components.
+
+        Parameters
+        ----------
+        atoms : Atoms
+            Atoms object to extract values from.
+        *args : tuple
+            Additional positional arguments passed to getter.
+        **kwargs : dict
+            Additional kwargs passed getter.
+
+        Returns
+        -------
+        list[float]
+            The stress components in GPa units.
         """
         return (
-            atoms.get_stress(include_ideal_gas=self.include_ideal_gas, voigt=True)[
-                self._index
-            ]
+            atoms.get_stress(include_ideal_gas=self.include_ideal_gas, voigt=True)
             / units.GPa
-        )
+        )[self._indices]
+
+
+StressDiagonal = Stress(["xx", "yy", "zz"])
+ShearStress = Stress(["xy", "yz", "zx"])
+
+
+# pylint: disable=too-few-public-methods
+class Velocity(Observable, ComponentMixin):
+    """
+    Observable for per atom velocity components.
+
+    Parameters
+    ----------
+    components : list[str]
+        Symbols for velocity components, x, y, z.
+    atoms : list[int]
+        List of atoms to observe velocities from.
+    """
+
+    def __init__(self, components: list[str], atoms: list[int]):
+        """
+        Initialise the observable from a symbolic str component and atom index.
+
+        Parameters
+        ----------
+        components : list[str]
+            Symbols for tensor components, x, y, and z.
+        atoms : list[int]
+            List of atoms to observe velocities from.
+        """
+        ComponentMixin.__init__(self, components={"x": 0, "y": 1, "z": 2})
+        self._set_components(components)
+
+        Observable.__init__(self, len(components))
+        self.atoms = atoms
+
+    def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
+        """
+        Get the velocity components for correlated atoms.
+
+        Parameters
+        ----------
+        atoms : Atoms
+            Atoms object to extract values from.
+        *args : tuple
+            Additional positional arguments passed to getter.
+        **kwargs : dict
+            Additional kwargs passed getter.
+
+        Returns
+        -------
+        list[float]
+            The velocity values.
+        """
+        return atoms.get_velocities()[self.atoms, :][:, self._indices].flatten()

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -138,9 +138,8 @@ class ComponentMixin:
         ValueError
             If any component is invalid.
         """
-        for component in components:
+        for component in self.allowed_components.keys() - components.keys():
             if component not in self.allowed_components:
-                component_names = list(self._components.keys())
                 raise ValueError(
                     f"'{component}' invalid, must be '{', '.join(component_names)}'"
                 )
@@ -267,10 +266,7 @@ class Velocity(Observable, ComponentMixin):
 
         Observable.__init__(self, len(components))
 
-        if atoms_slice:
-            self.atoms_slice = atoms_slice
-        else:
-            self.atoms_slice = slice(0, None, 1)
+        self.atoms_slice = atoms_slice if atoms_slice else slice(0, None, 1)
 
     def __call__(self, atoms: Atoms) -> list[float]:
         """

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from ase import Atoms, units
 
@@ -332,7 +332,7 @@ class Velocity(Observable, ComponentMixin):
     def __init__(
         self,
         components: list[str],
-        atoms: Optional[Union[list[int], "SliceLike"]] = None,
+        atoms: list[int] | SliceLike | None = None,
     ):
         """
         Initialise the observable from a symbolic str component and atom index.

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -138,11 +138,12 @@ class ComponentMixin:
         ValueError
             If any component is invalid.
         """
-        for component in self.allowed_components.keys() - components.keys():
-            if component not in self.allowed_components:
-                raise ValueError(
-                    f"'{component}' invalid, must be '{', '.join(component_names)}'"
-                )
+        if any(components - self.allowed_components.keys()):
+            raise ValueError(
+                f"'{components-self.allowed_components.keys()}'"
+                " invalid, must be '{', '.join(self._components)}'"
+            )
+
         self.components = components
 
 
@@ -228,8 +229,8 @@ class Stress(Observable, ComponentMixin):
         )[self._indices]
 
 
-StressDiagonal = Stress(components=["xx", "yy", "zz"])
-ShearStress = Stress(components=["xy", "yz", "zx"])
+StressHydrostatic = Stress(components=["xx", "yy", "zz"])
+StressShear = Stress(components=["xy", "yz", "zx"])
 
 
 # pylint: disable=too-few-public-methods

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -147,6 +147,7 @@ class ComponentMixin:
 
 # pylint: disable=too-few-public-methods
 class Stress(Observable, ComponentMixin):
+    __module__ = "observables"
     """
     Observable for stress components.
 
@@ -233,6 +234,7 @@ ShearStress = Stress(components=["xy", "yz", "zx"])
 
 # pylint: disable=too-few-public-methods
 class Velocity(Observable, ComponentMixin):
+    __module__ = "observables"
     """
     Observable for per atom velocity components.
 

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -30,8 +30,8 @@ class Observable(ABC):
 
         Parameters
         ----------
-        atoms_slice : list[int] | SliceLike | None = None
-            A slice of atoms to observe.
+        atoms_slice : list[int] | SliceLike | None
+            A slice of atoms to observe. By default all atoms are included.
         """
         if atoms_slice:
             if isinstance(atoms_slice, list):

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -98,19 +98,7 @@ class ComponentMixin:
         components : dict[str, int]
             Symbolic components mapped to indices.
         """
-        self._components = components
-
-    @property
-    def allowed_components(self) -> dict[str, int]:
-        """
-        Allowed symbolic components with associated indices.
-
-        Returns
-        -------
-        dict[str, int]
-            The allowed components and associated indices.
-        """
-        return self._components
+        self._allowed_components = components
 
     @property
     def _indices(self) -> list[int]:
@@ -122,7 +110,7 @@ class ComponentMixin:
         list[int]
             The indices for each self._components.
         """
-        return [self._components[c] for c in self.components]
+        return [self._allowed_components[c] for c in self.components]
 
     def _set_components(self, components: list[str]):
         """
@@ -138,7 +126,7 @@ class ComponentMixin:
         ValueError
             If any component is invalid.
         """
-        if any(components - self.allowed_components.keys()):
+        if any(components - self._allowed_components.keys()):
             raise ValueError(
                 f"'{components-self.allowed_components.keys()}'"
                 " invalid, must be '{', '.join(self._components)}'"

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -8,6 +8,7 @@ from ase import Atoms, units
 
 if TYPE_CHECKING:
     from janus_core.helpers.janus_types import SliceLike
+    from janus_core.helpers.utils import slicelike_len_for
 
 
 # pylint: disable=too-few-public-methods
@@ -81,16 +82,7 @@ class Observable:
         if self.atoms:
             if isinstance(self.atoms, list):
                 return len(self.atoms)
-            if isinstance(self.atoms, int):
-                return 1
-
-            start = self.atoms.start
-            stop = self.atoms.stop
-            step = self.atoms.step
-            start = start if start is None else 0
-            stop = stop if stop is None else n_atoms
-            step = step if step is None else 1
-            return len(range(start, stop, step))
+            return slicelike_len_for(self.n_atoms)
         return 0
 
 # pylint: disable=too-few-public-methods

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -33,13 +33,14 @@ class Observable(ABC):
         atoms_slice : list[int] | SliceLike | None
             A slice of atoms to observe. By default all atoms are included.
         """
-        if atoms_slice:
-            if isinstance(atoms_slice, list):
-                self.atoms_slice = atoms_slice
-            else:
-                self.atoms_slice = slice(*slicelike_to_startstopstep(atoms_slice))
-        else:
+        if not atoms_slice:
             self.atoms_slice = slice(0, None, 1)
+            return
+
+        if isinstance(atoms_slice, list):
+            self.atoms_slice = atoms_slice
+        else:
+            self.atoms_slice = slice(*slicelike_to_startstopstep(atoms_slice))
 
     @abstractmethod
     def __call__(self, atoms: Atoms) -> list[float]:

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -128,8 +128,8 @@ class ComponentMixin:
         """
         if any(components - self._allowed_components.keys()):
             raise ValueError(
-                f"'{components-self.allowed_components.keys()}'"
-                " invalid, must be '{', '.join(self._components)}'"
+                f"'{components-self._allowed_components.keys()}'"
+                f" invalid, must be '{', '.join(self._allowed_components)}'"
             )
 
         self.components = components

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -162,8 +162,6 @@ class Stress(Observable, ComponentMixin):
         Calculate with the ideal gas contribution.
     """
 
-    __module__ = "observables"
-
     def __init__(
         self,
         *,
@@ -247,8 +245,6 @@ class Velocity(Observable, ComponentMixin):
     atoms_slice : list[int] | SliceLike | None = None
         List or slice of atoms to observe velocities from.
     """
-
-    __module__ = "observables"
 
     def __init__(
         self,

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -82,12 +82,12 @@ class ComponentMixin:
     @property
     def _indices(self) -> list[int]:
         """
-        Get indices associated with self._components.
+        Get indices associated with self.components.
 
         Returns
         -------
         list[int]
-            The indices for each self._components.
+            The indices for each self.components.
         """
         return [self._allowed_components[c] for c in self.components]
 

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -207,12 +207,13 @@ class Stress(Observable, ComponentMixin):
         """
         sliced_atoms = atoms[self.atoms_slice]
         sliced_atoms.calc = atoms.calc
-        return (
+        stresses = (
             sliced_atoms.get_stress(
                 include_ideal_gas=self.include_ideal_gas, voigt=True
             )
             / units.GPa
-        )[self._indices]
+        )
+        return stresses[self._indices]
 
 
 StressHydrostatic = Stress(components=["xx", "yy", "zz"])

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
 
 from ase import Atoms, units
 
-if TYPE_CHECKING:
-    from janus_core.helpers.janus_types import SliceLike
-    from janus_core.helpers.utils import selector_len
+from janus_core.helpers.janus_types import SliceLike
+from janus_core.helpers.utils import selector_len
 
 
 # pylint: disable=too-few-public-methods
@@ -287,4 +285,4 @@ class Velocity(Observable, ComponentMixin):
         int
             The number of values returned by __call__.
         """
-        return selector_len(self.atoms_slice, self.n_atoms) * self.dimension
+        return selector_len(self.atoms_slice, n_atoms) * self.dimension

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -19,11 +19,9 @@ class Observable:
     ----------
     dimension : int
         The dimension of the observed data.
-    getter : Optional[callable]
-        An optional callable to construct the Observable from.
     """
 
-    def __init__(self, dimension: int = 1, *, getter: Optional[callable] = None):
+    def __init__(self, dimension: int = 1):
         """
         Initialise an observable with a given dimensionality.
 
@@ -31,16 +29,13 @@ class Observable:
         ----------
         dimension : int
             The dimension of the observed data.
-        getter : Optional[callable]
-            An optional callable to construct the Observable from.
         """
         self._dimension = dimension
-        self._getter = getter
         self.atoms = None
 
     def __call__(self, atoms: Atoms, *args, **kwargs) -> list[float]:
         """
-        Call the user supplied getter if it exits.
+        Signature for returning observed value from atoms.
 
         Parameters
         ----------
@@ -55,18 +50,7 @@ class Observable:
         -------
         list[float]
             The observed value, with dimensions atoms by self.dimension.
-
-        Raises
-        ------
-        ValueError
-            If user supplied getter is None.
         """
-        if self._getter:
-            value = self._getter(atoms, *args, **kwargs)
-            if not isinstance(value, list):
-                return [value]
-            return value
-        raise ValueError("No user getter supplied")
 
     @property
     def dimension(self):

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from ase import Atoms, units
 
-from janus_core.helpers.janus_types import SliceLike
+if TYPE_CHECKING:
+    from janus_core.helpers.janus_types import SliceLike
+
 from janus_core.helpers.utils import selector_len
 
 

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -91,7 +91,20 @@ class ComponentMixin:
         """
         return [self._allowed_components[c] for c in self.components]
 
-    def _set_components(self, components: list[str]):
+    @property
+    def components(self) -> list[str]:
+        """
+        Get the symbolic components of the observable.
+
+        Returns
+        -------
+        list[str]
+            The observables components.
+        """
+        return self._components
+
+    @components.setter
+    def components(self, components: list[str]):
         """
         Check if components are valid, if so set them.
 
@@ -111,7 +124,7 @@ class ComponentMixin:
                 f" invalid, must be '{', '.join(self._allowed_components)}'"
             )
 
-        self.components = components
+        self._components = components
 
 
 # pylint: disable=too-few-public-methods
@@ -162,7 +175,7 @@ class Stress(Observable, ComponentMixin):
                 "yx": 5,
             },
         )
-        self._set_components(components)
+        self.components = components
 
         Observable.__init__(self, atoms_slice)
         self.include_ideal_gas = include_ideal_gas
@@ -234,7 +247,7 @@ class Velocity(Observable, ComponentMixin):
             List or slice of atoms to observe velocities from.
         """
         ComponentMixin.__init__(self, components={"x": 0, "y": 1, "z": 2})
-        self._set_components(components)
+        self.components = components
 
         Observable.__init__(self, atoms_slice)
 

--- a/janus_core/processing/post_process.py
+++ b/janus_core/processing/post_process.py
@@ -15,33 +15,8 @@ from janus_core.helpers.janus_types import (
     MaybeSequence,
     PathLike,
     SliceLike,
-    StartStopStep,
 )
-
-
-def _process_index(index: SliceLike) -> StartStopStep:
-    """
-    Standarize `SliceLike`s into tuple of `start`, `stop`, `step`.
-
-    Parameters
-    ----------
-    index : SliceLike
-        `SliceLike` to standardize.
-
-    Returns
-    -------
-    StartStopStep
-        Standardized `SliceLike` as `start`, `stop`, `step` triplet.
-    """
-    if isinstance(index, int):
-        if index == -1:
-            return (index, None, 1)
-        return (index, index + 1, 1)
-
-    if isinstance(index, (slice, range)):
-        return (index.start, index.stop, index.step)
-
-    return index
+from janus_core.helpers.utils import slicelike_to_startstopstep
 
 
 def compute_rdf(
@@ -94,7 +69,7 @@ def compute_rdf(
         If `by_elements` is true returns a `dict` of RDF by element pairs.
         Otherwise returns RDF of total system filtered by elements.
     """
-    index = _process_index(index)
+    index = slicelike_to_startstopstep(index)
 
     if not isinstance(data, Sequence):
         data = [data]
@@ -261,7 +236,7 @@ def compute_vaf(
             )
 
     # Extract requested data
-    index = _process_index(index)
+    index = slicelike_to_startstopstep(index)
     data = data[slice(*index)]
 
     if use_velocities:

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -43,7 +43,7 @@ def correlate(
 def test_setup():
     """Test initial values."""
     cor = Correlator(blocks=1, points=100, averaging=2)
-    correlation, lags = cor.get()
+    correlation, lags = cor.get_value(), cor.get_lags()
     assert len(correlation) == len(lags)
     assert len(correlation) == 0
 
@@ -55,7 +55,7 @@ def test_correlation():
     signal = np.exp(-np.linspace(0.0, 1.0, points))
     for val in signal:
         cor.update(val, val)
-    correlation, lags = cor.get()
+    correlation, lags = cor.get_value(), cor.get_lags()
 
     direct = correlate(signal, signal, fft=False)
     fft = correlate(signal, signal, fft=True)

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -96,8 +96,8 @@ def test_vaf(tmp_path):
         file_prefix=file_prefix,
         correlation_kwargs=[
             {
-                "a": Velocity(["x", "y", "z"], na),
-                "b": Velocity(["x", "y", "z"], na),
+                "a": Velocity(components=["x", "y", "z"], atoms_slice=na),
+                "b": Velocity(components=["x", "y", "z"], atoms_slice=na),
                 "name": "vaf_Na",
                 "blocks": 1,
                 "points": 11,
@@ -105,8 +105,8 @@ def test_vaf(tmp_path):
                 "update_frequency": 1,
             },
             {
-                "a": Velocity(["x", "y", "z"], cl),
-                "b": Velocity(["x", "y", "z"], cl),
+                "a": Velocity(components=["x", "y", "z"], atoms_slice=cl),
+                "b": Velocity(components=["x", "y", "z"], atoms_slice=cl),
                 "name": "vaf_Cl",
                 "blocks": 1,
                 "points": 11,
@@ -130,8 +130,8 @@ def test_vaf(tmp_path):
         vaf = safe_load(cor)
     vaf_na = np.array(vaf["vaf_Na"]["value"])
     vaf_cl = np.array(vaf["vaf_Cl"]["value"])
-    assert vaf_na == approx(vaf_post[0], rel=1e-5)
-    assert vaf_cl == approx(vaf_post[1], rel=1e-5)
+    assert vaf_na * 3 == approx(vaf_post[0], rel=1e-5)
+    assert vaf_cl * 3 == approx(vaf_post[1], rel=1e-5)
 
 
 def test_md_correlations(tmp_path):
@@ -156,8 +156,8 @@ def test_md_correlations(tmp_path):
         file_prefix=file_prefix,
         correlation_kwargs=[
             {
-                "a": Stress([("xy")]),
-                "b": Stress([("xy")]),
+                "a": Stress(components=[("xy")]),
+                "b": Stress(components=[("xy")]),
                 "name": "stress_xy_auto_cor",
                 "blocks": 1,
                 "points": 11,

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -130,8 +130,8 @@ def test_vaf(tmp_path):
         vaf = safe_load(cor)
     vaf_na = np.array(vaf["vaf_Na"]["value"])
     vaf_cl = np.array(vaf["vaf_Cl"]["value"])
-    assert vaf_na * 3 == approx(vaf_post[0], rel=1e-5)
-    assert vaf_cl * 3 == approx(vaf_post[1], rel=1e-5)
+    assert vaf_na * 3 == approx(vaf_post[1][0], rel=1e-5)
+    assert vaf_cl * 3 == approx(vaf_post[1][1], rel=1e-5)
 
 
 def test_md_correlations(tmp_path):

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -16,7 +16,9 @@ from yaml import Loader, load, safe_load
 from janus_core.calculations.md import NVE
 from janus_core.calculations.single_point import SinglePoint
 from janus_core.processing.correlator import Correlator
-from janus_core.processing.observables import Stress
+from janus_core.processing.observables import Stress, Velocity
+from janus_core.processing import post_process
+from janus_core.helpers.janus_types import Observable
 
 DATA_PATH = Path(__file__).parent / "data"
 MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -78,13 +78,8 @@ def test_vaf(tmp_path):
         calc_kwargs={"model": MODEL_PATH},
     )
 
-    na = []
-    cl = []
-    for i, atom in enumerate(single_point.struct):
-        if atom.symbol == "Na":
-            na.append(i)
-        else:
-            cl.append(i)
+    na = list(range(0, len(single_point.struct), 2))
+    cl = list(range(1, len(single_point.struct), 2))
 
     nve = NVE(
         struct=single_point.struct,
@@ -96,8 +91,11 @@ def test_vaf(tmp_path):
         file_prefix=file_prefix,
         correlation_kwargs=[
             {
-                "a": Velocity(components=["x", "y", "z"], atoms_slice=na),
-                "b": Velocity(components=["x", "y", "z"], atoms_slice=na),
+                "a": Velocity(components=["x", "y", "z"], atoms_slice=(0, None, 2)),
+                "b": Velocity(
+                    components=["x", "y", "z"],
+                    atoms_slice=range(0, len(single_point.struct), 2),
+                ),
                 "name": "vaf_Na",
                 "blocks": 1,
                 "points": 11,
@@ -106,7 +104,9 @@ def test_vaf(tmp_path):
             },
             {
                 "a": Velocity(components=["x", "y", "z"], atoms_slice=cl),
-                "b": Velocity(components=["x", "y", "z"], atoms_slice=cl),
+                "b": Velocity(
+                    components=["x", "y", "z"], atoms_slice=slice(1, None, 2)
+                ),
                 "name": "vaf_Cl",
                 "blocks": 1,
                 "points": 11,

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -14,9 +14,9 @@ from yaml import Loader, load, safe_load
 
 from janus_core.calculations.md import NVE
 from janus_core.calculations.single_point import SinglePoint
+from janus_core.processing import post_process
 from janus_core.processing.correlator import Correlator
 from janus_core.processing.observables import Stress, Velocity
-from janus_core.processing import post_process
 
 DATA_PATH = Path(__file__).parent / "data"
 MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Union
 
 from ase import Atoms
 from ase.io import read
@@ -206,6 +207,6 @@ def test_slicelike_to_startstopstep(slc: SliceLike, expected: StartStopStep):
         (([0, -1, 2, 9], 10), 4),
     ],
 )
-def test_selector_len(slc_len: tuple[SliceLike | list, int], expected: int):
+def test_selector_len(slc_len: tuple[Union[SliceLike, list], int], expected: int):
     """Test converting SliceLike to StartStopStep."""
     assert selector_len(*slc_len) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
 
 from ase import Atoms
 from ase.io import read
@@ -192,21 +191,21 @@ def test_slicelike_to_startstopstep(slc: SliceLike, expected: StartStopStep):
 
 
 @pytest.mark.parametrize(
-    "slc_len, expected",
+    "slc, len, expected",
     [
-        (((1, 2, 3), 3), 1),
-        ((1, 1), 1),
-        ((range(1, 2, 3), 3), 1),
-        ((slice(1, 2, 3), 3), 1),
-        ((-1, 5), 1),
-        ((-3, 4), 1),
-        ((range(10), 10), 10),
-        ((slice(0, None, 2), 10), 5),
-        (([-2, -1, 0], 9), 3),
-        (([-1], 10), 1),
-        (([0, -1, 2, 9], 10), 4),
+        ((1, 2, 3), 3, 1),
+        (1, 1, 1),
+        (range(1, 2, 3), 3, 1),
+        (slice(1, 2, 3), 3, 1),
+        (-1, 5, 1),
+        (-3, 4, 1),
+        (range(10), 10, 10),
+        (slice(0, None, 2), 10, 5),
+        ([-2, -1, 0], 9, 3),
+        ([-1], 10, 1),
+        ([0, -1, 2, 9], 10, 4),
     ],
 )
-def test_selector_len(slc_len: tuple[Union[SliceLike, list], int], expected: int):
+def test_selector_len(slc: SliceLike | list[int], len: int, expected: int):
     """Test converting SliceLike to StartStopStep."""
-    assert selector_len(*slc_len) == expected
+    assert selector_len(slc, len) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Union
 
 from ase import Atoms
 from ase.io import read
@@ -206,6 +207,6 @@ def test_slicelike_to_startstopstep(slc: SliceLike, expected: StartStopStep):
         ([0, -1, 2, 9], 10, 4),
     ],
 )
-def test_selector_len(slc: SliceLike | list[int], len: int, expected: int):
+def test_selector_len(slc: Union[SliceLike, list[int]], len: int, expected: int):
     """Test converting SliceLike to StartStopStep."""
     assert selector_len(slc, len) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,10 +12,8 @@ from janus_core.cli.utils import dict_paths_to_strs, dict_remove_hyphens
 from janus_core.helpers.janus_types import SliceLike, StartStopStep
 from janus_core.helpers.mlip_calculators import choose_calculator
 from janus_core.helpers.struct_io import output_structs
-from janus_core.helpers.utils import none_to_dict
 from janus_core.helpers.utils import (
     none_to_dict,
-    output_structs,
     slicelike_len_for,
     slicelike_to_startstopstep,
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ from janus_core.helpers.mlip_calculators import choose_calculator
 from janus_core.helpers.struct_io import output_structs
 from janus_core.helpers.utils import (
     none_to_dict,
-    slicelike_len_for,
+    selector_len,
     slicelike_to_startstopstep,
 )
 
@@ -197,11 +197,15 @@ def test_slicelike_to_startstopstep(slc: SliceLike, expected: StartStopStep):
         ((1, 1), 1),
         ((range(1, 2, 3), 3), 1),
         ((slice(1, 2, 3), 3), 1),
-        ((-1, 1), 2),
+        ((-1, 5), 1),
+        ((-3, 4), 1),
         ((range(10), 10), 10),
         ((slice(0, None, 2), 10), 5),
+        (([-2, -1, 0], 9), 3),
+        (([-1], 10), 1),
+        (([0, -1, 2, 9], 10), 4),
     ],
 )
-def test_slicelike_len_for(slc_len: tuple[SliceLike, int], expected: int):
+def test_selector_len(slc_len: tuple[SliceLike | list, int], expected: int):
     """Test converting SliceLike to StartStopStep."""
-    assert slicelike_len_for(*slc_len) == expected
+    assert selector_len(*slc_len) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Union
 
 from ase import Atoms
 from ase.io import read
@@ -17,6 +16,7 @@ from janus_core.helpers.utils import (
     none_to_dict,
     selector_len,
     slicelike_to_startstopstep,
+    validate_slicelike,
 )
 
 DATA_PATH = Path(__file__).parent / "data/NaCl.cif"
@@ -207,6 +207,46 @@ def test_slicelike_to_startstopstep(slc: SliceLike, expected: StartStopStep):
         ([0, -1, 2, 9], 10, 4),
     ],
 )
-def test_selector_len(slc: Union[SliceLike, list[int]], len: int, expected: int):
+def test_selector_len(slc: SliceLike | list[int], len: int, expected: int):
     """Test converting SliceLike to StartStopStep."""
     assert selector_len(slc, len) == expected
+
+
+@pytest.mark.parametrize(
+    "slc",
+    [
+        slice(0, 1, 1),
+        slice(0, None, 1),
+        range(3),
+        range(0, 10, 1),
+        -1,
+        0,
+        1,
+        (0),
+        (0, 1, 1),
+        (0, None, 1),
+    ],
+)
+def test_valid_slicelikes(slc):
+    """Test validate_slicelike on valid SliceLikes."""
+    validate_slicelike(slc)
+
+
+@pytest.mark.parametrize(
+    "slc",
+    [
+        1.0,
+        "",
+        None,
+        [1],
+        (None, 0, None),
+        (0, 1, None),
+        (None, None, None),
+        (0, 1),
+        (0, 1, 2, 3),
+    ],
+)
+def test_invalid_slicelikes(slc):
+    """Test validate_slicelike on invalid SliceLikes."""
+    with pytest.raises(ValueError):
+        validate_slicelike(slc)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,9 +9,16 @@ from ase.io import read
 import pytest
 
 from janus_core.cli.utils import dict_paths_to_strs, dict_remove_hyphens
+from janus_core.helpers.janus_types import SliceLike, StartStopStep
 from janus_core.helpers.mlip_calculators import choose_calculator
 from janus_core.helpers.struct_io import output_structs
 from janus_core.helpers.utils import none_to_dict
+from janus_core.helpers.utils import (
+    none_to_dict,
+    output_structs,
+    slicelike_len_for,
+    slicelike_to_startstopstep,
+)
 
 DATA_PATH = Path(__file__).parent / "data/NaCl.cif"
 MODEL_PATH = Path(__file__).parent / "models/mace_mp_small.model"
@@ -166,3 +173,37 @@ def test_none_to_dict(dicts_in):
     assert dicts[2] == dicts_in[2]
     assert dicts[3] == dicts_in[3]
     assert dicts[4] == {}
+
+
+@pytest.mark.parametrize(
+    "slc, expected",
+    [
+        ((1, 2, 3), (1, 2, 3)),
+        (1, (1, 2, 1)),
+        (range(1, 2, 3), (1, 2, 3)),
+        (slice(1, 2, 3), (1, 2, 3)),
+        (-1, (-1, None, 1)),
+        (range(10), (0, 10, 1)),
+        (slice(0, None, 1), (0, None, 1)),
+    ],
+)
+def test_slicelike_to_startstopstep(slc: SliceLike, expected: StartStopStep):
+    """Test converting SliceLike to StartStopStep."""
+    assert slicelike_to_startstopstep(slc) == expected
+
+
+@pytest.mark.parametrize(
+    "slc_len, expected",
+    [
+        (((1, 2, 3), 3), 1),
+        ((1, 1), 1),
+        ((range(1, 2, 3), 3), 1),
+        ((slice(1, 2, 3), 3), 1),
+        ((-1, 1), 2),
+        ((range(10), 10), 10),
+        ((slice(0, None, 2), 10), 5),
+    ],
+)
+def test_slicelike_len_for(slc_len: tuple[SliceLike, int], expected: int):
+    """Test converting SliceLike to StartStopStep."""
+    assert slicelike_len_for(*slc_len) == expected


### PR DESCRIPTION
This adds a Velocity observable capable of averaging over supplied components ```x, y, z``` and atom lists. The behaviour is abstracted so also for stress we can obtain shear stress correlations $\langle \sigma_{xy}\sigma_{xy}\rangle+\langle \sigma_{yz}\sigma_{yz}\rangle+\langle \sigma_{zx}\sigma_{zx}\rangle$ with the built in ```ShearStress === Stress(['xy', 'yz', 'zx'])```

- ci tests now test against post-process vaf, dependent on changes to it #284 .

- I used the ShearStress observable to get experimental viscosity for LiF which could be an example perhaps along with the VAF.

- [x] still need to fix the docs/ update the developer guide.
- [x] ~~perhaps we could have a helper function to create Velocity-Velocity correlations from a structure (say, creating correlation_kwargs for different atom types automatically). As it stands ```Observable``` does not attach to a particular atoms object and so does not have this information at construction. Except implicitly via ```atoms: list[int]```.~~
- [x] Velocity can take a ```SliceLike``` or ```list[int]```. So open-ended ranges can be specified i.e. ```slice(0, None)```, but also non-monotonic, decreasing or whatever sequences can be specified that cannot be represented as a slice.

![bitmap](https://github.com/user-attachments/assets/c0f101b8-03ba-4e04-abcc-6209bfa38a5f)
