### PR TITLE
Make directories when building filenames

### DIFF
--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -159,10 +159,10 @@ class Descriptors(BaseCalculation):
             raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file
-        self.write_kwargs.setdefault(
-            "filename",
-            self._build_filename("descriptors.extxyz").absolute(),
-        )
+        self.write_kwargs.setdefault("filename", None)
+        self.write_kwargs["filename"] = self._build_filename(
+            "descriptors.extxyz", filename=self.write_kwargs["filename"]
+        ).absolute()
 
     def run(self) -> None:
         """Calculate descriptors for structure(s)."""

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -231,10 +231,10 @@ class EoS(BaseCalculation):
             raise ValueError("Please attach a calculator to `struct`.")
 
         # Set output file
-        self.write_kwargs.setdefault(
-            "filename",
-            self._build_filename("generated.extxyz").absolute(),
-        )
+        self.write_kwargs.setdefault("filename", None)
+        self.write_kwargs["filename"] = self._build_filename(
+            "generated.extxyz", filename=self.write_kwargs["filename"]
+        ).absolute()
 
         self.results = {}
         self.volumes = []

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -217,10 +217,11 @@ class GeomOpt(BaseCalculation):
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
 
-        self.write_kwargs.setdefault(
-            "filename",
-            self._build_filename("opt.extxyz").absolute(),
-        )
+        # Set output file
+        self.write_kwargs.setdefault("filename", None)
+        self.write_kwargs["filename"] = self._build_filename(
+            "opt.extxyz", filename=self.write_kwargs["filename"]
+        ).absolute()
 
         # Configure optimizer dynamics
         self.set_optimizer()

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -457,7 +457,12 @@ class MolecularDynamics(BaseCalculation):
         opt_file = self._build_filename("opt.extxyz", self.param_prefix, filename=None)
 
         if "write_kwargs" in self.minimize_kwargs:
-            self.minimize_kwargs["write_kwargs"].setdefault("filename", opt_file)
+            # Use _build_filename even if given filename to ensure directory exists
+            self.minimize_kwargs["write_kwargs"].setdefault("filename", None)
+            self.minimize_kwargs["write_kwargs"]["filename"] = self._build_filename(
+                "", filename=self.minimize_kwargs["write_kwargs"]["filename"]
+            ).absolute()
+
             # Assume if write_kwargs are specified that results should be written
             self.minimize_kwargs.setdefault("write_results", True)
         else:

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -261,10 +261,16 @@ class Phonons(BaseCalculation):
                     "filemode": "a",
                 }
             # If not specified otherwise, save optimized structure consistently with
-            # phonon output files
+            # other phonon output files
             opt_file = self._build_filename("opt.extxyz")
+
             if "write_kwargs" in self.minimize_kwargs:
-                self.minimize_kwargs["write_kwargs"].setdefault("filename", opt_file)
+                # Use _build_filename even if given filename to ensure directory exists
+                self.minimize_kwargs["write_kwargs"].setdefault("filename", None)
+                self.minimize_kwargs["write_kwargs"]["filename"] = self._build_filename(
+                    "", filename=self.minimize_kwargs["write_kwargs"]["filename"]
+                ).absolute()
+
                 # Assume if write_kwargs are specified that results should be written
                 self.minimize_kwargs.setdefault("write_results", True)
             else:

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -152,10 +152,10 @@ class SinglePoint(BaseCalculation):
         )
 
         # Set output file
