### PR TITLE
Remove duplicated descriptors log

### DIFF
--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -168,6 +168,9 @@ class Descriptors(BaseCalculation):
         """Calculate descriptors for structure(s)."""
         if self.logger:
             self.logger.info("Starting descriptors calculation")
+            self.logger.info("invariants_only: %s", self.invariants_only)
+            self.logger.info("calc_per_element: %s", self.calc_per_element)
+            self.logger.info("calc_per_atom: %s", self.calc_per_atom)
             self.tracker.start_task("Descriptors")
 
         if isinstance(self.struct, Sequence):
@@ -198,11 +201,6 @@ class Descriptors(BaseCalculation):
         struct : Atoms
             Structure to calculate descriptors for.
         """
-        if self.logger:
-            self.logger.info("invariants_only: %s", self.invariants_only)
-            self.logger.info("calc_per_element: %s", self.calc_per_element)
-            self.logger.info("calc_per_atom: %s", self.calc_per_atom)
-
         arch = struct.calc.parameters["arch"]
 
         # Calculate mean descriptor and save mean

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -57,6 +57,7 @@ def test_descriptors(tmp_path):
             "Starting descriptors calculation",
             "invariants_only: True",
             "calc_per_element: False",
+            "calc_per_atom: False",
         ],
     )
 
@@ -109,6 +110,7 @@ def test_calc_per_element(tmp_path):
             "Starting descriptors calculation",
             "invariants_only: True",
             "calc_per_element: True",
+            "calc_per_atom: False",
         ],
     )
 
@@ -210,3 +212,14 @@ def test_per_atom(tmp_path):
     assert "mace_mp_descriptors" in atoms.arrays
     assert len(atoms.arrays["mace_mp_descriptors"]) == 8
     assert atoms.arrays["mace_mp_descriptors"][0] == pytest.approx(-0.00203750)
+
+    # Check only initial structure is minimized
+    assert_log_contains(
+        log_path,
+        includes=[
+            "Starting descriptors calculation",
+            "invariants_only: True",
+            "calc_per_element: False",
+            "calc_per_atom: True",
+        ],
+    )


### PR DESCRIPTION
Fixes repeated log messages for settings when calculating descriptors for trajectory, and minor update to testing the log.