### PR TITLE
Add progress bar to phonon calculations

### DIFF
--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -216,6 +216,8 @@ class Phonons(BaseCalculation):
         file_prefix : Optional[PathLike]
             Prefix for output filenames. Default is inferred from structure name, or
             chemical formula of the structure.
+        enable_progress_bar : bool
+            Whether to show a progress bar during phonon calculations. Default is False.
         """
         (read_kwargs, minimize_kwargs) = none_to_dict((read_kwargs, minimize_kwargs))
 

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -867,12 +867,23 @@ def track_progress(sequence: Union[Sequence, Iterable], description: str) -> Ite
     Iterable
         An iterable of the values in the sequence.
     """
+    from rich.style import Style
+
     text_column = TextColumn("{task.description}")
-    bar_column = BarColumn(bar_width=None)
+    bar_column = BarColumn(
+        bar_width=None,
+        complete_style=Style(color="#FBBB10"),
+        finished_style=Style(color="#E38408"),
+    )
     completion_column = MofNCompleteColumn()
     time_column = TimeRemainingColumn()
     progress = Progress(
-        text_column, bar_column, completion_column, time_column, expand=True
+        text_column,
+        bar_column,
+        completion_column,
+        time_column,
+        expand=True,
+        auto_refresh=False,
     )
 
     with progress:

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -8,6 +8,7 @@ from numpy import ndarray
 import phonopy
 from phonopy.file_IO import write_force_constants_to_hdf5
 from phonopy.structure.atoms import PhonopyAtoms
+from tqdm import tqdm
 
 from janus_core.calculations.base import BaseCalculation
 from janus_core.calculations.geom_opt import GeomOpt
@@ -149,6 +150,7 @@ class Phonons(BaseCalculation):
         write_results: bool = True,
         write_full: bool = True,
         file_prefix: Optional[PathLike] = None,
+        enable_progress_bar: bool = False
     ) -> None:
         """
         Initialise Phonons class.
@@ -229,6 +231,7 @@ class Phonons(BaseCalculation):
         self.plot_to_file = plot_to_file
         self.write_results = write_results
         self.write_full = write_full
+        self.enable_progress_bar = enable_progress_bar
 
         # Ensure supercell is a valid list
         self.supercell = [supercell] * 3 if isinstance(supercell, int) else supercell
@@ -356,6 +359,9 @@ class Phonons(BaseCalculation):
         phonon = phonopy.Phonopy(cell, supercell_matrix)
         phonon.generate_displacements(distance=self.displacement)
         disp_supercells = phonon.supercells_with_displacements
+
+        if self.enable_progress_bar:
+            disp_supercells = tqdm(disp_supercells)
 
         phonon.forces = [
             self._calc_forces(supercell)

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -1,20 +1,13 @@
 """Phonon calculations."""
 
-from collections.abc import Iterable, Sequence
-from typing import Any, Optional, Union, get_args
+from collections.abc import Sequence
+from typing import Any, Optional, get_args
 
 from ase import Atoms
 from numpy import ndarray
 import phonopy
 from phonopy.file_IO import write_force_constants_to_hdf5
 from phonopy.structure.atoms import PhonopyAtoms
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    TextColumn,
-    TimeRemainingColumn,
-)
 
 from janus_core.calculations.base import BaseCalculation
 from janus_core.calculations.geom_opt import GeomOpt
@@ -27,7 +20,7 @@ from janus_core.helpers.janus_types import (
     PathLike,
     PhononCalcs,
 )
-from janus_core.helpers.utils import none_to_dict, write_table
+from janus_core.helpers.utils import none_to_dict, track_progress, write_table
 
 
 class Phonons(BaseCalculation):
@@ -845,46 +838,3 @@ class Phonons(BaseCalculation):
             self.calc_dos(plot_bands="bands" in self.calcs)
         if "pdos" in self.calcs:
             self.calc_pdos()
-
-
-def track_progress(sequence: Union[Sequence, Iterable], description: str) -> Iterable:
-    """
-    Track the progress of iterating over a sequence.
-
-    This is done by displaying a progress bar in the console using the rich library.
-    The function is an iterator over the sequence, updating the progress bar each
-    iteration.
-
-    Parameters
-    ----------
-    sequence : Iterable
-        The sequence to iterate over. Must support "len".
-    description : str
-        The text to display to the left of the progress bar.
-
-    Returns
-    -------
-    Iterable
-        An iterable of the values in the sequence.
-    """
-    from rich.style import Style
-
-    text_column = TextColumn("{task.description}")
-    bar_column = BarColumn(
-        bar_width=None,
-        complete_style=Style(color="#FBBB10"),
-        finished_style=Style(color="#E38408"),
-    )
-    completion_column = MofNCompleteColumn()
-    time_column = TimeRemainingColumn()
-    progress = Progress(
-        text_column,
-        bar_column,
-        completion_column,
-        time_column,
-        expand=True,
-        auto_refresh=False,
-    )
-
-    with progress:
-        yield from progress.track(sequence, description=description)

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -258,6 +258,7 @@ def phonons(
         "write_results": True,
         "write_full": write_full,
         "file_prefix": file_prefix,
+        "enable_progress_bar": True
     }
 
     # Initialise phonons

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -258,7 +258,7 @@ def phonons(
         "write_results": True,
         "write_full": write_full,
         "file_prefix": file_prefix,
-        "enable_progress_bar": True
+        "enable_progress_bar": True,
     }
 
     # Initialise phonons

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -11,6 +11,14 @@ from typing import Any, Literal, Optional, TextIO, Union, get_args
 from ase import Atoms
 from ase.io import read, write
 from ase.io.formats import filetype
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeRemainingColumn,
+)
+from rich.style import Style
 from spglib import get_spacegroup
 
 from janus_core.helpers.janus_types import (
@@ -691,20 +699,11 @@ def track_progress(sequence: Union[Sequence, Iterable], description: str) -> Ite
     description : str
         The text to display to the left of the progress bar.
 
-    Returns
-    -------
+    Yields
+    ------
     Iterable
         An iterable of the values in the sequence.
     """
