### PR TITLE
Add auto restart

### DIFF
--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -196,11 +196,17 @@ For example:
 
 .. code-block:: bash
 
-    janus md --ensemble nvt --struct tests/data/NaCl.cif --steps 1000 --stats-every 1 --restart-every 100
-    janus md --ensemble nvt --struct tests/data/NaCl.cif --steps 1000 --stats-every 1 --restart
+    janus md --ensemble nvt --struct tests/data/NaCl.cif --steps 1200 --stats-every 10 --traj-every 100 --restart-every 1000
+    janus md --ensemble nvt --struct tests/data/NaCl.cif --steps 1200 --stats-every 10 --traj-every 100 --restart
 
 will create, then restart from, ``NaCl-npt-T300.0-p1.0-res-1000.extxyz``,
 running an additional 1000 steps, and appending the statistics and trajectory files created by the first command.
+
+
+.. note::
+    Depending on the frequency of statistics, trajectory, and restart file outputs, it is likely that outputs for some steps may be repeated.
+    These can be identified using the ``Step`` column in the statistics file, and the ``step`` info label for each trajectory image.
+    For example, in the above example, outputs between steps 1000 and 1200 would be repeated.
 
 
 For all options, run ``janus md --help``.

--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -190,6 +190,18 @@ both before beginning dynamics and at steps 100 and 200 of the simulation.
 This performs an NVE molecular dynamics simulation at 300K for 200 steps (0.2 ps), saving the trajectory every 10 steps after the first 100, and the thermodynamical statistics every 10 steps,
 as well as changing the output file names for both.
 
+To restart a simulation, the restart file can be entered explicitly (e.g. ``--struct NaCl-npt-T300.0-p1.0-res-1000.extxyz``) in combination with the ``--restart`` option,
+but by default the ``--restart-auto`` option allows the same original structure to be used to infer the most recent restart file created.
+For example:
+
+.. code-block:: bash
+
+    janus md --ensemble nvt --struct tests/data/NaCl.cif --steps 1000 --stats-every 1 --restart-every 100
+    janus md --ensemble nvt --struct tests/data/NaCl.cif --steps 1000 --stats-every 1 --restart
+
+will create, then restart from, ``NaCl-npt-T300.0-p1.0-res-1000.extxyz``,
+running an additional 1000 steps, and appending the statistics and trajectory files created by the first command.
+
 
 For all options, run ``janus md --help``.
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -870,6 +870,11 @@ class MolecularDynamics(BaseCalculation):
                 self.dyn.nsteps > self.traj_start + self.traj_start % self.traj_every
             )
 
+            time = (self.offset * self.timestep + self.dyn.get_time()) / units.fs
+            step = self.offset + self.dyn.nsteps
+            self.dyn.atoms.info["time_fs"] = time
+            self.dyn.atoms.info["step"] = step
+
             write_kwargs = self.write_kwargs
             write_kwargs["filename"] = self.traj_file
             write_kwargs["append"] = append

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -536,7 +536,7 @@ class MolecularDynamics(BaseCalculation):
             # Use restart_stem.name otherwise T300.0 etc. counts as extension
             poss_restarts = restart_stem.parent.glob(f"{restart_stem.name}*.extxyz")
             try:
