### PR TITLE
Fix badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Contributors to this project were funded by
 [![CoSeC](https://raw.githubusercontent.com/stfc/janus-core/main/docs/source/images/cosec-100.webp)](https://www.scd.stfc.ac.uk/Pages/CoSeC.aspx)
 
 
-[ci-badge]: https://github.com/stfc/janus-core/workflows/ci/badge.svg
+[ci-badge]: https://github.com/stfc/janus-core/workflows/ci/badge.svg?branch=main
 [ci-link]: https://github.com/stfc/janus-core/actions
 [cov-badge]: https://coveralls.io/repos/github/stfc/janus-core/badge.svg?branch=main
 [cov-link]: https://coveralls.io/github/stfc/janus-core?branch=main

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Contributors to this project were funded by
 [![CoSeC](https://raw.githubusercontent.com/stfc/janus-core/main/docs/source/images/cosec-100.webp)](https://www.scd.stfc.ac.uk/Pages/CoSeC.aspx)
 
 
-[ci-badge]: https://github.com/stfc/janus-core/actions/workflows/ci.yml/badge.svg?branch=main
+[ci-badge]: https://github.com/stfc/janus-core/actions/workflows/ci.yml/badge.svg?branch=253-vaf-lags
 [ci-link]: https://github.com/stfc/janus-core/actions
 [cov-badge]: https://coveralls.io/repos/github/stfc/janus-core/badge.svg?branch=main
 [cov-link]: https://coveralls.io/github/stfc/janus-core?branch=main

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Contributors to this project were funded by
 [![CoSeC](https://raw.githubusercontent.com/stfc/janus-core/main/docs/source/images/cosec-100.webp)](https://www.scd.stfc.ac.uk/Pages/CoSeC.aspx)
 
 
-[ci-badge]: https://github.com/stfc/janus-core/workflows/ci/badge.svg?branch=main
+[ci-badge]: https://github.com/stfc/janus-core/actions/workflows/ci.yml/badge.svg?branch=main
 [ci-link]: https://github.com/stfc/janus-core/actions
 [cov-badge]: https://coveralls.io/repos/github/stfc/janus-core/badge.svg?branch=main
 [cov-link]: https://coveralls.io/github/stfc/janus-core?branch=main

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Contributors to this project were funded by
 [![CoSeC](https://raw.githubusercontent.com/stfc/janus-core/main/docs/source/images/cosec-100.webp)](https://www.scd.stfc.ac.uk/Pages/CoSeC.aspx)
 
 
-[ci-badge]: https://github.com/stfc/janus-core/actions/workflows/ci.yml/badge.svg?branch=253-vaf-lags
+[ci-badge]: https://github.com/stfc/janus-core/actions/workflows/ci.yml/badge.svg?branch=main
 [ci-link]: https://github.com/stfc/janus-core/actions
 [cov-badge]: https://coveralls.io/repos/github/stfc/janus-core/badge.svg?branch=main
 [cov-link]: https://coveralls.io/github/stfc/janus-core?branch=main


### PR DESCRIPTION
Based on https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-branch-parameter, this should mean the badge only reflects the status of `main`, rather than the most recent tests on any branch.

It seems to show as passing on my fork (and failing when I explicitly changed branch).