-        self.write_kwargs.setdefault(
-            "filename",
-            self._build_filename("results.extxyz").absolute(),
-        )
+        self.write_kwargs.setdefault("filename", None)
+        self.write_kwargs["filename"] = self._build_filename(
+            "results.extxyz", filename=self.write_kwargs["filename"]
+        ).absolute()
 
         self.results = {}
 

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -143,11 +143,18 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
             Filename specified, or default filename.
         """
         if filename:
-            return Path(filename)
-        prefix = (
-            prefix_override if prefix_override is not None else str(self.file_prefix)
-        )
-        return Path("-".join((prefix, *filter(None, additional), suffix)))
+            built_filename = Path(filename)
+        else:
+            prefix = (
+                prefix_override
+                if prefix_override is not None
+                else str(self.file_prefix)
+            )
+            built_filename = Path("-".join((prefix, *filter(None, additional), suffix)))
+
+        # Make directory if it does not exist
+        built_filename.parent.mkdir(parents=True, exist_ok=True)
+        return built_filename
 
 
 def spacegroup(

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -78,9 +78,10 @@ def test_descriptors(tmp_path):
 
 def test_calc_per_element(tmp_path):
     """Test calculating MLIP descriptors for each element."""
+    out_path = tmp_path / "test" / "NaCl-descriptors.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    out_path = tmp_path / "NaCl-descriptors.extxyz"
+
     result = runner.invoke(
         app,
         [

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -187,10 +187,10 @@ def test_minimising_all(tmp_path):
 
 def test_writing_structs(tmp_path):
     """Test writing out generated structures."""
+    file_prefix = tmp_path / "test" / "example"
+    generated_path = tmp_path / "test" / "example-generated.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    file_prefix = tmp_path / "example"
-    generated_path = tmp_path / "example-generated.extxyz"
 
     result = runner.invoke(
         app,

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -579,8 +579,8 @@ def test_invalid_traj_input(tmp_path):
 
 def test_reuse_output(tmp_path):
     """Test using geomopt output as new input."""
-    results_path_1 = tmp_path / "NaCl-opt-1.extxyz"
-    results_path_2 = tmp_path / "NaCl-opt-2.extxyz"
+    results_path_1 = tmp_path / "test" / "NaCl-opt-1.extxyz"
+    results_path_2 = tmp_path / "test" / "NaCl-opt-2.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -393,11 +393,11 @@ def test_invalid_config():
 def test_ensemble_kwargs(tmp_path):
     """Test passing ensemble-kwargs to NPT."""
     struct_path = DATA_PATH / "NaCl.cif"
-    file_prefix = tmp_path / "md"
-    log_path = tmp_path / "md.log"
+    file_prefix = tmp_path / "test" / "md"
+    final_path = tmp_path / "test" / "md-final.extxyz"
+    stats_path = tmp_path / "test" / "md-stats.dat"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    final_path = tmp_path / "md-final.extxyz"
-    stats_path = tmp_path / "md-stats.dat"
 
     ensemble_kwargs = "{'mask' : (0, 1, 0)}"
 
@@ -444,7 +444,7 @@ def test_ensemble_kwargs(tmp_path):
 def test_invalid_ensemble_kwargs(tmp_path):
     """Test passing invalid key to ensemble-kwargs."""
     file_prefix = tmp_path / "npt-T300"
-    log_path = tmp_path / "md.log"
+    log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
     # Not an option for NVT
@@ -519,10 +519,11 @@ def test_write_kwargs(tmp_path):
     """Test passing write-kwargs."""
     struct_path = DATA_PATH / "NaCl.cif"
     file_prefix = tmp_path / "md"
-    log_path = tmp_path / "md.log"
-    summary_path = tmp_path / "summary.yml"
     final_path = tmp_path / "md-final.extxyz"
     traj_path = tmp_path / "md-traj.extxyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+
     write_kwargs = (
         "{'invalidate_calc': False, 'columns': ['symbols', 'positions', 'masses']}"
     )
@@ -634,11 +635,11 @@ def test_invalid_traj_input(tmp_path):
 
 def test_minimize_kwargs_filename(tmp_path):
     """Test passing filename via minimize kwargs to MD."""
-    file_prefix = tmp_path / "md"
-    opt_path = tmp_path / "test.extxyz"
-    traj_path = tmp_path / "md-traj.extxyz"
-    stats_path = tmp_path / "md-stats.dat"
-    final_path = tmp_path / "md-final.extxyz"
+    file_prefix = tmp_path / "test" / "md"
+    opt_path = tmp_path / "test" / "test.extxyz"
+    traj_path = tmp_path / "test" / "md-traj.extxyz"
+    stats_path = tmp_path / "test" / "md-stats.dat"
+    final_path = tmp_path / "test" / "md-final.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 
@@ -680,11 +681,11 @@ def test_minimize_kwargs_filename(tmp_path):
 
 def test_minimize_kwargs_write_results(tmp_path):
     """Test passing write_results via minimize kwargs to MD."""
-    file_prefix = tmp_path / "md"
-    opt_path = tmp_path / "md-opt.extxyz"
-    traj_path = tmp_path / "md-traj.extxyz"
-    stats_path = tmp_path / "md-stats.dat"
-    final_path = tmp_path / "md-final.extxyz"
+    file_prefix = tmp_path / "test" / "md"
+    opt_path = tmp_path / "test" / "md-opt.extxyz"
+    traj_path = tmp_path / "test" / "md-traj.extxyz"
+    stats_path = tmp_path / "test" / "md-stats.dat"
+    final_path = tmp_path / "test" / "md-final.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -102,11 +102,13 @@ def test_bands_simple(tmp_path):
 
 
 def test_hdf5(tmp_path):
-    """Test calculating phonons."""
+    """Test saving force constants to HDF5 in new directory."""
+    file_prefix = tmp_path / "test" / "NaCl"
+    phonon_results = tmp_path / "test" / "NaCl-phonopy.yml"
+    hdf5_results = tmp_path / "test" / "NaCl-force_constants.hdf5"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    phonon_results = tmp_path / "NaCl-phonopy.yml"
-    hdf5_results = tmp_path / "NaCl-force_constants.hdf5"
+
     result = runner.invoke(
         app,
         [
@@ -114,7 +116,7 @@ def test_hdf5(tmp_path):
             "--struct",
             DATA_PATH / "NaCl.cif",
             "--file-prefix",
-            tmp_path / "NaCl",
+            file_prefix,
             "--hdf5",
             "--log",
             log_path,
@@ -129,9 +131,11 @@ def test_hdf5(tmp_path):
 
 def test_thermal_props(tmp_path):
     """Test calculating thermal properties."""
+    file_prefix = tmp_path / "test" / "NaCl"
+    thermal_results = tmp_path / "test" / "NaCl-thermal.dat"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    thermal_results = tmp_path / "NaCl-thermal.dat"
+
     result = runner.invoke(
         app,
         [
@@ -140,7 +144,7 @@ def test_thermal_props(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--thermal",
             "--file-prefix",
-            tmp_path / "NaCl",
+            file_prefix,
             "--log",
             log_path,
             "--summary",
@@ -153,9 +157,10 @@ def test_thermal_props(tmp_path):
 
 def test_dos(tmp_path):
     """Test calculating the DOS."""
+    file_prefix = tmp_path / "test" / "NaCl"
+    dos_results = tmp_path / "test" / "NaCl-dos.dat"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    dos_results = tmp_path / "NaCl-dos.dat"
     result = runner.invoke(
         app,
         [
@@ -164,7 +169,7 @@ def test_dos(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--dos",
             "--file-prefix",
-            tmp_path / "NaCl",
+            file_prefix,
             "--log",
             log_path,
             "--summary",
@@ -177,9 +182,11 @@ def test_dos(tmp_path):
 
 def test_pdos(tmp_path):
     """Test calculating the PDOS."""
+    file_prefix = tmp_path / "test" / "NaCl"
+    pdos_results = tmp_path / "test" / "NaCl-pdos.dat"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    pdos_results = tmp_path / "NaCl-pdos.dat"
+
     result = runner.invoke(
         app,
         [
@@ -188,7 +195,7 @@ def test_pdos(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--pdos",
             "--file-prefix",
-            tmp_path / "NaCl",
+            file_prefix,
             "--log",
             log_path,
             "--summary",
@@ -349,10 +356,10 @@ def test_minimize_kwargs(tmp_path):
 
 def test_minimize_filename(tmp_path):
     """Test minimize filename overwrites default."""
+    file_prefix = tmp_path / "test" / "test"
+    opt_path = tmp_path / "test" / "geomopt-opt.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
-    file_prefix = tmp_path / "test"
-    opt_path = tmp_path / "geomopt-opt.extxyz"
 
     # write_results should be set automatically
     minimize_kwargs = f"{{'write_kwargs': {{'filename': '{str(opt_path)}'}}}}"

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -49,9 +49,9 @@ def test_singlepoint(tmp_path):
 
 
 def test_properties(tmp_path):
-    """Test properties for singlepoint calculation."""
-    results_path_1 = tmp_path / "H2O-energy-results.extxyz"
-    results_path_2 = tmp_path / "H2O-stress-results.extxyz"
+    """Test properties for singlepoint calculation in a new directory."""
+    results_path_1 = tmp_path / "test" / "H2O-energy-results.extxyz"
+    results_path_2 = tmp_path / "test" / "H2O-stress-results.extxyz"
     log_path = tmp_path / "test.log"
     summary_path = tmp_path / "summary.yml"
 


### PR DESCRIPTION
Resolves #269

Anything that uses `build_filename` should now automatically create the parent directory if it does not already exist.

This also extends to filenames given through `write_kwargs` etc., since these did not previously use the `FileNameMixin`.