### PR TITLE
Add calculator lists

### DIFF
--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -30,17 +30,17 @@ class BaseCalculation(FileNameMixin):
     struct_path : Optional[PathLike]
         Path of structure to simulate. Required if `struct` is None.
         Default is None.
-    arch : Architectures
+    arch : MaybeSequence[Architectures]
         MLIP architecture to use for calculations. Default is "mace_mp".
-    device : Devices
+    device : MaybeSequence[Devices]
         Device to run model on. Default is "cpu".
-    model_path : Optional[PathLike]
+    model_path : Optional[MaybeSequence[PathLike]]
         Path to MLIP model. Default is `None`.
     read_kwargs : ASEReadArgs
         Keyword arguments to pass to ase.io.read. Default is {}.
     sequence_allowed : bool
         Whether a sequence of Atoms objects is allowed. Default is True.
-    calc_kwargs : Optional[dict[str, Any]]
+    calc_kwargs : Optional[MaybeSequence[dict[str, Any]]]
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : Optional[bool]
         Whether to set (new) calculators for structures. Default is None.
@@ -73,12 +73,12 @@ class BaseCalculation(FileNameMixin):
         calc_name: str = "base",
         struct: Optional[MaybeSequence[Atoms]] = None,
         struct_path: Optional[PathLike] = None,
-        arch: Architectures = "mace_mp",
-        device: Devices = "cpu",
-        model_path: Optional[PathLike] = None,
+        arch: MaybeSequence[Architectures] = "mace_mp",
+        device: MaybeSequence[Devices] = "cpu",
+        model_path: Optional[MaybeSequence[PathLike]] = None,
         read_kwargs: Optional[ASEReadArgs] = None,
         sequence_allowed: bool = True,
-        calc_kwargs: Optional[dict[str, Any]] = None,
+        calc_kwargs: Optional[MaybeSequence[dict[str, Any]]] = None,
         set_calc: Optional[bool] = None,
         attach_logger: bool = False,
         log_kwargs: Optional[dict[str, Any]] = None,
@@ -101,17 +101,17 @@ class BaseCalculation(FileNameMixin):
         struct_path : Optional[PathLike]
             Path of structure to simulate. Required if `struct` is None. Default is
             None.
-        arch : Architectures
+        arch : MaybeSequence[Architectures]
             MLIP architecture to use for calculations. Default is "mace_mp".
-        device : Devices
+        device : MaybeSequence[Devices]
             Device to run MLIP model on. Default is "cpu".
-        model_path : Optional[PathLike]
+        model_path : Optional[MaybeSequence[PathLike]]
             Path to MLIP model. Default is `None`.
         read_kwargs : Optional[ASEReadArgs]
             Keyword arguments to pass to ase.io.read. Default is {}.
         sequence_allowed : bool
             Whether a sequence of Atoms objects is allowed. Default is True.
-        calc_kwargs : Optional[dict[str, Any]]
+        calc_kwargs : Optional[MaybeSequence[dict[str, Any]]]
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : Optional[bool]
             Whether to set (new) calculators for structures. Default is None.

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -35,12 +35,12 @@ class SinglePoint(BaseCalculation):
     struct_path : Optional[PathLike]
         Path of structure to simulate. Required if `struct` is None.
         Default is None.
-    arch : Architectures
+    arch : MaybeSequence[Architectures]
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
-    device : Devices
+    device : MaybeSequence[Devices]
         Device to run model on. Default is "cpu".
-    model_path : Optional[PathLike]
+    model_path : Optional[MaybeSequence[PathLike]]
         Path to MLIP model. Default is `None`.
     read_kwargs : ASEReadArgs
         Keyword arguments to pass to ase.io.read. By default,
@@ -82,9 +82,9 @@ class SinglePoint(BaseCalculation):
         *,
         struct: Optional[MaybeSequence[Atoms]] = None,
         struct_path: Optional[PathLike] = None,
-        arch: Architectures = "mace_mp",
-        device: Devices = "cpu",
-        model_path: Optional[PathLike] = None,
+        arch: MaybeSequence[Architectures] = "mace_mp",
+        device: MaybeSequence[Devices] = "cpu",
+        model_path: Optional[MaybeSequence[PathLike]] = None,
         read_kwargs: Optional[ASEReadArgs] = None,
         calc_kwargs: Optional[dict[str, Any]] = None,
         set_calc: Optional[bool] = None,
