### PR TITLE
Fix unimplemented descriptors

### DIFF
--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -7,7 +7,6 @@ from ase import Atoms
 from ase.calculators.calculator import Calculator
 from ase.calculators.mixing import SumCalculator
 import numpy as np
-from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
 
 from janus_core.calculations.base import BaseCalculation
 from janus_core.helpers.janus_types import (
@@ -192,7 +191,7 @@ class Descriptors(BaseCalculation):
         if isinstance(calc, SumCalculator):
             if (
                 len(calc.mixer.calcs) == 2
-                and isinstance(calc.mixer.calcs[1], TorchDFTD3Calculator)
+                and calc.mixer.calcs[1].name == "TorchDFTD3Calculator"
                 and hasattr(calc.mixer.calcs[0], "get_descriptors")
             ):
                 calc.get_descriptors = calc.mixer.calcs[0].get_descriptors

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -166,7 +166,11 @@ class Descriptors(BaseCalculation):
         ):
             raise ValueError("Please attach a calculator to `struct`.")
 
-        self._check_calculator(self.struct.calc)
+        if isinstance(self.struct, Atoms):
+            self._check_calculator(self.struct.calc)
+        if isinstance(self.struct, Sequence):
+            for image in self.struct:
+                self._check_calculator(image.calc)
 
         # Set output file
         self.write_kwargs.setdefault("filename", None)

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -163,6 +163,14 @@ class Descriptors(BaseCalculation):
         ):
             raise ValueError("Please attach a calculator to `struct`.")
 
+        if not hasattr(self.struct.calc, "get_descriptors") or not callable(
+            self.struct.calc.get_descriptors
+        ):
+            raise NotImplementedError(
+                "The attached calculator does not currently support calculating "
+                "descriptors"
+            )
+
         # Set output file
         self.write_kwargs.setdefault("filename", None)
         self.write_kwargs["filename"] = self._build_filename(

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -88,3 +88,48 @@ def test_logging(tmp_path):
 
     assert log_file.exists()
     assert single_point.struct.info["emissions"] > 0
+
+
+def test_dispersion():
+    """Test using mace_mp with dispersion."""
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="mace_mp",
+        calc_kwargs={"dispersion": False},
+    )
+
+    descriptors = Descriptors(
+        single_point.struct,
+        calc_per_element=True,
+    )
+    descriptors.run()
+
+    single_point_disp = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="mace_mp",
+        calc_kwargs={"dispersion": True},
+    )
+
+    descriptors_disp = Descriptors(
+        single_point_disp.struct,
+        calc_per_element=True,
+    )
+    descriptors_disp.run()
+
+    assert (
+        descriptors_disp.struct.info["mace_mp_descriptor"]
+        == descriptors.struct.info["mace_mp_descriptor"]
+    )
+
+
+def test_not_implemented_error():
+    """Test correct error raised if descriptors not implemented."""
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="chgnet",
+    )
+    with pytest.raises(NotImplementedError):
+        Descriptors(
+            single_point.struct,
+            calc_per_element=True,
+        )


### PR DESCRIPTION
Resolves #309

The solution for the `SumCalculator` case isn't the nicest, but hopefully the checks are specific enough that it's reasonable.

The two added tests both fail prior to the subsequent changes :

```
FAILED tests/test_descriptors.py::test_dispersion - AttributeError: 'SumCalculator' object has no attribute 'get_descriptors'
FAILED tests/test_descriptors.py::test_not_implemented_error - Failed: DID NOT RAISE <class 'NotImplementedError'>
```