### PR TITLE
Add symmetry refining

### DIFF
--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -307,10 +307,10 @@ class GeomOpt(BaseCalculation):
 
             # Update max force
             old_max_force = max_force
-            if self.filter_func is not None:
-                max_force = linalg.norm(self.filtered_struct.get_forces(), axis=1).max()
-            else:
-                max_force = linalg.norm(self.struct.get_forces(), axis=1).max()
+            struct = (
+                self.filtered_struct if self.filter_func is not None else self.struct
+            )
+            max_force = linalg.norm(struct.get_forces(), axis=1).max()
 
             if max_force >= old_max_force:
                 warnings.warn(

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -18,6 +18,7 @@ from janus_core.helpers.utils import (
     Devices,
     none_to_dict,
     output_structs,
+    snap_symmetry,
     spacegroup,
 )
 
@@ -56,6 +57,8 @@ class GeomOpt(BaseCalculation):
         Set force convergence criteria for optimizer in units eV/Å. Default is 0.1.
     steps : int
         Set maximum number of optimization steps to run. Default is 1000.
+    symmetrize : bool
+        Whether to refine symmetry after geometry optimization. Default is False.
     symmetry_tolerance : float
         Atom displacement tolerance for spglib symmetry determination, in Å.
         Default is 0.001.
@@ -104,6 +107,7 @@ class GeomOpt(BaseCalculation):
         tracker_kwargs: Optional[dict[str, Any]] = None,
         fmax: float = 0.1,
         steps: int = 1000,
+        symmetrize: bool = False,
         symmetry_tolerance: float = 0.001,
         angle_tolerance: float = -1.0,
         filter_func: Optional[Union[Callable, str]] = FrechetCellFilter,
@@ -148,6 +152,8 @@ class GeomOpt(BaseCalculation):
             Set force convergence criteria for optimizer in units eV/Å. Default is 0.1.
         steps : int
             Set maximum number of optimization steps to run. Default is 1000.
+        symmetrize : bool
+            Whether to refine symmetry after geometry optimization. Default is False.
         symmetry_tolerance : float
             Atom displacement tolerance for spglib symmetry determination, in Å.
             Default is 0.001.
@@ -181,6 +187,7 @@ class GeomOpt(BaseCalculation):
 
         self.fmax = fmax
         self.steps = steps
+        self.symmetrize = symmetrize
         self.symmetry_tolerance = symmetry_tolerance
         self.angle_tolerance = angle_tolerance
         self.filter_func = filter_func
@@ -289,14 +296,29 @@ class GeomOpt(BaseCalculation):
 
         converged = self.dyn.run(fmax=self.fmax, steps=self.steps)
 
-        s_grp = spacegroup(self.struct, self.symmetry_tolerance, self.angle_tolerance)
-        self.struct.info["final_spacegroup"] = s_grp
-
         # Calculate current maximum force
         if self.filter_func is not None:
             max_force = linalg.norm(self.filtered_struct.get_forces(), axis=1).max()
         else:
             max_force = linalg.norm(self.struct.get_forces(), axis=1).max()
+
+        if self.symmetrize:
+            snap_symmetry(self.struct, self.symmetry_tolerance)
+
+            # Update max force
+            old_max_force = max_force
+            if self.filter_func is not None:
+                max_force = linalg.norm(self.filtered_struct.get_forces(), axis=1).max()
+            else:
+                max_force = linalg.norm(self.struct.get_forces(), axis=1).max()
+
+            if max_force >= old_max_force:
+                warnings.warn(
+                    "Refining symmetry increased the maximum force", stacklevel=2
+                )
+
+        s_grp = spacegroup(self.struct, self.symmetry_tolerance, self.angle_tolerance)
+        self.struct.info["final_spacegroup"] = s_grp
 
         if self.logger:
             self.logger.info("After optimization spacegroup: %s", s_grp)

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -278,19 +278,19 @@ class Phonons(BaseCalculation):
                     "name": self.logger.name,
                     "filemode": "a",
                 }