@@ -107,12 +107,12 @@ class SinglePoint(BaseCalculation):
         struct_path : Optional[PathLike]
             Path of structure to simulate. Required if `struct` is None.
             Default is None.
-        arch : Architectures
+        arch : MaybeSequence[Architectures]
             MLIP architecture to use for single point calculations.
             Default is "mace_mp".
-        device : Devices
+        device : MaybeSequence[Devices]
             Device to run MLIP model on. Default is "cpu".
-        model_path : Optional[PathLike]
+        model_path : Optional[MaybeSequence[PathLike]]
             Path to MLIP model. Default is `None`.
         read_kwargs : Optional[ASEReadArgs]
             Keyword arguments to pass to ase.io.read. By default,

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -7,11 +7,11 @@ from typer import Context, Option, Typer
 from typer_config import use_config
 
 from janus_core.cli.types import (
-    Architecture,
-    CalcKwargs,
-    Device,
+    ArchitectureList,
+    CalcKwargsList,
+    DeviceList,
     LogPath,
-    ModelPath,
+    ModelPathList,
     ReadKwargsAll,
     StructPath,
     Summary,
@@ -28,9 +28,9 @@ def singlepoint(
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,
-    arch: Architecture = "mace_mp",
-    device: Device = "cpu",
-    model_path: ModelPath = None,
+    arch: ArchitectureList = ("mace_mp",),
+    device: DeviceList = ("cpu",),
+    model_path: ModelPathList = None,
     properties: Annotated[
         Optional[list[str]],
         Option(
@@ -50,7 +50,7 @@ def singlepoint(
         ),
     ] = None,
     read_kwargs: ReadKwargsAll = None,
-    calc_kwargs: CalcKwargs = None,
+    calc_kwargs: CalcKwargsList = None,
     write_kwargs: WriteKwargs = None,
     log: LogPath = None,
     tracker: Annotated[

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -72,6 +72,14 @@ Architecture = Annotated[
 Device = Annotated[Optional[str], Option(help="Device to run calculations on.")]
 ModelPath = Annotated[Optional[str], Option(help="Path to MLIP model.")]
 
+ArchitectureList = Annotated[
+    Optional[list[str]], Option(help="MLIP architecture to use for calculations.")
+]
+DeviceList = Annotated[
+    Optional[list[str]], Option(help="Device to run calculations on.")
+]
+ModelPathList = Annotated[Optional[list[str]], Option(help="Path to MLIP model.")]
+
 ReadKwargsAll = Annotated[
     Optional[TyperDict],
     Option(
@@ -104,6 +112,21 @@ ReadKwargsLast = Annotated[
 
 CalcKwargs = Annotated[
     Optional[TyperDict],
+    Option(
+        parser=parse_dict_class,
+        help=(
+            """
+            Keyword arguments to pass to selected calculator. Must be passed as a
+            dictionary wrapped in quotes, e.g. "{'key' : value}". For the default
+            architecture ('mace_mp'), "{'model':'small'}" is set unless overwritten.
+            """
+        ),
+        metavar="DICT",
+    ),
+]
+
+CalcKwargsList = Annotated[
+    Optional[list[TyperDict]],
     Option(
         parser=parse_dict_class,
         help=(

--- a/janus_core/helpers/multi_calc.py
+++ b/janus_core/helpers/multi_calc.py
@@ -1,0 +1,113 @@
+"""Define MultiCalc ASE Calculator."""
+
+from collections.abc import Sequence
+from typing import Any
+
+from ase.calculators.calculator import (
+    BaseCalculator,
+    Calculator,
+    CalculatorSetupError,
+    PropertyNotImplementedError,
+)
+
+
+class MultiCalc(BaseCalculator):
+    """
+    ASE MultiCalc class.
+
+    Parameters
+    ----------
+    calcs : Sequence[Calculator]
+        Calculators to use.
+    """
+
+    def __init__(self, calcs: Sequence[Calculator]):
+        """
+        Initialise class.
+
+        Parameters
+        ----------
+        calcs : Sequence[Calculator]
+            Calculators to use.
+        """
+        super().__init__()
+
+        if len(calcs) == 0:
+            raise CalculatorSetupError("Please provide a list of Calculators")
+
+        common_properties = set.intersection(
+            *(set(calc.implemented_properties) for calc in calcs)
+        )
+
+        self.implemented_properties = list(common_properties)
+        if not self.implemented_properties:
+            raise PropertyNotImplementedError(
+                "The provided Calculators have" " no properties in common!"
+            )
+
+        self.calcs = calcs
+
+    def __str__(self) -> str:
+        """
+        Return string representation of the calculator.
+
+        Returns
+        -------
+        str
+            String representation.
+        """
+        calcs = ", ".join(calc.__class__.__name__ for calc in self.calcs)
+        return f"{self.__class__.__name__}({calcs})"
+
+    def get_properties(self, properties, atoms) -> dict[str, Any]:
+        """
+        Get properties from each listed calculator.
+
+        Parameters
+        ----------
+        properties : list[str]
+            List of properties to be calculated.
+        atoms : Atoms
+            Atoms object to calculate properties for.
+
+        Returns
+        -------
+        dict
+            Dictionary of results.
+        """
+        results = {}
+
+        def get_property(prop: str) -> None:
+            """
+            Get property from each listed calculator.
+
+            Parameters
+            ----------
+            prop : str
+                Property to get.
+            """
+            contribs = [calc.get_property(prop, atoms) for calc in self.calcs]
+            results[prop] = contribs
+
+        for prop in properties:  # get requested properties
+            get_property(prop)
+        for prop in self.implemented_properties:  # cache all available props
+            if all(prop in calc.results for calc in self.calcs):
+                get_property(prop)
+        return results
+
+    def calculate(self, atoms, properties, system_changes) -> None:
+        """
+        Calculate properties for each calculator and return values as list.
+
+        Parameters
+        ----------
+        atoms : Atoms
+            Atoms object to calculate properties for.
+        properties : list[str]
+            List of properties to be calculated.
+        system_changes : list[str]
+            List of what has changed since last calculation.
+        """
+        self.atoms = atoms.copy()  # for caching of results
+        self.results = self.get_properties(properties, atoms)

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -166,6 +166,25 @@ def none_to_dict(dictionaries: Sequence[Optional[dict]]) -> Generator[dict, None
     yield from (dictionary if dictionary else {} for dictionary in dictionaries)
 
 
+def param_to_sequence(param: Any) -> Sequence[Any]:
+    """
+    Convert parameter to sequence.
+
+    Parameters
+    ----------
+    param : Any
+        Parameter to be converted.
+
+    Returns
+    -------
+    Sequence[Any]
+        Parameter as sequence.
+    """
+    if param is None or param == {} or isinstance(param, (str, Path)):
+        param = (param,)
+    return param
+
+
 def write_table(
     fmt: Literal["ascii", "csv"],
     file: Optional[TextIO] = None,


### PR DESCRIPTION
Starting point for one potential solution to #240

- Converts results from Atoms.get_property to list, with a value for each calculator
- Wraps calculations, to ensure torch data type is set between MLIPs
  - This would need generalising to use the correct dtype, and ideally, not to be called for non-`MultiCalc`s, e.g. for MD with one calculator, this become a huge number of unnecessary calls, although maybe extra operations have a minimal impact?

The main issue this approach has is some built in functions, such as [`get_stress`](https://wiki.fysik.dtu.dk/ase/_modules/ase/atoms.html#Atoms.get_stress), check the shape of the value returned by the calculator, which means currently this throws an error.

Without overwriting this, I'm not sure this is possible to avoid.

The main other alternative I can think of is to create copies of the `Atoms` objects, each of which has its own calculator.

The disadvantage of this would be duplication of potentially quite large amounts of data, but it would ensure all results from calculators are returned in their expected forms, so remain useable by ASE functions.

This implementation would also make it much more readily available for distributed calculations using any of the calculations e.g. MD for MACE and CHGNet with the same settings, if we wanted to offer that, eventually.

In terms of `singlepoint`, we'd want to recombine the two `Atoms` objects when writing out, but it would allow `geomopt` structures to diverge, for example