-                last_restart = sorted(poss_restarts, key=getmtime)[-1]
+                last_restart = max(poss_restarts, key=getmtime)
 
                 # Read in last structure
                 self.struct = input_structs(
@@ -556,9 +556,9 @@ class MolecularDynamics(BaseCalculation):
                 try:
                     # Remove restart_stem from filename
                     # Use restart_stem.name otherwise T300.0 etc. counts as extension
-                    self.offset = int("".join(last_stem.split(f"{restart_stem.name}-")))
+                    self.offset = int(last_stem.split("-")[-1])
 
-                    # Check "-"" not inlcuded in offset
+                    # Check "-" not inlcuded in offset
                     assert self.offset > 0
 
                 except (ValueError, AssertionError) as e:

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -524,8 +524,12 @@ class MolecularDynamics(BaseCalculation):
 
         if self.restart_auto:
             # Attempt to infer restart file
+            # param_prefix is added to prefix_override, so only use if no restart_stem
+            param_prefix = (
+                f"{self.param_prefix}-res" if self.restart_stem is None else ""
+            )
             restart_stem = self._build_filename(
-                "res", self.param_prefix, prefix_override=self.restart_stem
+                "", param_prefix, prefix_override=self.restart_stem
             )
             # Use restart_stem.name otherwise T300.0 etc. counts as extension
             poss_restarts = restart_stem.parent.glob(f"{restart_stem.name}*.extxyz")
@@ -549,9 +553,10 @@ class MolecularDynamics(BaseCalculation):
                 last_stem = last_restart.stem
                 try:
                     # Use restart_stem.name otherwise T300.0 etc. counts as extension
-                    self.offset = int("".join(last_stem.split(f"{restart_stem.name}-")))
+                    self.offset = int("".join(last_stem.split(f"{restart_stem.name}")))
 
                 except ValueError as e:
+                    print(restart_stem)
                     raise ValueError(
                         f"Unable to infer final dynamics step from {last_restart}"
                     ) from e
@@ -649,8 +654,10 @@ class MolecularDynamics(BaseCalculation):
            File name for restart files.
         """
         step = self.offset + self.dyn.nsteps
+        # param_prefix is added to prefix_override, so only use if no restart_stem
+        param_prefix = f"{self.param_prefix}-res" if self.restart_stem is None else ""
         return self._build_filename(
-            f"res-{step}.extxyz", self.param_prefix, prefix_override=self.restart_stem
+            f"{step}.extxyz", param_prefix, prefix_override=self.restart_stem
         )
 
     def _parse_correlations(self) -> None:

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -527,9 +527,10 @@ class MolecularDynamics(BaseCalculation):
             restart_stem = self._build_filename(
                 "res", self.param_prefix, prefix_override=self.restart_stem
             )
-            possible_restarts = restart_stem.parent.glob(f"{restart_stem.stem}*.extxyz")
+            # Use restart_stem.name otherwise T300.0 etc. counts as extension
+            poss_restarts = restart_stem.parent.glob(f"{restart_stem.name}*.extxyz")
             try:
-                last_restart = sorted(possible_restarts, key=getmtime)[-1]
+                last_restart = sorted(poss_restarts, key=getmtime)[-1]
 
                 # Read in last structure
                 self.struct = input_structs(
@@ -547,12 +548,13 @@ class MolecularDynamics(BaseCalculation):
                 # Infer last dynamics step
                 last_stem = last_restart.stem
                 try:
-                    last_offset = int("".join(last_stem.split(f"{restart_stem.stem}-")))
+                    # Use restart_stem.name otherwise T300.0 etc. counts as extension
+                    offset = int("".join(last_stem.split(f"{restart_stem.name}-")))
 
                     assert (
-                        last_offset >= self.offset
+                        offset >= self.offset
                     ), "Statistics file and restart file steps are inconsistent"
-                    self.offset = last_offset
+                    self.offset = offset
 
                 except ValueError as e:
                     raise ValueError(

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -549,12 +549,7 @@ class MolecularDynamics(BaseCalculation):
                 last_stem = last_restart.stem
                 try:
                     # Use restart_stem.name otherwise T300.0 etc. counts as extension
-                    offset = int("".join(last_stem.split(f"{restart_stem.name}-")))
-
-                    assert (
-                        offset >= self.offset
-                    ), "Statistics file and restart file steps are inconsistent"
-                    self.offset = offset
+                    self.offset = int("".join(last_stem.split(f"{restart_stem.name}-")))
 
                 except ValueError as e:
                     raise ValueError(

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -112,6 +112,9 @@ def md(
         ),
     ] = None,
     restart: Annotated[bool, Option(help="Whether restarting dynamics.")] = False,
+    restart_auto: Annotated[
+        bool, Option(help="Whether to infer restart file if restarting dynamics.")
+    ] = True,
     restart_stem: Annotated[
         Optional[Path],
         Option(help="Stem for restart file name. Default inferred from `file_prefix`."),
@@ -242,6 +245,8 @@ def md(
         and temperature.
     restart : bool
         Whether restarting dynamics. Default is False.
+    restart_auto : bool
+        Whether to infer restart file name if restarting dynamics. Default is True.
     restart_stem : str
         Stem for restart file name. Default inferred from `file_prefix`.
     restart_every : int
@@ -351,6 +356,7 @@ def md(
         "rescale_every": rescale_every,
         "file_prefix": file_prefix,
         "restart": restart,
+        "restart_auto": restart_auto,
         "restart_stem": restart_stem,
         "restart_every": restart_every,
         "rotate_restart": rotate_restart,

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -146,7 +146,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
             built_filename = Path(filename)
         else:
             prefix = (
-                prefix_override
+                str(prefix_override)
                 if prefix_override is not None
                 else str(self.file_prefix)
             )

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -145,10 +145,8 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
         if filename:
             built_filename = Path(filename)
         else:
-            prefix = (
-                str(prefix_override)
-                if prefix_override is not None
-                else str(self.file_prefix)
+            prefix = str(
+                prefix_override if prefix_override is not None else self.file_prefix
             )
             built_filename = Path("-".join((prefix, *filter(None, additional), suffix)))
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -887,7 +887,7 @@ def test_logging(tmp_path):
     assert single_point.struct.info["emissions"] > 0
 
 
-def test_auto_restart_no_prefix(tmp_path):
+def test_auto_restart(tmp_path):
     """Test auto restarting simulation."""
     # tmp_path for all files other than restart
     # Include T300.0 to test Path.stem vs Path.name
@@ -978,15 +978,16 @@ def test_auto_restart_no_prefix(tmp_path):
         restart_path.unlink(missing_ok=True)
 
 
-def test_auto_restart_file_prefix(tmp_path):
-    """Test auto restarting simulation with file prefix defined."""
+def test_auto_restart_restart_stem(tmp_path):
+    """Test auto restarting simulation with restart stem defined."""
     file_prefix = tmp_path / "npt"
     traj_path = tmp_path / "npt-traj.extxyz"
     stats_path = tmp_path / "npt-stats.dat"
     log_file = tmp_path / "md.log"
 
-    # Predicted restart file, from file_prefix
-    restart_path = tmp_path / "npt-res-4.extxyz"
+    # Set restart stem and predict restart file
+    restart_stem = tmp_path / "npt-test"
+    restart_path = tmp_path / "npt-test-4.extxyz"
 
     npt = NPT(
         struct_path=DATA_PATH / "NaCl.cif",
@@ -997,6 +998,7 @@ def test_auto_restart_file_prefix(tmp_path):
         stats_every=3,
         traj_every=1,
         file_prefix=file_prefix,
+        restart_stem=str(restart_stem),
         restart_every=4,
         timestep=10,
     )
@@ -1025,6 +1027,7 @@ def test_auto_restart_file_prefix(tmp_path):
         temp=300.0,
         steps=3,
         stats_every=1,
+        restart_stem=restart_stem,
         restart=True,
         restart_auto=True,
         file_prefix=file_prefix,

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -256,6 +256,7 @@ def test_restart(tmp_path):
         restart_every=4,
         stats_every=1,
         restart=True,
+        restart_auto=False,
         file_prefix=file_prefix,
     )
     nvt_restart.run()
@@ -270,7 +271,7 @@ def test_restart(tmp_path):
 
     traj = read(traj_path, index=":")
     assert all(isinstance(image, Atoms) for image in traj)
-    assert len(traj) == 10
+    assert len(traj) == 9
 
 
 def test_minimize(tmp_path):
@@ -490,10 +491,10 @@ def test_rescale_every(tmp_path):
 
 def test_rotate_restart(tmp_path):
     """Test setting rotate_restart."""
-    file_prefix = tmp_path / "Cl4Na4-nvt"
-    restart_path_1 = tmp_path / "Cl4Na4-nvt-T300.0-res-1.extxyz"
-    restart_path_2 = tmp_path / "Cl4Na4-nvt-T300.0-res-2.extxyz"
-    restart_path_3 = tmp_path / "Cl4Na4-nvt-T300.0-res-3.extxyz"
+    file_prefix = tmp_path / "NaCl-nvt"
+    restart_path_1 = tmp_path / "NaCl-nvt-res-1.extxyz"
+    restart_path_2 = tmp_path / "NaCl-nvt-res-2.extxyz"
+    restart_path_3 = tmp_path / "NaCl-nvt-res-3.extxyz"
     single_point = SinglePoint(
         struct_path=DATA_PATH / "NaCl.cif",
         arch="mace",
@@ -884,3 +885,173 @@ def test_logging(tmp_path):
     assert log_file.exists()
     assert "emissions" in single_point.struct.info
     assert single_point.struct.info["emissions"] > 0
+
+
+def test_auto_restart_no_prefix(tmp_path):
+    """Test auto restarting simulation."""
+    # tmp_path for all files other than restart
+    # Include T300.0 to test Path.stem vs Path.name
+    final_path = tmp_path / "md-T300.0-final.extxyz"
+    traj_path = tmp_path / "md-T300.0-traj.extxyz"
+    stats_path = tmp_path / "md-T300.0-stats.dat"
+    log_file = tmp_path / "md.log"
+
+    # Predicted restart file, from defaults
+    restart_path = Path(".").absolute() / "NaCl-nvt-T300.0-res-4.extxyz"
+    assert not restart_path.exists()
+
+    try:
+        nvt = NVT(
+            struct_path=DATA_PATH / "NaCl.cif",
+            arch="mace_mp",
+            calc_kwargs={"model": MODEL_PATH},
+            temp=300.0,
+            steps=4,
+            stats_file=stats_path,
+            stats_every=3,
+            traj_file=traj_path,
+            traj_every=1,
+            final_file=final_path,
+            restart_every=4,
+            timestep=100,
+        )
+        nvt.run()
+
+        assert nvt.dyn.nsteps == 4
+        assert stats_path.exists()
+        assert traj_path.exists()
+        assert restart_path.exists()
+
+        with open(stats_path, encoding="utf8") as stats_file:
+            lines = stats_file.readlines()
+        # Header and steps 0 & 3 only in stats
+        assert len(lines) == 3
+        assert int(lines[-1].split()[0]) == 3
+
+        restart_struct = read(restart_path)
+        traj_struct = read(traj_path, index=-1)
+
+        # Prepare with auto restart from step 4
+        nvt_restart = NVT(
+            struct_path=DATA_PATH / "NaCl.cif",
+            arch="mace_mp",
+            calc_kwargs={"model": MODEL_PATH},
+            temp=300.0,
+            steps=3,
+            stats_every=1,
+            restart=True,
+            restart_auto=True,
+            stats_file=stats_path,
+            traj_file=traj_path,
+            traj_every=1,
+            final_file=final_path,
+            log_kwargs={"filename": log_file},
+        )
+
+        assert_log_contains(log_file, includes="Auto restart successful")
+
+        # Check saved restart struct is same as last trajectory struct
+        assert restart_struct.positions == pytest.approx(traj_struct.positions)
+        # Check saved restart struct is starting structure for new sim
+        assert restart_struct.positions == pytest.approx(nvt_restart.struct.positions)
+        # Check starting structure for new sim is same as final structure of old sim
+        assert nvt.struct.positions == pytest.approx(
+            nvt_restart.struct.positions, rel=1e-6
+        )
+
+        # Offset from restart file, not stats
+        assert nvt_restart.offset == 4
+
+        nvt_restart.run()
+
+        # Check outputs are appended
+        with open(stats_path, encoding="utf8") as stats_file:
+            lines = stats_file.readlines()
+        # Header and steps 0 & 3, and 5, 6 and 7
+        assert len(lines) == 6
+        assert int(lines[-1].split()[0]) == 7
+
+        final_traj = read(traj_path, index=":")
+        assert len(final_traj) == 8
+
+    finally:
+        restart_path.unlink(missing_ok=True)
+
+
+def test_auto_restart_file_prefix(tmp_path):
+    """Test auto restarting simulation with file prefix defined."""
+    file_prefix = tmp_path / "npt"
+    traj_path = tmp_path / "npt-traj.extxyz"
+    stats_path = tmp_path / "npt-stats.dat"
+    log_file = tmp_path / "md.log"
+
+    # Predicted restart file, from file_prefix
+    restart_path = tmp_path / "npt-res-4.extxyz"
+
+    npt = NPT(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="mace_mp",
+        calc_kwargs={"model": MODEL_PATH},
+        temp=300.0,
+        steps=6,
+        stats_every=3,
+        traj_every=1,
+        file_prefix=file_prefix,
+        restart_every=4,
+        timestep=10,
+    )
+    npt.run()
+
+    assert npt.dyn.nsteps == 6
+    assert stats_path.exists()
+    assert traj_path.exists()
+    assert restart_path.exists()
+
+    with open(stats_path, encoding="utf8") as stats_file:
+        lines = stats_file.readlines()
+    # Header and steps 3, 6 only in stats
+    assert len(lines) == 3
+    assert int(lines[-1].split()[0]) == 6
+
+    restart_struct = read(restart_path)
+    # Initial structure not saved by npt, so 4th structure from traj
+    traj_struct = read(traj_path, index=3)
+
+    # Prepare with auto restart from step 4
+    npt_restart = NPT(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="mace_mp",
+        calc_kwargs={"model": MODEL_PATH},
+        temp=300.0,
+        steps=3,
+        stats_every=1,
+        restart=True,
+        restart_auto=True,
+        file_prefix=file_prefix,
+        traj_every=1,
+        log_kwargs={"filename": log_file},
+    )
+
+    assert_log_contains(log_file, includes="Auto restart successful")
+
+    # Check saved restart struct is same as last trajectory struct
+    assert restart_struct.positions == pytest.approx(traj_struct.positions)
+    # Check saved restart struct is starting structure for new sim
+    assert restart_struct.positions == pytest.approx(npt_restart.struct.positions)
+    # Check starting structure for new sim is different to final structure of old sim
+    assert npt.struct.positions != pytest.approx(npt_restart.struct.positions, rel=1e-6)
+
+    # Offset from restart file, not stats
+    assert npt_restart.offset == 4
+
+    npt_restart.run()
+
+    # Check outputs are appended
+    with open(stats_path, encoding="utf8") as stats_file:
+        lines = stats_file.readlines()
+    # Header and steps 0, 3, 6 and 5, 6 and 7
+    assert len(lines) == 6
+    assert int(lines[-1].split()[0]) == 7
+
+    final_traj = read(traj_path, index=":")
+    assert len(final_traj) == 9

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -695,6 +695,8 @@ def test_auto_restart(tmp_path):
 
     traj = read(traj_path, index=":")
     assert len(traj) == 5
+    for i, struct in enumerate(traj):
+        assert struct.info["step"] == i
 
     with open(stats_path, encoding="utf8") as stats_file:
         lines = stats_file.readlines()
@@ -731,6 +733,8 @@ def test_auto_restart(tmp_path):
 
     traj = read(traj_path, index=":")
     assert len(traj) == 8
+    for i, struct in enumerate(traj):
+        assert struct.info["step"] == i
 
     with open(stats_path, encoding="utf8") as stats_file:
         lines = stats_file.readlines()


### PR DESCRIPTION
Resolves #169

Adds auto restart option for MD, which generates `restart_stem` based on inputs (including `file_prefix` and `restart_stem`), and if restarting simulation, uses the most recent matching file for the input structure.

Also includes fixes for:

- `prefix_override`, which threw errors if given a `Path`s (e.g. anything via `--restart-stem`)
- How `restart_stem` was used, as currently for `restart_stem=stem`, files of the form `stem-T300.0-res-1.extxyz` are created, the same as the old usage of `struct_name`. With these changes, they should now be `stem-1.extxyz`

Note: the limit after restarting is the effectively the same as before - however far the previous simulation got + the full `steps` input (e.g. for `NaCl-nvt-T300.0-res-100.extxyz`, with `--steps 1000`, the last step would be 1100.)


One thing to consider is that this implementation can (and arguably is likely) to lead to duplicated steps for statistics and/or trajectory file.

E.g. if you were to print statistics every 100 steps, but restart every 1000 steps, then the statistics file may to be written for a while after the last restart file. When we restart, we then append duplicate steps.

Do we want to delete these duplicate steps? This is even harder for the trajectory, since we'd have to calculate which images would be duplicated.