### PR TITLE
Tidy code

### DIFF
--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -84,6 +84,40 @@ prints the following:
       --help               Show this message and exit.
 
 
+Using configuration files
+-------------------------
+
+Default values for all command line options may be specifed through a Yaml 1.1 formatted configuration file by adding the ``--config`` option.
+If an option is present in both the command line and configuration file, the command line value takes precedence.
+
+For example, with the following configuration file and command:
+
+.. code-block:: yaml
+
+    struct: "NaCl.cif"
+    properties:
+    - "energy"
+    out: "NaCl-results.extxyz"
+    arch: mace_mp
+    model-path: medium
+    calc-kwargs:
+      dispersion: True
+
+
+.. code-block:: bash
+
+    janus singlepoint --struct KCl.cif --out KCl-results.cif --config config.yml
+
+
+This will run a singlepoint energy calculation on ``KCl.cif`` using the `MACE-MP <https://github.com/ACEsuit/mace-mp>`_ "medium" force-field, saving the results to ``KCl-results.cif``.
+
+
+.. note::
+    ``properties`` must be passed as a Yaml list, as above, not as a string.
+
+Example configurations for all commands can be found in `janus-tutorials <https://github.com/stfc/janus-tutorials/tree/main/configs>`_
+
+
 Single point calculations
 -------------------------
 
@@ -288,40 +322,6 @@ This will create additional output files: ``NaCl-thermal.dat`` for the thermal p
 between 0K and 300K, ``NaCl-dos.dat`` for the DOS, and ``NaCl-pdos.dat`` for the PDOS.
 
 For all options, run ``janus phonons --help``.
-
-
-Using configuration files
--------------------------
-
-Default values for all command line options may be specifed through a Yaml 1.1 formatted configuration file by adding the ``--config`` option.
-If an option is present in both the command line and configuration file, the command line value takes precedence.
-
-For example, with the following configuration file and command:
-
-.. code-block:: yaml
-
-    struct: "NaCl.cif"
-    properties:
-    - "energy"
-    out: "NaCl-results.extxyz"
-    arch: mace_mp
-    model-path: medium
-    calc-kwargs:
-      dispersion: True
-
-
-.. code-block:: bash
-
-    janus singlepoint --struct KCl.cif --out KCl-results.cif --config config.yml
-
-
-This will run a singlepoint energy calculation on ``KCl.cif`` using the `MACE-MP <https://github.com/ACEsuit/mace-mp>`_ "medium" force-field, saving the results to ``KCl-results.cif``.
-
-
-.. note::
-    ``properties`` must be passed as a Yaml list, as above, not as a string.
-
-Example configurations for all commands can be found in `janus-tutorials <https://github.com/stfc/janus-tutorials/tree/main/configs>`_
 
 
 Training and fine-tuning MLIPs

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -60,31 +60,31 @@ class Phonons(BaseCalculation):
         Size of supercell for calculation. Default is 2.
     displacement : float
         Displacement for force constants calculation, in A. Default is 0.01.
-    t_step : float
-        Temperature step for thermal properties calculations, in K. Default is 50.0.
-    t_min : float
-        Start temperature for thermal properties calculations, in K. Default is 0.0.
-    t_max : float
-        End temperature for thermal properties calculations, in K. Default is 1000.0.
+    symmetrize : bool
+        Whether to symmetrize force constants after calculation.
+        Default is False.
     minimize : bool
         Whether to perform geometry optimisation before calculating phonons.
         Default is False.
+    minimize_kwargs : Optional[dict[str, Any]]
+        Keyword arguments to pass to geometry optimizer. Default is {}.
+    temp_min : float
+        Start temperature for thermal properties calculations, in K. Default is 0.0.
+    temp_max : float
+        End temperature for thermal properties calculations, in K. Default is 1000.0.
+    temp_step : float
+        Temperature step for thermal properties calculations, in K. Default is 50.0.
     force_consts_to_hdf5 : bool
         Whether to write force constants in hdf format or not.
         Default is True.
     plot_to_file : bool
         Whether to plot various graphs as band stuctures, dos/pdos in svg.
         Default is False.
-    symmetrize : bool
-        Whether to symmetrize force constants after calculation.
-        Default is False.
     write_results : bool
         Default for whether to write out results to file. Default is True.
     write_full : bool
         Whether to maximize information written in various output files.
         Default is True.
-    minimize_kwargs : Optional[dict[str, Any]]
-        Keyword arguments to pass to geometry optimizer. Default is {}.
     file_prefix : Optional[PathLike]
         Prefix for output filenames. Default is inferred from chemical formula of the
         structure.
@@ -138,16 +138,16 @@ class Phonons(BaseCalculation):
         calcs: MaybeSequence[PhononCalcs] = (),
         supercell: MaybeList[int] = 2,
         displacement: float = 0.01,
