### PR TITLE
Update typer and Optional CLI parameters

### DIFF
--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -1,7 +1,7 @@
 """Set up MLIP descriptors commandline interface."""
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional
 
 from typer import Context, Option, Typer
 from typer_config import use_config
@@ -53,7 +53,7 @@ def descriptors(
     device: Device = "cpu",
     model_path: ModelPath = None,
     out: Annotated[
-        Path,
+        Optional[Path],
         Option(
             help=(
                 "Path to save structure with calculated descriptors. Default is "
@@ -101,10 +101,10 @@ def descriptors(
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log : Optional[Path]
         Path to write logs to. Default is inferred from the name of the structure file.
-    summary : Path
+    summary : Optional[Path]
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Path
+    config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
     # Check options from configuration file are all valid

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -129,10 +129,10 @@ def eos(
         chemical formula.
     log : Optional[Path]
         Path to write logs to. Default is inferred from the name of the structure file.
-    summary : Path
+    summary : Optional[Path]
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Path
+    config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
     # Check options from configuration file are all valid

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -96,7 +96,7 @@ def geomopt(
     ctx: Context,
     struct: StructPath,
     optimizer: Annotated[
-        str,
+        Optional[str],
         Option(help="Name of ASE optimizer function to use."),
     ] = "LBFGS",
     fmax: Annotated[
@@ -117,7 +117,7 @@ def geomopt(
         ),
     ] = False,
     filter_func: Annotated[
-        str,
+        Optional[str],
         Option(
             help=(
                 "Name of ASE filter/constraint function to use. If using "
@@ -130,7 +130,7 @@ def geomopt(
         float, Option(help="Scalar pressure when optimizing cell geometry, in GPa.")
     ] = 0.0,
     out: Annotated[
-        Path,
+        Optional[Path],
         Option(
             help=(
                 "Path to save optimized structure. Default is inferred from name "
@@ -140,7 +140,7 @@ def geomopt(
     ] = None,
     traj: Annotated[
         str,
-        Option(help="Path if saving optimization frames.  [default: None]"),
+        Option(help="Path if saving optimization frames."),
     ] = None,
     read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
@@ -202,10 +202,10 @@ def geomopt(
         Default is {}.
     log : Optional[Path]
         Path to write logs to. Default is inferred from the name of the structure file.
-    summary : Path
+    summary : Optional[Path]
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Path
+    config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
     # Check options from configuration file are all valid

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -126,7 +126,7 @@ def md(
         int, Option(help="Restart files to keep if rotating.")
     ] = 4,
     final_file: Annotated[
-        Path,
+        Optional[Path],
         Option(
             help=(
                 """
@@ -137,7 +137,7 @@ def md(
         ),
     ] = None,
     stats_file: Annotated[
-        Path,
+        Optional[Path],
         Option(
             help=(
                 """
@@ -149,7 +149,7 @@ def md(
     ] = None,
     stats_every: Annotated[int, Option(help="Frequency to output statistics.")] = 100,
     traj_file: Annotated[
-        Path,
+        Optional[Path],
         Option(help="File to save trajectory. Default inferred from `file_prefix`."),
     ] = None,
     traj_append: Annotated[bool, Option(help="Whether to append trajectory.")] = False,
@@ -159,17 +159,17 @@ def md(
     ] = 100,
     temp_start: Annotated[
         Optional[float],
-        Option(help="Temperature to start heating, in K.  [default: None]"),
+        Option(help="Temperature to start heating, in K."),
     ] = None,
     temp_end: Annotated[
         Optional[float],
-        Option(help="Maximum temperature for heating, in K.  [default: None]"),
+        Option(help="Maximum temperature for heating, in K."),
     ] = None,
     temp_step: Annotated[
-        float, Option(help="Size of temperature steps when heating, in K.")
+        Optional[float], Option(help="Size of temperature steps when heating, in K.")
     ] = None,
     temp_time: Annotated[
-        float, Option(help="Time between heating steps, in fs.")
+        Optional[float], Option(help="Time between heating steps, in fs.")
     ] = None,
     write_kwargs: WriteKwargs = None,
     post_process_kwargs: PostProcessKwargs = None,
@@ -287,10 +287,10 @@ def md(
         Default is None.
     log : Optional[Path]
         Path to write logs to. Default is inferred from the name of the structure file.
-    summary : Path
+    summary : Optional[Path]
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Path
+    config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
     # Check options from configuration file are all valid

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -188,10 +188,10 @@ def phonons(
         chemical formula.
     log : Optional[Path]
         Path to write logs to. Default is inferred from the name of the structure file.
-    summary : Path
+    summary : Optional[Path]
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Path
+    config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
     # Check options from configuration file are all valid

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -1,7 +1,7 @@
 """Set up singlepoint commandline interface."""
 
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Optional
 
 from typer import Context, Option, Typer
 from typer_config import use_config
@@ -41,7 +41,7 @@ def singlepoint(
     device: Device = "cpu",
     model_path: ModelPath = None,
     properties: Annotated[
-        list[str],
+        Optional[list[str]],
         Option(
             help=(
                 "Properties to calculate. If not specified, 'energy', 'forces' "
@@ -50,7 +50,7 @@ def singlepoint(
         ),
     ] = None,
     out: Annotated[
-        Path,
+        Optional[Path],
         Option(
             help=(
                 "Path to save structure with calculated results. Default is inferred "
@@ -94,10 +94,10 @@ def singlepoint(
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log : Optional[Path]
         Path to write logs to. Default is inferred from the name of the structure file.
-    summary : Path
+    summary : Optional[Path]
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Path
+    config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
     # Check options from configuration file are all valid

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -41,7 +41,7 @@ def train(
         Whether to fine-tune a foundational model. Default is False.
     log : Optional[Path]
         Path to write logs to. Default is Path("train-log.yml").
-    summary : Path
+    summary : Optional[Path]
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is Path("train-summary.yml").
     """

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -2,7 +2,7 @@
 
 import ast
 from pathlib import Path
-from typing import Annotated, Union
+from typing import Annotated, Optional, Union
 
 from typer import Option
 
@@ -63,18 +63,21 @@ class TyperDict:
 
 StructPath = Annotated[Path, Option(help="Path of structure to simulate.")]
 
-Architecture = Annotated[str, Option(help="MLIP architecture to use for calculations.")]
-Device = Annotated[str, Option(help="Device to run calculations on.")]
-ModelPath = Annotated[str, Option(help="Path to MLIP model.  [default: None]")]
+Architecture = Annotated[
+    Optional[str], Option(help="MLIP architecture to use for calculations.")
+]
+Device = Annotated[Optional[str], Option(help="Device to run calculations on.")]
+ModelPath = Annotated[Optional[str], Option(help="Path to MLIP model.")]
 
 ReadKwargsAll = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
             """
             Keyword arguments to pass to ase.io.read. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}".  [default: "{'index': ':'}"]
+            wrapped in quotes, e.g. "{'key' : value}". By default,
+            read_kwargs['index'] = ':', so all structures are read.
             """
         ),
         metavar="DICT",
@@ -82,13 +85,14 @@ ReadKwargsAll = Annotated[
 ]
 
 ReadKwargsLast = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
             """
             Keyword arguments to pass to ase.io.read. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}".  [default: "{'index': -1}"]
+            wrapped in quotes, e.g. "{'key' : value}". By default,
+            read_kwargs['index'] = -1, so only the last structure is read.
             """
         ),
         metavar="DICT",
@@ -96,7 +100,7 @@ ReadKwargsLast = Annotated[
 ]
 
 CalcKwargs = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
@@ -111,14 +115,13 @@ CalcKwargs = Annotated[
 ]
 
 WriteKwargs = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
             """
             Keyword arguments to pass to ase.io.write when saving results. Must be
             passed as a dictionary wrapped in quotes, e.g. "{'key' : value}".
-             [default: "{}"]
             """
         ),
         metavar="DICT",
@@ -126,13 +129,13 @@ WriteKwargs = Annotated[
 ]
 
 OptKwargs = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
             """
             Keyword arguments to pass to optimizer. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}".  [default: "{}"]
+            wrapped in quotes, e.g. "{'key' : value}".
             """
         ),
         metavar="DICT",
@@ -140,7 +143,7 @@ OptKwargs = Annotated[
 ]
 
 MinimizeKwargs = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
@@ -154,7 +157,7 @@ MinimizeKwargs = Annotated[
 ]
 
 EnsembleKwargs = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
@@ -168,7 +171,7 @@ EnsembleKwargs = Annotated[
 ]
 
 PostProcessKwargs = Annotated[
-    TyperDict,
+    Optional[TyperDict],
     Option(
         parser=parse_dict_class,
         help=(
@@ -182,7 +185,7 @@ PostProcessKwargs = Annotated[
 ]
 
 LogPath = Annotated[
-    Path,
+    Optional[Path],
     Option(
         help=(
             "Path to save logs to. Default is inferred from the name of the structure "
@@ -192,7 +195,7 @@ LogPath = Annotated[
 ]
 
 Summary = Annotated[
-    Path,
+    Optional[Path],
     Option(
         help=(
             "Path to save summary of inputs, start/end time, and carbon emissions. "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ seekpath = "^1.9.7"
 spglib = "^2.3.0"
 torch = ">= 2.1, <= 2.2" # Range required for dgl
 torch-dftd = "0.4.0"
-typer = "^0.9.0"
+typer = "^0.12.5"
 typer-config = "^1.4.0"
 
 alignn = { version = "2024.5.27", optional = true }


### PR DESCRIPTION
I'd hoped that this could include all forms of `Union`, but as of [typer 0.12.2](https://github.com/fastapi/typer/releases/tag/0.12.2), `Union[x | None] `/ `Optional` typing should be fully supported.

I think we were actually making use of this to some extent already, which could lead to errors, so this bumps the minimum version of typer to ensure it is supported, included fixes in subsequent minor releases, as well as adding `Optional` everywhere that was missing.