+
+            # Write out file by default
+            self.minimize_kwargs.setdefault("write_results", True)
+
             # If not specified otherwise, save optimized structure consistently with
             # other phonon output files
             opt_file = self._build_filename("opt.extxyz")
-
             if "write_kwargs" in self.minimize_kwargs:
                 # Use _build_filename even if given filename to ensure directory exists
                 self.minimize_kwargs["write_kwargs"].setdefault("filename", None)
                 self.minimize_kwargs["write_kwargs"]["filename"] = self._build_filename(
                     "", filename=self.minimize_kwargs["write_kwargs"]["filename"]
                 ).absolute()
-
-                # Assume if write_kwargs are specified that results should be written
-                self.minimize_kwargs.setdefault("write_results", True)
             else:
                 self.minimize_kwargs["write_kwargs"] = {"filename": opt_file}
 

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -63,7 +63,7 @@ class Phonons(BaseCalculation):
     mesh : tuple[int, int, int]
         Mesh for sampling. Default is (10, 10, 10).
     symmetrize : bool
-        Whether to symmetrize force constants after calculation.
+        Whether to symmetrize structure and force constants after calculation.
         Default is False.
     minimize : bool
         Whether to perform geometry optimisation before calculating phonons.
@@ -195,7 +195,7 @@ class Phonons(BaseCalculation):
         mesh : tuple[int, int, int]
             Mesh for sampling. Default is (10, 10, 10).
         symmetrize : bool
-            Whether to symmetrize force constants after calculations.
+            Whether to symmetrize structure and force constants after calculation.
             Default is False.
         minimize : bool
             Whether to perform geometry optimisation before calculating phonons.
@@ -293,6 +293,9 @@ class Phonons(BaseCalculation):
                 self.minimize_kwargs.setdefault("write_results", True)
             else:
                 self.minimize_kwargs["write_kwargs"] = {"filename": opt_file}