-        t_step: float = 50.0,
-        t_min: float = 0.0,
-        t_max: float = 1000.0,
+        symmetrize: bool = False,
         minimize: bool = False,
+        minimize_kwargs: Optional[dict[str, Any]] = None,
+        temp_min: float = 0.0,
+        temp_max: float = 1000.0,
+        temp_step: float = 50.0,
         force_consts_to_hdf5: bool = True,
         plot_to_file: bool = False,
-        symmetrize: bool = False,
         write_results: bool = True,
         write_full: bool = True,
-        minimize_kwargs: Optional[dict[str, Any]] = None,
         file_prefix: Optional[PathLike] = None,
     ) -> None:
         """
@@ -186,31 +186,31 @@ class Phonons(BaseCalculation):
             Size of supercell for calculation. Default is 2.
         displacement : float
             Displacement for force constants calculation, in A. Default is 0.01.
-        t_step : float
-            Temperature step for thermal calculations, in K. Default is 50.0.
-        t_min : float
-            Start temperature for thermal calculations, in K. Default is 0.0.
-        t_max : float
-            End temperature for thermal calculations, in K. Default is 1000.0.
+        symmetrize : bool
+            Whether to symmetrize force constants after calculations.
+            Default is False.
         minimize : bool
             Whether to perform geometry optimisation before calculating phonons.
             Default is False.
+        minimize_kwargs : Optional[dict[str, Any]]
+            Keyword arguments to pass to geometry optimizer. Default is {}.
+        temp_min : float
+            Start temperature for thermal calculations, in K. Default is 0.0.
+        temp_max : float
+            End temperature for thermal calculations, in K. Default is 1000.0.
+        temp_step : float
+            Temperature step for thermal calculations, in K. Default is 50.0.
         force_consts_to_hdf5 : bool
             Whether to write force constants in hdf format or not.
             Default is True.
         plot_to_file : bool
             Whether to plot various graphs as band stuctures, dos/pdos in svg.
             Default is False.
-        symmetrize : bool
-            Whether to symmetrize force constants after calculations.
-            Default is False.
         write_results : bool
             Default for whether to write out results to file. Default is True.
         write_full : bool
             Whether to maximize information written in various output files.
             Default is True.
-        minimize_kwargs : Optional[dict[str, Any]]
-            Keyword arguments to pass to geometry optimizer. Default is {}.
         file_prefix : Optional[PathLike]
             Prefix for output filenames. Default is inferred from structure name, or
             chemical formula of the structure.
@@ -219,16 +219,16 @@ class Phonons(BaseCalculation):
 
         self.calcs = calcs
         self.displacement = displacement
-        self.t_step = t_step
-        self.t_min = t_min
-        self.t_max = t_max
+        self.symmetrize = symmetrize
         self.minimize = minimize
+        self.minimize_kwargs = minimize_kwargs
+        self.temp_min = temp_min
+        self.temp_max = temp_max
+        self.temp_step = temp_step
         self.force_consts_to_hdf5 = force_consts_to_hdf5
         self.plot_to_file = plot_to_file
-        self.symmetrize = symmetrize
         self.write_results = write_results
         self.write_full = write_full
-        self.minimize_kwargs = minimize_kwargs
 
         # Ensure supercell is a valid list
         self.supercell = [supercell] * 3 if isinstance(supercell, int) else supercell
@@ -517,7 +517,7 @@ class Phonons(BaseCalculation):
 
         self.results["phonon"].run_mesh()
         self.results["phonon"].run_thermal_properties(
-            t_step=self.t_step, t_max=self.t_max, t_min=self.t_min
+            t_step=self.temp_step, t_max=self.temp_max, t_min=self.temp_min
         )
         self.results["thermal_properties"] = self.results[
             "phonon"

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -46,33 +46,9 @@ def phonons(
         float,
         Option(help="Displacement for force constants calculation, in A."),
     ] = 0.01,
-    thermal: Annotated[
-        bool,
-        Option(help="Whether to calculate thermal properties."),
-    ] = False,
-    temp_start: Annotated[
-        float,
-        Option(help="Start temperature for thermal properties calculations, in K."),
-    ] = 0.0,
-    temp_end: Annotated[
-        float,
-        Option(help="End temperature for thermal properties calculations, in K."),
-    ] = 1000.0,
-    temp_step: Annotated[
-        float,
-        Option(help="Temperature step for thermal properties calculations, in K."),
-    ] = 50,
     bands: Annotated[
         bool,
         Option(help="Whether to compute band structure."),
-    ] = False,
-    hdf5: Annotated[
-        bool,
-        Option(help="Whether to save force constants in hdf5."),
-    ] = True,
-    plot_to_file: Annotated[
-        bool,
-        Option(help="Whether to plot band structure and/or dos/pdos when calculated."),
     ] = False,
     dos: Annotated[
         bool,
@@ -84,14 +60,42 @@ def phonons(
             help="Whether to calculate the PDOS.",
         ),
     ] = False,
+    thermal: Annotated[
+        bool,
+        Option(help="Whether to calculate thermal properties."),
+    ] = False,
+    temp_min: Annotated[
+        float,
+        Option(help="Start temperature for thermal properties calculations, in K."),
+    ] = 0.0,
+    temp_max: Annotated[
+        float,
+        Option(help="End temperature for thermal properties calculations, in K."),
+    ] = 1000.0,
+    temp_step: Annotated[
+        float,
+        Option(help="Temperature step for thermal properties calculations, in K."),
+    ] = 50,
+    symmetrize: Annotated[
+        bool, Option(help="Whether to symmetrize force constants.")
+    ] = False,
     minimize: Annotated[
         bool,
         Option(
             help="Whether to minimize structure before calculations.",
         ),
     ] = False,
-    symmetrize: Annotated[
-        bool, Option(help="Whether to symmetrize force constants.")
+    fmax: Annotated[
+        float, Option(help="Maximum force for optimization convergence.")
+    ] = 0.1,
+    minimize_kwargs: MinimizeKwargs = None,
+    hdf5: Annotated[
+        bool,
+        Option(help="Whether to save force constants in hdf5."),
+    ] = True,
+    plot_to_file: Annotated[
+        bool,
+        Option(help="Whether to plot band structure and/or dos/pdos when calculated."),
     ] = False,
     write_full: Annotated[
         bool,
@@ -101,10 +105,6 @@ def phonons(
             ),
         ),
     ] = True,
-    fmax: Annotated[
-        float, Option(help="Maximum force for optimization convergence.")
-    ] = 0.1,
-    minimize_kwargs: MinimizeKwargs = None,
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     model_path: ModelPath = None,
@@ -138,39 +138,39 @@ def phonons(
         2x2x2.
     displacement : float
         Displacement for force constants calculation, in A. Default is 0.01.
+    bands : bool
+        Whether to calculate and save the band structure. Default is False.
+    dos : bool
+        Whether to calculate and save the DOS. Default is False.
+    pdos : bool
+        Whether to calculate and save the PDOS. Default is False.
     thermal : bool
         Whether to calculate thermal properties. Default is False.
-    temp_start : float
+    temp_min : float
         Start temperature for thermal calculations, in K. Unused if `thermal` is False.
         Default is 0.0.
-    temp_end : float
+    temp_max : float
         End temperature for thermal calculations, in K. Unused if `thermal` is False.
         Default is 1000.0.
     temp_step : float
         Temperature step for thermal calculations, in K. Unused if `thermal` is False.
         Default is 50.0.
-    bands : bool
-        Whether to calculate and save the band structure. Default is False.
-    hdf5 : bool
-        Whether to save force constants in hdf5 format. Default is True.
-    plot_to_file : bool
-        Whether to plot. Default is False.
-    dos : bool
-        Whether to calculate and save the DOS. Default is False.
-    pdos : bool
-        Whether to calculate and save the PDOS. Default is False.
-    minimize : bool
-        Whether to minimize structure before calculations. Default is False.
     symmetrize : bool
         Whether to symmetrize force constants. Default is False.
-    write_full : bool
-        Whether to maximize information written in various output files.
-        Default is True.
+    minimize : bool
+        Whether to minimize structure before calculations. Default is False.
     fmax : float
         Set force convergence criteria for optimizer in units eV/Å.
         Default is 0.1.
     minimize_kwargs : Optional[dict[str, Any]]
         Other keyword arguments to pass to geometry optimizer. Default is {}.
+    hdf5 : bool
+        Whether to save force constants in hdf5 format. Default is True.
+    plot_to_file : bool
+        Whether to plot. Default is False.
+    write_full : bool
+        Whether to maximize information written in various output files.
+        Default is True.
     arch : Optional[str]
         MLIP architecture to use for geometry optimization.
         Default is "mace_mp".
@@ -247,12 +247,12 @@ def phonons(
         "calcs": calcs,
         "supercell": supercell,
         "displacement": displacement,
-        "t_step": temp_step,
-        "t_min": temp_start,
-        "t_max": temp_end,
         "symmetrize": symmetrize,
         "minimize": minimize,
         "minimize_kwargs": minimize_kwargs,
+        "temp_min": temp_min,
+        "temp_max": temp_max,
+        "temp_step": temp_step,
         "force_consts_to_hdf5": hdf5,
         "plot_to_file": plot_to_file,
         "write_results": True,


### PR DESCRIPTION
Resolves #259

- Reorder and rename phonon parameters
  - Groups relevant parameters together e.g. minimize with minimize kwargs, output options at end
  - `t_step` -> `temp_step` etc. to match CLI option names, similar to changes we made for MD
- Moves explanation of config files towards top of command line docs, as otherwise it's a bit hidden away

