### PR TITLE
Fix set_calc default when reading structure file

### DIFF
--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -369,10 +369,10 @@ def input_structs(
         if struct_path:
             set_calc = True
 
-        if isinstance(struct, Atoms):
+        elif isinstance(struct, Atoms):
             set_calc = struct.calc is None
 
-        if isinstance(struct, Sequence):
+        elif isinstance(struct, Sequence):
             set_calc = any(image.calc is None for image in struct)
 
     if set_calc:


### PR DESCRIPTION
Resolves #290

Fixes setting default for `set_calc` to be set to `True` if `struct_path` is specified.

This was supposed to be the case already, but was being overwritten by the structures read from file having `SinglePointCalculators `attached, due to their saved results, leading to errors.

Test added fails before fix implemented.