### PR TITLE
Fix singlepoint summary

### DIFF
--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -140,8 +140,8 @@ def singlepoint(
     ).absolute()
     log = s_point.log_kwargs["filename"]
 
-    # Store only filename as filemode is not set by user
-    inputs = {"log": log}
+    # Store inputs for yaml summary
+    inputs = singlepoint_kwargs.copy()
 
     # Add structure, MLIP information, and log to inputs
     save_struct_calc(

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -240,6 +240,7 @@ def test_summary(tmp_path):
     assert "inputs" in sp_summary
     assert "end_time" in sp_summary
 
+    assert "properties" in sp_summary["inputs"]
     assert "traj" in sp_summary["inputs"]
     assert "length" in sp_summary["inputs"]["traj"]
     assert "struct" in sp_summary["inputs"]["traj"]


### PR DESCRIPTION
At some point the other singlepoint inputs (e.g. `properties`) got lost from the summary.

Duplicates should still be dealt with within `save_struct_calc`, as for all other calculations.