### PR TITLE
Fix summary duplication

### DIFF
--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -27,7 +27,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -145,11 +144,7 @@ def descriptors(
     # Store inputs for yaml summary
     inputs = descriptors_kwargs.copy()
 
-    # Store only filename as filemode is not set by user
-    del inputs["log_kwargs"]
-    inputs["log"] = log
-
-    # Add structure and MLIP information to inputs
+    # Add structure, MLIP information, and log to inputs
     save_struct_calc(
         inputs=inputs,
         struct=descript.struct,
@@ -159,10 +154,8 @@ def descriptors(
         model_path=model_path,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
+        log=log,
     )
-
-    # Convert all paths to strings in inputs nested dictionary
-    dict_paths_to_strs(inputs)
 
     # Save summary information before calculation begins
     start_summary(command="descriptors", summary=summary, inputs=inputs)

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -30,7 +30,6 @@ from janus_core.cli.utils import (
     yaml_converter_callback,
 )
 from janus_core.helpers.janus_types import EoSNames
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -180,11 +179,7 @@ def eos(
     # Store inputs for yaml summary
     inputs = eos_kwargs.copy()
 
-    # Store only filename as filemode is not set by user
-    del inputs["log_kwargs"]
-    inputs["log"] = log
-
-    # Add structure and MLIP information to inputs
+    # Add structure, MLIP information, and log to inputs
     save_struct_calc(
         inputs=inputs,
         struct=equation_of_state.struct,
@@ -194,10 +189,8 @@ def eos(
         model_path=model_path,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
+        log=log,
     )
-
-    # Convert all paths to strings in inputs nested dictionary
-    dict_paths_to_strs(inputs)
 
     # Save summary information before calculations begin
     start_summary(command="eos", summary=summary, inputs=inputs)

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -29,7 +29,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -263,11 +262,7 @@ def geomopt(
     # Store inputs for yaml summary
     inputs = optimize_kwargs.copy()
 
-    # Store only filename as filemode is not set by user
-    del inputs["log_kwargs"]
-    inputs["log"] = log
-
-    # Add structure and MLIP information to inputs
+    # Add structure, MLIP information, and log to inputs
     save_struct_calc(
         inputs=inputs,
         struct=optimizer.struct,
@@ -277,10 +272,8 @@ def geomopt(
         model_path=model_path,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
+        log=log,
     )
-
-    # Convert all paths to strings in inputs nested dictionary
-    dict_paths_to_strs(inputs)
 
     # Save summary information before optimization begins
     start_summary(command="geomopt", summary=summary, inputs=inputs)

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -32,7 +32,6 @@ from janus_core.cli.utils import (
     yaml_converter_callback,
 )
 from janus_core.helpers.janus_types import Ensembles
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -398,11 +397,7 @@ def md(
     # Store inputs for yaml summary
     inputs = dyn_kwargs | {"ensemble": ensemble}
 
-    # Store only filename as filemode is not set by user
-    del inputs["log_kwargs"]
-    inputs["log"] = log
-
-    # Add structure and MLIP information to inputs
+    # Add structure, MLIP information, and log to inputs
     save_struct_calc(
         inputs=inputs,
         struct=dyn.struct,
@@ -412,10 +407,8 @@ def md(
         model_path=model_path,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
+        log=log,
     )
-
-    # Convert all paths to strings in inputs nested dictionary
-    dict_paths_to_strs(inputs)
 
     # Save summary information before simulation begins
     start_summary(command="md", summary=summary, inputs=inputs)

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -28,7 +28,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -261,11 +260,7 @@ def phonons(
     # Store inputs for yaml summary
     inputs = phonons_kwargs.copy()
 
-    # Store only filename as filemode is not set by user
-    del inputs["log_kwargs"]
-    inputs["log"] = log
-
-    # Add structure and MLIP information to inputs
+    # Add structure, MLIP information, and log to inputs
     save_struct_calc(
         inputs=inputs,
         struct=phonon.struct,
@@ -275,10 +270,8 @@ def phonons(
         model_path=model_path,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
+        log=log,
     )
-
-    # Convert all paths to strings in inputs nested dictionary
-    dict_paths_to_strs(inputs)
 
     # Save summary information before calculations begin
     start_summary(command="phonons", summary=summary, inputs=inputs)

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -27,7 +27,6 @@ from janus_core.cli.utils import (
     start_summary,
     yaml_converter_callback,
 )
-from janus_core.helpers.utils import dict_paths_to_strs
 
 app = Typer()
 
@@ -132,10 +131,10 @@ def singlepoint(
     # Initialise singlepoint structure and calculator
     s_point = SinglePoint(**singlepoint_kwargs)
 
-    # Store only filename as filemode is not set by user
-    inputs = {"log": log}
+    # Store inputs for yaml summary
+    inputs = singlepoint_kwargs.copy()
 
-    # Add structure and MLIP information to inputs
+    # Add structure, MLIP information, and log to inputs
     save_struct_calc(
         inputs=inputs,
         struct=s_point.struct,
@@ -145,15 +144,8 @@ def singlepoint(
         model_path=model_path,
         read_kwargs=read_kwargs,
         calc_kwargs=calc_kwargs,
+        log=log,
     )
-
-    inputs["run"] = {
-        "properties": properties,
-        "write_kwargs": write_kwargs,
-    }
-
-    # Convert all paths to strings in inputs nested dictionary
-    dict_paths_to_strs(inputs)
 
     # Save summary information before singlepoint calculation begins
     start_summary(command="singlepoint", summary=summary, inputs=inputs)

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -200,42 +200,6 @@ def none_to_dict(dictionaries: Sequence[Optional[dict]]) -> Generator[dict, None
     yield from (dictionary if dictionary else {} for dictionary in dictionaries)
 
 
-def dict_paths_to_strs(dictionary: dict) -> None:
-    """
-    Recursively iterate over dictionary, converting Path values to strings.
-
-    Parameters
-    ----------
-    dictionary : dict
-        Dictionary to be converted.
-    """
-    for key, value in dictionary.items():
-        if isinstance(value, dict):
-            dict_paths_to_strs(value)
-        elif isinstance(value, Path):
-            dictionary[key] = str(value)
-
-
-def dict_remove_hyphens(dictionary: dict) -> dict:
-    """
-    Recursively iterate over dictionary, replacing hyphens with underscores in keys.
-
-    Parameters
-    ----------
-    dictionary : dict
-        Dictionary to be converted.
-
-    Returns
-    -------
-    dict
-        Dictionary with hyphens in keys replaced with underscores.
-    """
-    for key, value in dictionary.items():
-        if isinstance(value, dict):
-            dictionary[key] = dict_remove_hyphens(value)
-    return {k.replace("-", "_"): v for k, v in dictionary.items()}
-
-
 def results_to_info(
     struct: Atoms,
     *,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,14 +7,10 @@ from ase import Atoms
 from ase.io import read
 import pytest
 
+from janus_core.cli.utils import dict_paths_to_strs, dict_remove_hyphens
 from janus_core.helpers.janus_types import Properties
 from janus_core.helpers.mlip_calculators import choose_calculator
-from janus_core.helpers.utils import (
-    dict_paths_to_strs,
-    dict_remove_hyphens,
-    none_to_dict,
-    output_structs,
-)
+from janus_core.helpers.utils import none_to_dict, output_structs
 
 DATA_PATH = Path(__file__).parent / "data/NaCl.cif"
 MODEL_PATH = Path(__file__).parent / "models/mace_mp_small.model"


### PR DESCRIPTION
Since #283, the information that used to be passed to `SinglePoint` was duplicated, which also led to weird yaml aliases/anchors for the duplicated dictionaries.

This fixes this by removing duplicate keys from `inputs`, and also tides up the summary to handle it all in one place.