-    from rich.progress import (
-        BarColumn,
-        MofNCompleteColumn,
-        Progress,
-        TextColumn,
-        TimeRemainingColumn,
-    )
-    from rich.style import Style
-
     text_column = TextColumn("{task.description}")
     bar_column = BarColumn(
         bar_width=None,

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -6,7 +6,7 @@ from copy import copy
 from io import StringIO
 import logging
 from pathlib import Path
-from typing import Any, Literal, Optional, TextIO, get_args
+from typing import Any, Literal, Optional, TextIO, Union, get_args
 
 from ase import Atoms
 from ase.io import read, write
@@ -674,3 +674,53 @@ def _dump_csv(
 
     for cols in zip(*columns.values()):
         print(",".join(map(format, cols, formats)), file=file)
+
+
+def track_progress(sequence: Union[Sequence, Iterable], description: str) -> Iterable:
+    """
+    Track the progress of iterating over a sequence.
+
+    This is done by displaying a progress bar in the console using the rich library.
+    The function is an iterator over the sequence, updating the progress bar each
+    iteration.
+
+    Parameters
+    ----------
+    sequence : Iterable
+        The sequence to iterate over. Must support "len".
+    description : str
+        The text to display to the left of the progress bar.
+
+    Returns
+    -------
+    Iterable
+        An iterable of the values in the sequence.
+    """
+    from rich.progress import (
+        BarColumn,
+        MofNCompleteColumn,
+        Progress,
+        TextColumn,
+        TimeRemainingColumn,
+    )
+    from rich.style import Style
+
+    text_column = TextColumn("{task.description}")
+    bar_column = BarColumn(
+        bar_width=None,
+        complete_style=Style(color="#FBBB10"),
+        finished_style=Style(color="#E38408"),
+    )
+    completion_column = MofNCompleteColumn()
+    time_column = TimeRemainingColumn()
+    progress = Progress(
+        text_column,
+        bar_column,
+        completion_column,
+        time_column,
+        expand=True,
+        auto_refresh=False,
+    )
+
+    with progress:
+        yield from progress.track(sequence, description=description)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ numpy = "^1.26.4"
 phonopy = "^2.23.1"
 python = "^3.9"
 pyyaml = "^6.0.1"
+rich = "^13.9.1"
 seekpath = "^1.9.7"
 spglib = "^2.3.0"
 torch = ">= 2.1, <= 2.2" # Range required for dgl


### PR DESCRIPTION
Closes #268 

Adds a progress bar to phonon calculations using `tqdm`, which is already a dependency. A new argument was added to `Phonons.__init__` to control the presence of this feature, disabled by default to minimise impact on code in general. However, the progress bar is always enabled for CLI.

One issue that I and @ajjackson have noted is that the bar only shows the progress over displacements, meaning that when bands, DOS, or PDOS are chosen to be calculated, the 100% bar just continues sitting there despite the prolonged calculations. This could be confusing to users. One solution could be writing to stdout before/after the progress bar appears, saying what the bar is for, but we weren't sure what the best path forward is. What do you think?

Additionally, I should probably mention that I ran into #316 while working on this despite only running janus only in serial.