+
+            if self.symmetrize:
+                self.minimize_kwargs.setdefault("symmetrize", True)
 
         self.calc = self.struct.calc
         self.results = {}

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -129,6 +129,15 @@ def geomopt(
     pressure: Annotated[
         float, Option(help="Scalar pressure when optimizing cell geometry, in GPa.")
     ] = 0.0,
+    symmetrize: Annotated[
+        bool, Option(help="Whether to refine symmetry after geometry optimization.")
+    ] = False,
+    symmetry_tolerance: Annotated[
+        float,
+        Option(
+            help="Atom displacement tolerance for spglib symmetry determination, in Å."
+        ),
+    ] = 0.001,
     out: Annotated[
         Optional[Path],
         Option(
@@ -185,6 +194,11 @@ def geomopt(
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
         function if either `opt_cell_lengths` or `opt_cell_fully` is True. Default is
         0.0.
+    symmetrize : bool
+        Whether to refine symmetry after geometry optimization. Default is False.
+    symmetry_tolerance : float
+        Atom displacement tolerance for spglib symmetry determination, in Å.
+        Default is 0.001.
     out : Optional[Path]
         Path to save optimized structure, or last structure if optimization did not
         converge. Default is inferred from name of structure file.
@@ -255,6 +269,8 @@ def geomopt(
         "optimizer": optimizer,
         "fmax": fmax,
         "steps": steps,
+        "symmetrize": symmetrize,
+        "symmetry_tolerance": symmetry_tolerance,
         **opt_cell_fully_dict,
         **minimize_kwargs,
         "write_results": True,

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, Optional, TextIO, Union, get_args
 from ase import Atoms
 from ase.io import read, write
 from ase.io.formats import filetype
+from ase.spacegroup.symmetrize import refine_symmetry
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -194,6 +195,21 @@ def spacegroup(
         symprec=sym_tolerance,
         angle_tolerance=angle_tolerance,
     )
+
+
+def snap_symmetry(struct: Atoms, sym_tolerance: float = 0.001) -> None:
+    """
+    Refine symmetry of structure.
+
+    Parameters
+    ----------
+    struct : Atoms
+        Structure as an ase Atoms object.
+    sym_tolerance : float
+        Atom displacement tolerance for spglib symmetry determination, in Å.
+        Default is 0.001.
+    """
+    refine_symmetry(struct, symprec=sym_tolerance, verbose=False)
 
 
 def none_to_dict(dictionaries: Sequence[Optional[dict]]) -> Generator[dict, None, None]:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -199,7 +199,7 @@ def spacegroup(
 
 def snap_symmetry(struct: Atoms, sym_tolerance: float = 0.001) -> None:
     """
-    Refine symmetry of structure.
+    Symmetrize structure's cell vectors and atomic positions.
 
     Parameters
     ----------

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -651,3 +651,61 @@ def test_reuse_output(tmp_path):
     assert result.exit_code == 0
     results_2 = read(results_path_2)
     assert results_1.positions != pytest.approx(results_2.positions)
+
+
+def test_symmetrize(tmp_path):
+    """Test symmetrizing final structure."""
+    results_path_1 = tmp_path / "test" / "NaCl-opt-1.extxyz"
+    results_path_2 = tmp_path / "test" / "NaCl-opt-2.extxyz"
+    log_path = tmp_path / "test.log"
+    summary_path = tmp_path / "summary.yml"
+
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            DATA_PATH / "NaCl-deformed.cif",
+            "--fmax",
+            0.001,
+            "--out",
+            results_path_1,
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+    results_1 = read(results_path_1)
+
+    result = runner.invoke(
+        app,
+        [
+            "geomopt",
+            "--struct",
+            results_path_1,
+            "--fmax",
+            0.001,
+            "--out",
+            results_path_2,
+            "--symmetrize",
+            "--log",
+            log_path,
+            "--summary",
+            summary_path,
+        ],
+    )
+    assert result.exit_code == 0
+    results_2 = read(results_path_2)
+    assert results_1.positions != pytest.approx(results_2.positions)
+
+    expected = [
+        5.619999999999999,
+        5.619999999999999,
+        5.619999999999999,
+        89.00000000000003,
+        90.0,
+        90.0,
+    ]
+    assert results_2.cell.cellpar() == pytest.approx(expected)

--- a/tests/test_phonons.py
+++ b/tests/test_phonons.py
@@ -99,3 +99,35 @@ def test_logging(tmp_path):
 
     assert log_file.exists()
     assert single_point.struct.info["emissions"] > 0
+
+
+def test_symmetrize(tmp_path):
+    """Test symmetrize."""
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl-deformed.cif",
+        arch="mace_mp",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+
+    phonons_1 = Phonons(
+        struct=single_point.struct.copy(),
+        write_results=False,
+        minimize=True,
+        minimize_kwargs={"fmax": 0.001},
+        symmetrize=False,
+    )
+    phonons_1.calc_force_constants()
+
+    phonons_2 = Phonons(
+        struct=single_point.struct.copy(),
+        write_results=False,
+        minimize=True,
+        minimize_kwargs={"fmax": 0.001},
+        symmetrize=True,
+    )
+    phonons_2.calc_force_constants()
+
+    assert phonons_1.struct.positions != pytest.approx(phonons_2.struct.positions)
+    assert phonons_1.results["phonon"].forces != pytest.approx(
+        phonons_2.results["phonon"].forces
+    )


### PR DESCRIPTION
Address part of #310

- Adds `snap_symmetry` function to utils, currently used explicitly in geom_opt, and indirectly for phonons
  - Currently this only applies after optimization. As discussed with @oerc0122 and others, it may also be useful to apply this before optimization, but I'm not sure if that should be built in to this, or simply an option via the Python utils, which this allows
- Change defaults to save optimized file automatically
- ~Add displacement_kwargs, passed to `generate_displacements`~

These could arguably be three separate PRs, but the latter two will be useful for testing `snap_symmetry` (e.g. setting the `seed`), so I've kept them together for now.



To do:

- [x] Add tests