### PR TITLE
Update sevennet version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Tools for machine learnt interatomic potentials
 - mace-torch = 0.3.6
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
-- sevenn = 0.9.3 (optional)
+- sevenn = 0.10.0 (optional)
 - alignn = 2024.5.27 (optional)
 
 All required and optional dependencies can be found in [pyproject.toml](pyproject.toml).

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -18,7 +18,7 @@ New MLIPs should be added as optional dependencies under ``[tool.poetry.dependen
 
     [tool.poetry.dependencies]
     alignn = { version = "2024.5.27", optional = true }
-    sevenn = { version = "0.9.3", optional = true }
+    sevenn = { version = "0.10.0", optional = true }
     torch_geometric = { version = "^2.5.3", optional = true }
 
     [tool.poetry.extras]

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -12,7 +12,7 @@ Dependencies
 - mace-torch = 0.3.6
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
-- sevenn = 0.9.3 (optional)
+- sevenn = 0.10.0 (optional)
 - alignn = 2024.5.27 (optional)
 
 All required and optional dependencies can be found in `pyproject.toml <https://github.com/stfc/janus-core/blob/main/pyproject.toml>`_.


### PR DESCRIPTION
Should have been part of #337 really.

For future reference, `tutorial.rst` doesn't necessarily need updating, since it's just an example, but the README and getting started should be consistent with current requirements.