### PR TITLE
Update sevenn

### DIFF
--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -207,8 +207,7 @@ def choose_calculator(
         calculator = AlignnAtomwiseCalculator(path=path, device=device, **kwargs)
 
     elif arch == "sevennet":
-        # Disable constant-imported-as-non-constant
-        from sevenn._const import SEVENN_VERSION as __version__  # noqa: N811
+        from sevenn import __version__
         from sevenn.sevennet_calculator import SevenNetCalculator
 
         if isinstance(model_path, Path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ alignn = { version = "2024.5.27", optional = true }
 chgnet = {version = "0.3.8", optional = true}
 dgl = { version = "2.1.0", optional = true } # Pin due to matgl installation issues
 matgl = { version = "1.1.3", optional = true}
-sevenn = { version = "0.9.3", optional = true }
+sevenn = { version = "0.10.0", optional = true }
 torchdata = {version = "0.7.1", optional = true} # Pin due to dgl issue
 torch_geometric = { version = "^2.5.3", optional = true }
 ruff = "^0.5.7"


### PR DESCRIPTION
The version of sevennet we currently use is [yanked](https://pypi.org/project/sevenn/0.9.3/#history), and the update also includes various [fixes/updates](https://github.com/MDIL-SNU/SevenNet/releases/tag/v0.10.0).