### PR TITLE
Add support for non-diagonal supercells

### DIFF
--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -314,7 +314,7 @@ Calculate phonons with a 2x2x2 supercell, after geometry optimization (using the
 
 .. code-block:: bash
 
-    janus phonons --struct tests/data/NaCl.cif --supercell 2 2 2 --minimize --arch mace_mp --model-path small
+    janus phonons --struct tests/data/NaCl.cif --supercell "2 2 2" --minimize --arch mace_mp --model-path small
 
 
 This will save the Phonopy parameters, including displacements and force constants, to ``NaCl-phonopy.yml`` and ``NaCl-force_constants.hdf5``,
@@ -324,7 +324,7 @@ Additionally, the ``--bands`` option can be added to calculate the band structur
 
 .. code-block:: bash
 
-    janus phonons --struct tests/data/NaCl.cif --supercell 2 2 2 --minimize --arch mace_mp --model-path small --bands
+    janus phonons --struct tests/data/NaCl.cif --supercell "2 2 2" --minimize --arch mace_mp --model-path small --bands
 
 
 If you need eigenvectors and group velocities written, add the ``--write-full`` option. This will generate a much larger file, but can be used to visualise phonon modes.
@@ -333,7 +333,7 @@ Further calculations, including thermal properties, DOS, and PDOS, can also be c
 
 .. code-block:: bash
 
-    janus phonons --struct tests/data/NaCl.cif --supercell 2 3 4 --dos --pdos --thermal --temp-start 0 --temp-end 300 --temp-step 50
+    janus phonons --struct tests/data/NaCl.cif --supercell "2 3 4" --dos --pdos --thermal --temp-start 0 --temp-end 300 --temp-step 50
 
 
 This will create additional output files: ``NaCl-thermal.dat`` for the thermal properties (heat capacity, entropy, and free energy)

--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -339,6 +339,13 @@ Further calculations, including thermal properties, DOS, and PDOS, can also be c
 This will create additional output files: ``NaCl-thermal.dat`` for the thermal properties (heat capacity, entropy, and free energy)
 between 0K and 300K, ``NaCl-dos.dat`` for the DOS, and ``NaCl-pdos.dat`` for the PDOS.
 
+To define the supercell, the ``--supercell`` option can be used, which *must* be passed in as a space-separated string.
+Similar to Phonopy, the supercell matrix can be defined in three ways:
+
+1. One integer (``--supercell "2"``) specifying all diagonal elements.
+2. Three integers (``--supercell "2 2 2"``) specifying each individual diagonal element.
+3. Nine integers (``--supercell "2 0 0 0 2 0 0 0 2"``) specifying all elements, filling the matrix row-wise.
+
 For all options, run ``janus phonons --help``.
 
 

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -257,7 +257,13 @@ class Phonons(BaseCalculation):
         # Ensure supercell is a valid list
         self.supercell = [supercell] * 3 if isinstance(supercell, int) else supercell
         if len(self.supercell) not in [3, 9]:
-            raise ValueError("`supercell` must be an integer, or list of length 3 or 9")
+            raise ValueError(
+                "`supercell` must be an integer, or list of length 3 or 9. A list of "
+                "length 3 must specify the values of a diagonal supercell, and a list "
+                "of length 9 must specify all values of a full supercell matrix, where "
+                "the first three values are the first row, the second three are the "
+                "second row, etc."
+            )
 
         # Read last image by default
         read_kwargs.setdefault("index", -1)

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -196,11 +196,12 @@ class Phonons(BaseCalculation):
         supercell : MaybeList[int]
             The size of a supercell for calculation, or the supercell itself.
             If a single number is provided, it is interpreted as the size, so a
-            symmetrical supercell of that size in all dimensions is constructed.
+            diagonal supercell of that size in all dimensions is constructed.
             If three values are provided, they are interpreted as the diagonal
-            values of a symmetrical supercell. If nine values are provided, they
-            are assumed to be the full supercell matrix in the style of Phonopy.
-            Default is 2.
+            values of a diagonal supercell. If nine values are provided, they
+            are assumed to be the full supercell matrix in the style of Phonopy,
+            so the first three values will be used as the first row, the second
+            three as the second row, etc. Default is 2.
         displacement : float
             Displacement for force constants calculation, in A. Default is 0.01.
         mesh : tuple[int, int, int]

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -59,7 +59,14 @@ class Phonons(BaseCalculation):
     calcs : Optional[MaybeSequence[PhononCalcs]]
         Phonon calculations to run. Default calculates force constants only.
     supercell : MaybeList[int]
-        Size of supercell for calculation. Default is 2.
+        The size of a supercell for calculation, or the supercell itself.
+        If a single number is provided, it is interpreted as the size, so a
+        diagonal supercell of that size in all dimensions is constructed.
+        If three values are provided, they are interpreted as the diagonal
+        values of a diagonal supercell. If nine values are provided, they
+        are assumed to be the full supercell matrix in the style of Phonopy,
+        so the first three values will be used as the first row, the second
+        three as the second row, etc. Default is 2.
     displacement : float
         Displacement for force constants calculation, in A. Default is 0.01.
     mesh : tuple[int, int, int]

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -226,7 +226,9 @@ def phonons(
     # Validate supercell list
     if len(supercell) not in [3, 9]:
         raise ValueError(
-            "Please pass three or nine lattice vectors in the form '1 2 3'"
+            "Please pass three or nine lattice vectors in the form '1 2 3' or "
+            "'1 2 3 4 5 6 7 8 9'. In the latter case first three values are the first "
+            "row of the supercell matrix, the second three are the second row, etc."
         )
 
     calcs = []

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -31,15 +31,11 @@ def phonons(
     supercell: Annotated[
         str,
         Option(
-            help="Supercell specification as a string, in the Phonopy style. "
-            "There are three different valid inputs: single value (i.e. '2') "
-            "which specifies what all of the diagonal values of the supercell "
-            "matrix whould be, three values (i.e. '1 2 3') which specify the "
-            "individual diagonal elements of the supercell matrix, or nine "
-            "values (i.e. '1 2 3 4 5 6 7 8 9') which specify all the elements "
-            "of the full supercell matrix. In the last case, the first three "
-            "values form the first row of the matrix, the second three the "
-            "second row, etc."
+            help="Supercell matrix, in the Phonopy style. Must be passed as a string "
+            "in one of three forms: single integer ('2'), which specifies all "
+            "diagonal elements; three integers ('1 2 3'), which specifies each "
+            "individual diagonal element; or nine values ('1 2 3 4 5 6 7 8 9'), "
+            "which specifies all elements, filling the matrix row-wise."
         ),
     ] = "2 2 2",
     displacement: Annotated[
@@ -126,15 +122,11 @@ def phonons(
     struct : Path
         Path of structure to simulate.
     supercell : str
-        Supercell specification as a string, in the Phonopy style.
-        There are three different valid inputs: single value (i.e. '2')
-        which specifies what all of the diagonal values of the supercell
-        matrix whould be, three values (i.e. '1 2 3') which specify the
-        individual diagonal elements of the supercell matrix, or nine
-        values (i.e. '1 2 3 4 5 6 7 8 9') which specify all the elements
-        of the full supercell matrix. In the last case, the first three
-        values form the first row of the matrix, the second three the
-        second row, etc.
+        Supercell matrix, in the Phonopy style. Must be passed as a string in one of
+        three forms: single integer ('2'), which specifies all diagonal elements;
+        three integers ('1 2 3'), which specifies each individual diagonal element;
+        or nine values ('1 2 3 4 5 6 7 8 9'), which specifies all elements, filling the
+        matrix row-wise.
     displacement : float
         Displacement for force constants calculation, in A. Default is 0.01.
     mesh : tuple[int, int, int]

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -30,7 +30,12 @@ def phonons(
     struct: StructPath,
     supercell: Annotated[
         str,
-        Option(help="Supercell lattice vectors in the form '1x2x3'."),
+        Option(help="Supercell lattice vectors in the form '1 2 3' or "
+                    "'1 2 3 4 5 6 7 8 9'. If three values are provided, "
+                    "the supercell is assumed to be diagonal. Otherwise, "
+                    "the first three values will be interpreted as the "
+                    "first row of the supercell matrix, the second three, "
+                    "as the second row, etc."),
     ] = "2 2 2",
     displacement: Annotated[
         float, Option(help="Displacement for force constants calculation, in A.")
@@ -118,9 +123,9 @@ def phonons(
     supercell : str
         Supercell lattice vectors. Must be passed inside a string, as a series of
         either 3 or 9 wihtespace-separated numbers, i.e. '1 2 3' or '1 2 3 4 5 6 7 8 9'.
-        If 3 numbers are provided, the supercell is assumed to be symmetrical, so the
-        remaining values are set to 0. Otherwise, all 9 values are used to construct
-        the transformation matrix, as in Phonopy. Default is '2 2 2'.
+        If 3 numbers are provided, the supercell is assumed to be diagonal. Otherwise,
+        all 9 values are used to construct the transformation matrix, using the first
+        three as the first row, the second three as the second row, etc. Default is '2 2 2'.
     displacement : float
         Displacement for force constants calculation, in A. Default is 0.01.
     mesh : tuple[int, int, int]

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -215,7 +215,7 @@ def phonons(
         supercell = [int(x) for x in supercell.split()]
     except ValueError as exc:
         raise ValueError(
-            "Please pass lattice vectors as integers in the form 1x2x3"
+            "Please pass lattice vectors as integers in the form '1 2 3'"
         ) from exc
 
     # Validate supercell list

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -237,10 +237,8 @@ def phonons(
         supercell = supercell[0]
     elif supercell_length not in [3, 9]:
         raise ValueError(
-            "Please pass one, three or nine lattice vectors in the form '1', '1 2 3' "
-            "or '1 2 3 4 5 6 7 8 9'. In the latter case first three values are the "
-            "first row of the supercell matrix, the second three are the second row, "
-            "etc."
+            "Please pass lattice vectors as space-separated integers in quotes. "
+            "For example, '1 2 3'."
         )
 
     calcs = []

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -303,7 +303,7 @@ test_data = [
     ("--supercell", [2]),
     ("--supercell", ["2x2x2"]),
     ("--supercell", ["2 2 2"]),
-    ("--supercell", [2.1, 2.1, 2.1]),
+    ("--supercell", ["2.1", "2.1", "2.1"]),
     ("--supercell", [2, 2, "a"]),
     ("--supercell", [2, 2]),
     ("--supercell", [2] * 6),
@@ -311,7 +311,7 @@ test_data = [
     ("--supercell-matrix", [2]),
     ("--supercell-matrix", ["2x2x2" * 3]),
     ("--supercell-matrix", ["2 2 2 2 2 2 2 2 2"]),
-    ("--supercell-matrix", [2.1] * 9),
+    ("--supercell-matrix", ["2.1"] * 9),
     ("--supercell-matrix", [2, 2, "a"] * 3),
     ("--supercell-matrix", [2] * 6),
     ("--supercell-matrix", [2] * 12),
@@ -336,9 +336,6 @@ def test_invalid_supercell(supercell_arg, supercell, tmp_path):
         ],
     )
     assert result.exit_code == 1 or result.exit_code == 2
-
-    print(result.exception)
-    # assert isinstance(result.exception, ValueError)
 
 
 def test_minimize_kwargs(tmp_path):

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -228,9 +228,7 @@ def test_plot(tmp_path):
             "--struct",
             DATA_PATH / "NaCl.cif",
             "--supercell",
-            1,
-            1,
-            1,
+            "1 1 1",
             "--pdos",
             "--dos",
             "--bands",
@@ -270,9 +268,7 @@ def test_supercell(tmp_path):
             "--struct",
             DATA_PATH / "NaCl.cif",
             "--supercell",
-            1,
-            2,
-            3,
+            "1 2 3",
             "--no-hdf5",
             "--file-prefix",
             file_prefix,
@@ -289,7 +285,11 @@ def test_supercell(tmp_path):
     assert params["supercell_matrix"] == [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
 
 
-@pytest.mark.parametrize("supercell", [(2,), (2, 2), (2, 2, "a"), ("2x2x2",)])
+
+test_data = ["2", "2x2x2", "2.1 2.1 2.1", "2 2 a", "2 2", "2 2 2 2 2 2"]
+
+
+@pytest.mark.parametrize("supercell", test_data)
 def test_invalid_supercell(supercell, tmp_path):
     """Test errors are raise for invalid supercells."""
     file_prefix = tmp_path / "test"
@@ -379,9 +379,7 @@ def test_valid_traj_input(read_kwargs, tmp_path):
             "--struct",
             DATA_PATH / "NaCl-traj.xyz",
             "--supercell",
-            1,
-            1,
-            1,
+            "1 1 1",
             "--read-kwargs",
             read_kwargs,
             "--no-hdf5",

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -256,7 +256,14 @@ def test_plot(tmp_path):
     assert phonon_summary["inputs"]["calcs"][2] == "pdos"
 
 
-def test_supercell(tmp_path):
+test_data = [
+    ("1 2 3", [[1, 0, 0], [0, 2, 0], [0, 0, 3]]),
+    ("1 1 0 -1 1 0 0 0 2", [[1, 1, 0], [-1, 1, 0], [0, 0, 2]])
+]
+
+
+@pytest.mark.parametrize("supercell,supercell_matrix", test_data)
+def test_supercell(supercell, supercell_matrix, tmp_path):
     """Test setting the supercell."""
     file_prefix = tmp_path / "NaCl"
     param_file = tmp_path / "NaCl-phonopy.yml"
@@ -268,7 +275,7 @@ def test_supercell(tmp_path):
             "--struct",
             DATA_PATH / "NaCl.cif",
             "--supercell",
-            "1 2 3",
+            supercell,
             "--no-hdf5",
             "--file-prefix",
             file_prefix,
@@ -282,7 +289,7 @@ def test_supercell(tmp_path):
 
     assert "supercell_matrix" in params
     assert len(params["supercell_matrix"]) == 3
-    assert params["supercell_matrix"] == [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
+    assert params["supercell_matrix"] == supercell_matrix
 
 
 

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -228,9 +228,7 @@ def test_plot(tmp_path):
             "--struct",
             DATA_PATH / "NaCl.cif",
             "--supercell",
-            1,
-            1,
-            1,
+            "1 1 1",
             "--pdos",
             "--dos",
             "--bands",
@@ -259,17 +257,14 @@ def test_plot(tmp_path):
 
 
 test_data = [
-    ("--supercell", [1, 2, 3], [[1, 0, 0], [0, 2, 0], [0, 0, 3]]),
-    (
-        "--supercell-matrix",
-        [1, 1, 0, -1, 1, 0, 0, 0, 2],
-        [[1, 1, 0], [-1, 1, 0], [0, 0, 2]],
-    ),
+    ("1", [[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+    ("1 2 3", [[1, 0, 0], [0, 2, 0], [0, 0, 3]]),
+    ("1 1 0 -1 1 0 0 0 2", [[1, 1, 0], [-1, 1, 0], [0, 0, 2]]),
 ]
 
 
-@pytest.mark.parametrize("supercell_arg,supercell,supercell_matrix", test_data)
-def test_supercell(supercell_arg, supercell, supercell_matrix, tmp_path):
+@pytest.mark.parametrize("supercell,supercell_matrix", test_data)
+def test_supercell(supercell, supercell_matrix, tmp_path):
     """Test setting the supercell."""
     file_prefix = tmp_path / "NaCl"
     param_file = tmp_path / "NaCl-phonopy.yml"
@@ -280,8 +275,8 @@ def test_supercell(supercell_arg, supercell, supercell_matrix, tmp_path):
             "phonons",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            supercell_arg,
-            *supercell,
+            "--supercell",
+            supercell,
             "--no-hdf5",
             "--file-prefix",
             file_prefix,
@@ -298,28 +293,11 @@ def test_supercell(supercell_arg, supercell, supercell_matrix, tmp_path):
     assert params["supercell_matrix"] == supercell_matrix
 
 
-
-test_data = [
-    ("--supercell", [2]),
-    ("--supercell", ["2x2x2"]),
-    ("--supercell", ["2 2 2"]),
-    ("--supercell", ["2.1", "2.1", "2.1"]),
-    ("--supercell", [2, 2, "a"]),
-    ("--supercell", [2, 2]),
-    ("--supercell", [2] * 6),
-    ("--supercell", [2] * 9),
-    ("--supercell-matrix", [2]),
-    ("--supercell-matrix", ["2x2x2" * 3]),
-    ("--supercell-matrix", ["2 2 2 2 2 2 2 2 2"]),
-    ("--supercell-matrix", ["2.1"] * 9),
-    ("--supercell-matrix", [2, 2, "a"] * 3),
-    ("--supercell-matrix", [2] * 6),
-    ("--supercell-matrix", [2] * 12),
-]
+test_data = ["2x2x2", "2.1 2.1 2.1", "2 2 a", "2 2", "2 2 2 2 2 2"]
 
 
-@pytest.mark.parametrize("supercell_arg,supercell", test_data)
-def test_invalid_supercell(supercell_arg, supercell, tmp_path):
+@pytest.mark.parametrize("supercell", test_data)
+def test_invalid_supercell(supercell, tmp_path):
     """Test errors are raise for invalid supercells."""
     file_prefix = tmp_path / "test"
 
@@ -329,8 +307,8 @@ def test_invalid_supercell(supercell_arg, supercell, tmp_path):
             "phonons",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            supercell_arg,
-            *supercell,
+            "--supercell",
+            supercell,
             "--file-prefix",
             file_prefix,
         ],
@@ -408,9 +386,7 @@ def test_valid_traj_input(read_kwargs, tmp_path):
             "--struct",
             DATA_PATH / "NaCl-traj.xyz",
             "--supercell",
-            1,
-            1,
-            1,
+            "1 1 1",
             "--read-kwargs",
             read_kwargs,
             "--no-hdf5",

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -228,7 +228,9 @@ def test_plot(tmp_path):
             "--struct",
             DATA_PATH / "NaCl.cif",
             "--supercell",
-            "1 1 1",
+            1,
+            1,
+            1,
             "--pdos",
             "--dos",
             "--bands",
@@ -257,13 +259,17 @@ def test_plot(tmp_path):
 
 
 test_data = [
-    ("1 2 3", [[1, 0, 0], [0, 2, 0], [0, 0, 3]]),
-    ("1 1 0 -1 1 0 0 0 2", [[1, 1, 0], [-1, 1, 0], [0, 0, 2]])
+    ("--supercell", [1, 2, 3], [[1, 0, 0], [0, 2, 0], [0, 0, 3]]),
+    (
+        "--supercell-matrix",
+        [1, 1, 0, -1, 1, 0, 0, 0, 2],
+        [[1, 1, 0], [-1, 1, 0], [0, 0, 2]],
+    ),
 ]
 
 
-@pytest.mark.parametrize("supercell,supercell_matrix", test_data)
-def test_supercell(supercell, supercell_matrix, tmp_path):
+@pytest.mark.parametrize("supercell_arg,supercell,supercell_matrix", test_data)
+def test_supercell(supercell_arg, supercell, supercell_matrix, tmp_path):
     """Test setting the supercell."""
     file_prefix = tmp_path / "NaCl"
     param_file = tmp_path / "NaCl-phonopy.yml"
@@ -274,8 +280,8 @@ def test_supercell(supercell, supercell_matrix, tmp_path):
             "phonons",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            "--supercell",
-            supercell,
+            supercell_arg,
+            *supercell,
             "--no-hdf5",
             "--file-prefix",
             file_prefix,
@@ -293,11 +299,27 @@ def test_supercell(supercell, supercell_matrix, tmp_path):
 
 
 
-test_data = ["2", "2x2x2", "2.1 2.1 2.1", "2 2 a", "2 2", "2 2 2 2 2 2"]
+test_data = [
+    ("--supercell", [2]),
+    ("--supercell", ["2x2x2"]),
+    ("--supercell", ["2 2 2"]),
+    ("--supercell", [2.1, 2.1, 2.1]),
+    ("--supercell", [2, 2, "a"]),
+    ("--supercell", [2, 2]),
+    ("--supercell", [2] * 6),
+    ("--supercell", [2] * 9),
+    ("--supercell-matrix", [2]),
+    ("--supercell-matrix", ["2x2x2" * 3]),
+    ("--supercell-matrix", ["2 2 2 2 2 2 2 2 2"]),
+    ("--supercell-matrix", [2.1] * 9),
+    ("--supercell-matrix", [2, 2, "a"] * 3),
+    ("--supercell-matrix", [2] * 6),
+    ("--supercell-matrix", [2] * 12),
+]
 
 
-@pytest.mark.parametrize("supercell", test_data)
-def test_invalid_supercell(supercell, tmp_path):
+@pytest.mark.parametrize("supercell_arg,supercell", test_data)
+def test_invalid_supercell(supercell_arg, supercell, tmp_path):
     """Test errors are raise for invalid supercells."""
     file_prefix = tmp_path / "test"
 
@@ -307,13 +329,16 @@ def test_invalid_supercell(supercell, tmp_path):
             "phonons",
             "--struct",
             DATA_PATH / "NaCl.cif",
-            "--supercell",
+            supercell_arg,
             *supercell,
             "--file-prefix",
             file_prefix,
         ],
     )
     assert result.exit_code == 1 or result.exit_code == 2
+
+    print(result.exception)
+    # assert isinstance(result.exception, ValueError)
 
 
 def test_minimize_kwargs(tmp_path):
@@ -386,7 +411,9 @@ def test_valid_traj_input(read_kwargs, tmp_path):
             "--struct",
             DATA_PATH / "NaCl-traj.xyz",
             "--supercell",
-            "1 1 1",
+            1,
+            1,
+            1,
             "--read-kwargs",
             read_kwargs,
             "--no-hdf5",


### PR DESCRIPTION
As discussed, and mentioned in #310, I had a try at adding support for non-diagonal supercells to phonon calculations. The Python API change is small: simply adding support for lists of length 9, which are then turned into a 3x3 matrix. The CLI API is much trickier due to the restrictions that typer/click impose ([certain hacks](https://stackoverflow.com/questions/48391777/nargs-equivalent-for-options-in-click) notwithstanding); for now, I and @ajjackson decided to require the supercell input to be a whitespace-separated string, e.g. `"1 2 3"`), which would have to be passed in as a string. The other option we considered was having two different options for the two cases, e.g. `--supercell-diagonal` and `--supercell-nondiagonal`. However, we aren't sure what would be the best approach; what do you think?

Also, I have tried adding some tests, but let me know if more/different tests are required.