### PR TITLE
Add lazy imports for CLI and calculators

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -203,7 +203,9 @@ nitpick_ignore = [
     ("py:class", "Architectures"),
     ("py:class", "Devices"),
     ("py:class", "MaybeSequence"),
+    ("py:class", "PathLike"),
     ("py:class", "Atoms"),
+    ("py:class", "Calculator"),
     ("py:class", "Context"),
     ("py:class", "Path"),
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -200,4 +200,10 @@ nitpick_ignore = [
     ("py:class", "ase.optimize.optimize.Optimizer"),
     ("py:class", "codecarbon.emissions_tracker.OfflineEmissionsTracker"),
     ("py:class", "_io.StringIO"),
+    ("py:class", "Architectures"),
+    ("py:class", "Devices"),
+    ("py:class", "MaybeSequence"),
+    ("py:class", "Atoms"),
+    ("py:class", "Context"),
+    ("py:class", "Path"),
 ]

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -6,7 +6,6 @@ from typing import Annotated, Optional
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.descriptors import Descriptors
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -18,15 +17,7 @@ from janus_core.cli.types import (
     Summary,
     WriteKwargs,
 )
-from janus_core.cli.utils import (
-    carbon_summary,
-    check_config,
-    end_summary,
-    parse_typer_dicts,
-    save_struct_calc,
-    start_summary,
-    yaml_converter_callback,
-)
+from janus_core.cli.utils import yaml_converter_callback
 
 app = Typer()
 
@@ -107,6 +98,16 @@ def descriptors(
     config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.descriptors import Descriptors
+    from janus_core.cli.utils import (
+        carbon_summary,
+        check_config,
+        end_summary,
+        parse_typer_dicts,
+        save_struct_calc,
+        start_summary,
+    )
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -6,7 +6,6 @@ from typing import Annotated, Optional, get_args
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.eos import EoS
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -19,17 +18,7 @@ from janus_core.cli.types import (
     Summary,
     WriteKwargs,
 )
-from janus_core.cli.utils import (
-    carbon_summary,
-    check_config,
-    end_summary,
-    parse_typer_dicts,
-    save_struct_calc,
-    set_read_kwargs_index,
-    start_summary,
-    yaml_converter_callback,
-)
-from janus_core.helpers.janus_types import EoSNames
+from janus_core.cli.utils import yaml_converter_callback
 
 app = Typer()
 
@@ -135,6 +124,18 @@ def eos(
     config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.eos import EoS
+    from janus_core.cli.utils import (
+        carbon_summary,
+        check_config,
+        end_summary,
+        parse_typer_dicts,
+        save_struct_calc,
+        set_read_kwargs_index,
+        start_summary,
+    )
+    from janus_core.helpers.janus_types import EoSNames
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -6,7 +6,6 @@ from typing import Annotated, Any, Optional
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.geom_opt import GeomOpt
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -19,16 +18,7 @@ from janus_core.cli.types import (
     Summary,
     WriteKwargs,
 )
-from janus_core.cli.utils import (
-    carbon_summary,
-    check_config,
-    end_summary,
-    parse_typer_dicts,
-    save_struct_calc,
-    set_read_kwargs_index,
-    start_summary,
-    yaml_converter_callback,
-)
+from janus_core.cli.utils import yaml_converter_callback
 
 app = Typer()
 
@@ -222,6 +212,17 @@ def geomopt(
     config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.geom_opt import GeomOpt
+    from janus_core.cli.utils import (
+        carbon_summary,
+        check_config,
+        end_summary,
+        parse_typer_dicts,
+        save_struct_calc,
+        set_read_kwargs_index,
+        start_summary,
+    )
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -6,7 +6,6 @@ from typing import Annotated, Optional, get_args
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_NH
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -21,17 +20,7 @@ from janus_core.cli.types import (
     Summary,
     WriteKwargs,
 )
-from janus_core.cli.utils import (
-    carbon_summary,
-    check_config,
-    end_summary,
-    parse_typer_dicts,
-    save_struct_calc,
-    set_read_kwargs_index,
-    start_summary,
-    yaml_converter_callback,
-)
-from janus_core.helpers.janus_types import Ensembles
+from janus_core.cli.utils import yaml_converter_callback
 
 app = Typer()
 
@@ -298,6 +287,18 @@ def md(
     config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_NH
+    from janus_core.cli.utils import (
+        carbon_summary,
+        check_config,
+        end_summary,
+        parse_typer_dicts,
+        save_struct_calc,
+        set_read_kwargs_index,
+        start_summary,
+    )
+    from janus_core.helpers.janus_types import Ensembles
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -6,7 +6,6 @@ from typing import Annotated, Optional
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.phonons import Phonons
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -18,17 +17,7 @@ from janus_core.cli.types import (
     StructPath,
     Summary,
 )
-from janus_core.cli.utils import (
-    carbon_summary,
-    check_config,
-    dict_tuples_to_lists,
-    end_summary,
-    parse_typer_dicts,
-    save_struct_calc,
-    set_read_kwargs_index,
-    start_summary,
-    yaml_converter_callback,
-)
+from janus_core.cli.utils import yaml_converter_callback
 
 app = Typer()
 
@@ -184,6 +173,18 @@ def phonons(
     config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.phonons import Phonons
+    from janus_core.cli.utils import (
+        carbon_summary,
+        check_config,
+        dict_tuples_to_lists,
+        end_summary,
+        parse_typer_dicts,
+        save_struct_calc,
+        set_read_kwargs_index,
+        start_summary,
+    )
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -6,7 +6,6 @@ from typing import Annotated, Optional
 from typer import Context, Option, Typer
 from typer_config import use_config
 
-from janus_core.calculations.single_point import SinglePoint
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
@@ -18,15 +17,7 @@ from janus_core.cli.types import (
     Summary,
     WriteKwargs,
 )
-from janus_core.cli.utils import (
-    carbon_summary,
-    check_config,
-    end_summary,
-    parse_typer_dicts,
-    save_struct_calc,
-    start_summary,
-    yaml_converter_callback,
-)
+from janus_core.cli.utils import yaml_converter_callback
 
 app = Typer()
 
@@ -100,6 +91,16 @@ def singlepoint(
     config : Optional[Path]
         Path to yaml configuration file to define the above options. Default is None.
     """
+    from janus_core.calculations.single_point import SinglePoint
+    from janus_core.cli.utils import (
+        carbon_summary,
+        check_config,
+        end_summary,
+        parse_typer_dicts,
+        save_struct_calc,
+        start_summary,
+    )
+
     # Check options from configuration file are all valid
     check_config(ctx)
 

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -6,9 +6,6 @@ from typing import Annotated
 from typer import Option, Typer
 import yaml
 
-from janus_core.cli.utils import carbon_summary, end_summary, start_summary
-from janus_core.helpers.train import train as run_train
-
 app = Typer()
 
 
@@ -45,6 +42,9 @@ def train(
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is Path("train-summary.yml").
     """
+    from janus_core.cli.utils import carbon_summary, end_summary, start_summary
+    from janus_core.helpers.train import train as run_train
+
     with open(mlip_config, encoding="utf8") as config_file:
         config = yaml.safe_load(config_file)
 

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -12,13 +12,13 @@ if TYPE_CHECKING:
     from janus_core.helpers.janus_types import ASEReadArgs
 
 
-def parse_dict_class(value: str | ASEReadArgs):
+def parse_dict_class(value: str | ASEReadArgs) -> TyperDict:
     """
     Convert string input into a dictionary.
 
     Parameters
     ----------
-    value : str
+    value : str | ASEReadArgs
         String representing dictionary to be parsed.
 
     Returns

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -1,15 +1,18 @@
 """Module containing types used for Janus-Core CLI."""
 
+from __future__ import annotations
+
 import ast
 from pathlib import Path
-from typing import Annotated, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Optional
 
 from typer import Option
 
-from janus_core.helpers.janus_types import ASEReadArgs
+if TYPE_CHECKING:
+    from janus_core.helpers.janus_types import ASEReadArgs
 
 
-def parse_dict_class(value: Union[str, ASEReadArgs]):
+def parse_dict_class(value: str | ASEReadArgs):
     """
     Convert string input into a dictionary.
 

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -1,23 +1,27 @@
 """Utility functions for CLI."""
 
+from __future__ import annotations
+
 from collections.abc import Sequence
 import datetime
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ase import Atoms
-from typer import Context
 from typer_config import conf_callback_factory, yaml_loader
 import yaml
 
-from janus_core.cli.types import TyperDict
-from janus_core.helpers.janus_types import (
-    Architectures,
-    ASEReadArgs,
-    Devices,
-    MaybeSequence,
-)
+if TYPE_CHECKING:
+    from ase import Atoms
+    from typer import Context
+
+    from janus_core.cli.types import TyperDict
+    from janus_core.helpers.janus_types import (
+        Architectures,
+        ASEReadArgs,
+        Devices,
+        MaybeSequence,
+    )
 
 
 def dict_paths_to_strs(dictionary: dict) -> None:
@@ -246,6 +250,8 @@ def save_struct_calc(
     log : Path
         Path to log file.
     """
+    from ase import Atoms
+
     # Clean up duplicate parameters
     for key in (
         "struct",

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -6,19 +6,22 @@ Similar in spirit to matcalc and quacc approaches
 - https://github.com/Quantum-Accelerators/quacc.git
 """
 
-from pathlib import Path
-from typing import Any, Optional, Union, get_args
+from __future__ import annotations
 
-from ase.calculators.calculator import Calculator
-import torch
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, get_args
 
 from janus_core.helpers.janus_types import Architectures, Devices, PathLike
 
+if TYPE_CHECKING:
+    from ase.calculators.calculator import Calculator
+    import torch
+
 
 def _set_model_path(
-    model_path: Optional[PathLike] = None,
-    kwargs: Optional[dict[str, Any]] = None,
-) -> Optional[Union[PathLike, torch.nn.Module]]:
+    model_path: PathLike | None = None,
+    kwargs: dict[str, Any] | None = None,
+) -> PathLike | torch.nn.Module | None:
     """
     Set `model_path`.
 
@@ -31,7 +34,7 @@ def _set_model_path(
 
     Returns
     -------
-    Optional[Union[PathLike, torch.nn.Module]]
+    Optional[PathLike | torch.nn.Module]
         Path to MLIP model file, loaded model, or None.
     """
     kwargs = kwargs if kwargs else {}
@@ -66,7 +69,7 @@ def _set_model_path(
 def choose_calculator(
     arch: Architectures = "mace",
     device: Devices = "cpu",
-    model_path: Optional[PathLike] = None,
+    model_path: PathLike | None = None,
     **kwargs,
 ) -> Calculator:
     """
@@ -139,6 +142,7 @@ def choose_calculator(
         from matgl import __version__, load_model
         from matgl.apps.pes import Potential
         from matgl.ext.ase import M3GNetCalculator
+        import torch
 
         # Set before loading model to avoid type mismatches
         torch.set_default_dtype(torch.float32)
@@ -163,6 +167,7 @@ def choose_calculator(
         from chgnet import __version__
         from chgnet.model.dynamics import CHGNetCalculator
         from chgnet.model.model import CHGNet
+        import torch
 
         # Set before loading to avoid type mismatches
         torch.set_default_dtype(torch.float32)


### PR DESCRIPTION
Resolves #267

A lot of this has turned out to be similar to #272. I hadn't appreciated that our current structure with individual modules for each command (`janus_core.cli.singlepoint` etc.) meant that we actually already shared a lot of the structure with the solutions I linked, but to get their benefits we still need to move imports into the `@app.command()` functions.

I think moving `from janus_core.calculations.single_point import SinglePoint` etc. into these functions is all we really need for a much more responsive CLI, but I also moved the utils imports to keep the required CLI command modules as clean as possible.

I've then added `TYPE_CHECKING` for the the CLI types and utils, to minimize imports needed for defining the CLI options, without need to worry too much about other parts of `janus_core`.

Finally, I also added `TYPE_CHECKING` for `torch` and `Calculator` in `mlip_calculators.py`. In general, I didn't want to worry about, and I'm not sure there would be huge benefits, to lazy imports throughout the rest of the code base, particularly in `calculations` modules, but in this case we already have imports specific to each MLIP, and `torch` can be particularly slow, so I think it's reasonable.

Note: sphinx doesn't seem to play very well with `TYPE_CHECKING`, so the `nitpick_ignore` has grown quite a lot, but I couldn't find any ways around it for most cases. I think for `Path`, using `pathlib.Path` may be a solution, but I didn't want to define it differently in a single file to everywhere else.