### PR TITLE
Autodoc typehints

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,10 @@ import janus_core
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "numpydoc",
+    # "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
     "sphinxcontrib.contentui",
@@ -35,8 +36,10 @@ extensions = [
 ]
 
 always_use_bars_union = True
+napoleon_include_special_with_doc = True
+napoleon_use_param = True
 
-numpydoc_validation_checks = {"all", "EX01", "SA01", "ES01"}
+numpydoc_validation_checks = {"all", "EX01", "SA01", "ES01", "PR04"}
 numpydoc_validation_exclude = {
     r"\.__weakref__$",
     r"\.__repr__$",
@@ -193,6 +196,7 @@ html_search_language = "en"
 
 # Warnings to ignore when using the -n (nitpicky) option
 # We should ignore any python built-in exception, for instance
+nitpicky = True
 nitpick_ignore = [
     ("py:class", "Logger"),
     ("py:class", "numpy.float64"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,7 +31,10 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.contentui",
     "sphinx_copybutton",
+    "sphinx_autodoc_typehints",
 ]
+
+always_use_bars_union = True
 
 numpydoc_validation_checks = {"all", "EX01", "SA01", "ES01"}
 numpydoc_validation_exclude = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,6 @@ import janus_core
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    # "numpydoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -39,43 +39,43 @@ class BaseCalculation(FileNameMixin):
 
     Parameters
     ----------
-    calc_name : str
+    calc_name
         Name of calculation being run, used for name of logger. Default is "base".
-    struct : MaybeSequence[Atoms] | None
+    struct
         ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
         Default is None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to simulate. Required if `struct` is None.
         Default is None.
-    arch : Architectures
+    arch
         MLIP architecture to use for calculations. Default is "mace_mp".
-    device : Devices
+    device
         Device to run model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : ASEReadArgs
+    read_kwargs
         Keyword arguments to pass to ase.io.read. Default is {}.
-    sequence_allowed : bool
+    sequence_allowed
         Whether a sequence of Atoms objects is allowed. Default is True.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-    file_prefix : PathLike | None
+    file_prefix
         Prefix for output filenames. Default is None.
-    additional_prefix : str | None
+    additional_prefix
         Component to add to default file_prefix (joined by hyphens). Default is None.
-    param_prefix : str | None
+    param_prefix
         Additional parameters to add to default file_prefix. Default is None.
 
     Attributes
@@ -112,44 +112,44 @@ class BaseCalculation(FileNameMixin):
 
         Parameters
         ----------
-        calc_name : str
+        calc_name
             Name of calculation being run, used for name of logger. Default is "base".
-        struct : MaybeSequence[Atoms] | None
+        struct
             ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
             Default is None.
-        struct_path : PathLike | None
+        struct_path
             Path of structure to simulate. Required if `struct` is None. Default is
             None.
-        arch : Architectures
+        arch
             MLIP architecture to use for calculations. Default is "mace_mp".
-        device : Devices
+        device
             Device to run MLIP model on. Default is "cpu".
-        model_path : PathLike | None
+        model_path
             Path to MLIP model. Default is `None`.
-        read_kwargs : ASEReadArgs | None
+        read_kwargs
             Keyword arguments to pass to ase.io.read. Default is {}.
-        sequence_allowed : bool
+        sequence_allowed
             Whether a sequence of Atoms objects is allowed. Default is True.
-        calc_kwargs : dict[str, Any] | None
+        calc_kwargs
             Keyword arguments to pass to the selected calculator. Default is {}.
-        set_calc : bool | None
+        set_calc
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool | None
+        attach_logger
             Whether to attach a logger. Default is True if "filename" is passed in
             log_kwargs, else False.
-        log_kwargs : dict[str, Any] | None
+        log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool | None
+        track_carbon
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
-        tracker_kwargs : dict[str, Any] | None
+        tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames. Default is None.
-        additional_prefix : str | None
+        additional_prefix
             Component to add to default file_prefix (joined by hyphens). Default is
             None.
-        param_prefix : str | None
+        param_prefix
             Additional parameters to add to default file_prefix. Default is None.
         """
         read_kwargs, calc_kwargs, log_kwargs, tracker_kwargs = none_to_dict(
@@ -232,7 +232,7 @@ class BaseCalculation(FileNameMixin):
 
         Parameters
         ----------
-        keys : Sequence
+        keys
             Keys for which to add units to structure info. Default is
             ("energy", "forces", "stress").
         """

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -28,44 +28,44 @@ class Descriptors(BaseCalculation):
 
     Parameters
     ----------
-    struct : MaybeSequence[Atoms] | None
+    struct
         ASE Atoms structure(s) to calculate descriptors for. Required if `struct_path`
         is None. Default is None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to calculate descriptors for. Required if `struct` is None.
         Default is None.
-    arch : Architectures
+    arch
         MLIP architecture to use for calculations. Default is "mace_mp".
-    device : Devices
+    device
         Device to run MLIP model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : ASEReadArgs | None
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is -1.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Default is True if
         attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
-    invariants_only : bool
+    invariants_only
         Whether only the invariant descriptors should be returned. Default is True.
-    calc_per_element : bool
+    calc_per_element
         Whether to calculate mean descriptors for each element. Default is False.
-    calc_per_atom : bool
+    calc_per_atom
         Whether to calculate descriptors for each atom. Default is False.
-    write_results : bool
+    write_results
         True to write out structure with results of calculations. Default is False.
-    write_kwargs : ASEWriteArgs | None
+    write_kwargs
         Keyword arguments to pass to ase.io.write if saving structure with
         results of calculations. Default is {}.
 
@@ -100,44 +100,44 @@ class Descriptors(BaseCalculation):
 
         Parameters
         ----------
-        struct : MaybeSequence[Atoms] | None
+        struct
             ASE Atoms structure(s) to calculate descriptors for. Required if
             `struct_path` is None. Default is None.
-        struct_path : PathLike | None
+        struct_path
             Path of structure to calculate descriptors for. Required if `struct` is
             None. Default is None.
-        arch : Architectures
+        arch
             MLIP architecture to use for calculations. Default is "mace_mp".
-        device : Devices
+        device
             Device to run MLIP model on. Default is "cpu".
-        model_path : PathLike | None
+        model_path
             Path to MLIP model. Default is `None`.
-        read_kwargs : ASEReadArgs | None
+        read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-        calc_kwargs : dict[str, Any] | None
+        calc_kwargs
             Keyword arguments to pass to the selected calculator. Default is {}.
-        set_calc : bool | None
+        set_calc
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool | None
+        attach_logger
             Whether to attach a logger. Default is True if "filename" is passed in
             log_kwargs, else False.
-        log_kwargs : dict[str, Any] | None
+        log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool | None
+        track_carbon
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
-        tracker_kwargs : dict[str, Any] | None
+        tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-        invariants_only : bool
+        invariants_only
             Whether only the invariant descriptors should be returned. Default is True.
-        calc_per_element : bool
+        calc_per_element
             Whether to calculate mean descriptors for each element. Default is False.
-        calc_per_atom : bool
+        calc_per_atom
             Whether to calculate descriptors for each atom. Default is False.
-        write_results : bool
+        write_results
             True to write out structure with results of calculations. Default is False.
-        write_kwargs : ASEWriteArgs | None
+        write_kwargs
             Keyword arguments to pass to ase.io.write if saving structure with
             results of calculations. Default is {}.
         """
@@ -229,7 +229,7 @@ class Descriptors(BaseCalculation):
 
         Parameters
         ----------
-        struct : Atoms
+        struct
             Structure to calculate descriptors for.
         """
         if "arch" in struct.calc.parameters:

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -31,61 +31,61 @@ class EoS(BaseCalculation):
 
     Parameters
     ----------
-    struct : Atoms | None
+    struct
         ASE Atoms structure to calculate equation of state for. Required if
         `struct_path` is None. Default is None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to calculate equation of state for. Required if `struct` is
         None. Default is None.
-    arch : Architectures
+    arch
         MLIP architecture to use for calculations. Default is "mace_mp".
-    device : Devices
+    device
         Device to run MLIP model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : ASEReadArgs | None
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is -1.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Default is True if
         attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
-    min_volume : float
+    min_volume
         Minimum volume scale factor. Default is 0.95.
-    max_volume : float
+    max_volume
         Maximum volume scale factor. Default is 1.05.
-    n_volumes : int
+    n_volumes
         Number of volumes to use. Default is 7.
-    eos_type : EoSNames
+    eos_type
         Type of fit for equation of state. Default is "birchmurnaghan".
-    minimize : bool
+    minimize
         Whether to minimize initial structure before calculations. Default is True.
-    minimize_all : bool
+    minimize_all
         Whether to optimize geometry for all generated structures. Default is False.
-    minimize_kwargs : dict[str, Any] | None
+    minimize_kwargs
         Keyword arguments to pass to optimize. Default is None.
-    write_results : bool
+    write_results
         True to write out results of equation of state calculations. Default is True.
-    write_structures : bool
+    write_structures
         True to write out all genereated structures. Default is False.
-    write_kwargs : OutputKwargs | None
+    write_kwargs
         Keyword arguments to pass to ase.io.write to save generated structures.
         Default is {}.
-    plot_to_file : bool
+    plot_to_file
         Whether to save plot equation of state to svg. Default is False.
-    plot_kwargs : dict[str, Any] | None
+    plot_kwargs
         Keyword arguments to pass to EquationOfState.plot. Default is {}.
-    file_prefix : PathLike | None
+    file_prefix
         Prefix for output filenames. Default is inferred from structure name, or
         chemical formula of the structure.
 
@@ -140,63 +140,63 @@ class EoS(BaseCalculation):
 
         Parameters
         ----------
-        struct : Atoms | None
+        struct
             ASE Atoms structure to optimize geometry for. Required if `struct_path` is
             None. Default is None.
-        struct_path : PathLike | None
+        struct_path
             Path of structure to optimize. Required if `struct` is None. Default is
             None.
-        arch : Architectures
+        arch
             MLIP architecture to use for optimization. Default is "mace_mp".
-        device : Devices
+        device
             Device to run MLIP model on. Default is "cpu".
-        model_path : PathLike | None
+        model_path
             Path to MLIP model. Default is `None`.
-        read_kwargs : ASEReadArgs | None
+        read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-        calc_kwargs : dict[str, Any] | None
+        calc_kwargs
             Keyword arguments to pass to the selected calculator. Default is {}.
-        set_calc : bool | None
+        set_calc
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool | None
+        attach_logger
             Whether to attach a logger. Default is True if "filename" is passed in
             log_kwargs, else False.
-        log_kwargs : dict[str, Any] | None
+        log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool | None
+        track_carbon
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
-        tracker_kwargs : dict[str, Any] | None
+        tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-        min_volume : float
+        min_volume
             Minimum volume scale factor. Default is 0.95.
-        max_volume : float
+        max_volume
             Maximum volume scale factor. Default is 1.05.
-        n_volumes : int
+        n_volumes
             Number of volumes to use. Default is 7.
-        eos_type : EoSNames
+        eos_type
             Type of fit for equation of state. Default is "birchmurnaghan".
-        minimize : bool
+        minimize
             Whether to minimize initial structure before calculations. Default is True.
-        minimize_all : bool
+        minimize_all
             Whether to optimize geometry for all generated structures. Default is
             False.
-        minimize_kwargs : dict[str, Any] | None
+        minimize_kwargs
             Keyword arguments to pass to optimize. Default is None.
-        write_results : bool
+        write_results
             True to write out results of equation of state calculations. Default is
             True.
-        write_structures : bool
+        write_structures
             True to write out all genereated structures. Default is False.
-        write_kwargs : OutputKwargs | None
+        write_kwargs
             Keyword arguments to pass to ase.io.write to save generated structures.
             Default is {}.
-        plot_to_file : bool
+        plot_to_file
             Whether to save plot equation of state to svg. Default is False.
-        plot_kwargs : dict[str, Any] | None
+        plot_kwargs
             Keyword arguments to pass to EquationOfState.plot. Default is {}.
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames. Default is inferred from structure name, or
             chemical formula of the structure.
         """

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -33,62 +33,62 @@ class GeomOpt(BaseCalculation):
 
     Parameters
     ----------
-    struct : Atoms | None
+    struct
         ASE Atoms structure to optimize geometry for. Required if `struct_path` is
         None. Default is None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to optimize. Required if `struct` is None. Default is None.
-    arch : Architectures
+    arch
         MLIP architecture to use for optimization. Default is "mace_mp".
-    device : Devices
+    device
         Device to run MLIP model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : ASEReadArgs | None
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is -1.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
-    fmax : float
+    fmax
         Set force convergence criteria for optimizer in units eV/Å. Default is 0.1.
-    steps : int
+    steps
         Set maximum number of optimization steps to run. Default is 1000.
-    symmetrize : bool
+    symmetrize
         Whether to refine symmetry after geometry optimization. Default is False.
-    symmetry_tolerance : float
+    symmetry_tolerance
         Atom displacement tolerance for spglib symmetry determination, in Å.
         Default is 0.001.
-    angle_tolerance : float
+    angle_tolerance
         Angle precision for spglib symmetry determination, in degrees. Default is -1.0,
         which means an internally optimized routine is used to judge symmetry.
-    filter_func : Callable | str | None
+    filter_func
         Filter function, or name of function from ase.filters to apply constraints to
         atoms. Default is `FrechetCellFilter`.
-    filter_kwargs : dict[str, Any] | None
+    filter_kwargs
         Keyword arguments to pass to filter_func. Default is {}.
-    optimizer : Callable | str
+    optimizer
         Optimization function, or name of function from ase.optimize. Default is
         `LBFGS`.
-    opt_kwargs : ASEOptArgs | None
+    opt_kwargs
         Keyword arguments to pass to optimizer. Default is {}.
-    write_results : bool
+    write_results
         True to write out optimized structure. Default is False.
-    write_kwargs : OutputKwargs | None
+    write_kwargs
         Keyword arguments to pass to ase.io.write to save optimized structure.
         Default is {}.
-    traj_kwargs : OutputKwargs | None
+    traj_kwargs
         Keyword arguments to pass to ase.io.write to save optimization trajectory.
         Must include "filename" keyword. Default is {}.
 
@@ -132,63 +132,63 @@ class GeomOpt(BaseCalculation):
 
         Parameters
         ----------
-        struct : Atoms | None
+        struct
             ASE Atoms structure to optimize geometry for. Required if `struct_path` is
             None. Default is None.
-        struct_path : PathLike | None
+        struct_path
             Path of structure to optimize. Required if `struct` is None. Default is
             None.
-        arch : Architectures
+        arch
             MLIP architecture to use for optimization. Default is "mace_mp".
-        device : Devices
+        device
             Device to run MLIP model on. Default is "cpu".
-        model_path : PathLike | None
+        model_path
             Path to MLIP model. Default is `None`.
-        read_kwargs : ASEReadArgs | None
+        read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-        calc_kwargs : dict[str, Any] | None
+        calc_kwargs
             Keyword arguments to pass to the selected calculator. Default is {}.
-        set_calc : bool | None
+        set_calc
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool
+        attach_logger
             Whether to attach a logger. Default is True if "filename" is passed in
             log_kwargs, else False.
-        log_kwargs : dict[str, Any] | None
+        log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool | None
+        track_carbon
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
-        tracker_kwargs : dict[str, Any] | None
+        tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-        fmax : float
+        fmax
             Set force convergence criteria for optimizer in units eV/Å. Default is 0.1.
-        steps : int
+        steps
             Set maximum number of optimization steps to run. Default is 1000.
-        symmetrize : bool
+        symmetrize
             Whether to refine symmetry after geometry optimization. Default is False.
-        symmetry_tolerance : float
+        symmetry_tolerance
             Atom displacement tolerance for spglib symmetry determination, in Å.
             Default is 0.001.
-        angle_tolerance : float
+        angle_tolerance
             Angle precision for spglib symmetry determination, in degrees. Default is
             -1.0, which means an internally optimized routine is used to judge symmetry.
-        filter_func : Callable | str | None
+        filter_func
             Filter function, or name of function from ase.filters to apply constraints
             to atoms. Default is `FrechetCellFilter`.
-        filter_kwargs : dict[str, Any] | None
+        filter_kwargs
             Keyword arguments to pass to filter_func. Default is {}.
-        optimizer : Callable | str
+        optimizer
             Optimization function, or name of function from ase.optimize. Default is
             `LBFGS`.
-        opt_kwargs : ASEOptArgs | None
+        opt_kwargs
             Keyword arguments to pass to optimizer. Default is {}.
-        write_results : bool
+        write_results
             True to write out optimized structure. Default is False.
-        write_kwargs : OutputKwargs | None
+        write_kwargs
             Keyword arguments to pass to ase.io.write to save optimized structure.
             Default is {}.
-        traj_kwargs : OutputKwargs | None
+        traj_kwargs
             Keyword arguments to pass to ase.io.write to save optimization trajectory.
             Must include "filename" keyword. Default is {}.
         """

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -55,107 +55,107 @@ class MolecularDynamics(BaseCalculation):
 
     Parameters
     ----------
-    struct : Atoms | None
+    struct
         ASE Atoms structure to simulate. Required if `struct_path` is None. Default is
         None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to simulate. Required if `struct` is None. Default is None.
-    arch : Architectures
+    arch
         MLIP architecture to use for simulation. Default is "mace_mp".
-    device : Devices
+    device
         Device to run MLIP model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : ASEReadArgs | None
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is -1.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
-    struct : Atoms
+    struct
         Structure to simulate.
-    ensemble : Ensembles
+    ensemble
         Name for thermodynamic ensemble. Default is None.
-    steps : int
+    steps
         Number of steps in simulation. Default is 0.
-    timestep : float
+    timestep
         Timestep for integrator, in fs. Default is 1.0.
-    temp : float
+    temp
         Temperature, in K. Default is 300.
-    equil_steps : int
+    equil_steps
         Maximum number of steps at which to perform optimization and reset velocities.
         Default is 0.
-    minimize : bool
+    minimize
         Whether to minimize structure during equilibration. Default is False.
-    minimize_every : int
+    minimize_every
         Frequency of minimizations. Default is -1, which disables minimization after
         beginning dynamics.
-    minimize_kwargs : dict[str, Any] | None
+    minimize_kwargs
         Keyword arguments to pass to geometry optimizer. Default is {}.
-    rescale_velocities : bool
+    rescale_velocities
         Whether to rescale velocities. Default is False.
-    remove_rot : bool
+    remove_rot
         Whether to remove rotation. Default is False.
-    rescale_every : int
+    rescale_every
         Frequency to rescale velocities. Default is 10.
-    file_prefix : PathLike | None
+    file_prefix
         Prefix for output filenames. Default is inferred from structure, ensemble,
         and temperature.
-    restart : bool
+    restart
         Whether restarting dynamics. Default is False.
-    restart_auto : bool
+    restart_auto
         Whether to infer restart file name if restarting dynamics. Default is True.
-    restart_stem : str
+    restart_stem
         Stem for restart file name. Default inferred from `file_prefix`.
-    restart_every : int
+    restart_every
         Frequency of steps to save restart info. Default is 1000.
-    rotate_restart : bool
+    rotate_restart
         Whether to rotate restart files. Default is False.
-    restarts_to_keep : int
+    restarts_to_keep
         Restart files to keep if rotating. Default is 4.
-    final_file : PathLike | None
+    final_file
         File to save final configuration at each temperature of similation. Default
         inferred from `file_prefix`.
-    stats_file : PathLike | None
+    stats_file
         File to save thermodynamical statistics. Default inferred from `file_prefix`.
-    stats_every : int
+    stats_every
         Frequency to output statistics. Default is 100.
-    traj_file : PathLike | None
+    traj_file
         Trajectory file to save. Default inferred from `file_prefix`.
-    traj_append : bool
+    traj_append
         Whether to append trajectory. Default is False.
-    traj_start : int
+    traj_start
         Step to start saving trajectory. Default is 0.
-    traj_every : int
+    traj_every
         Frequency of steps to save trajectory. Default is 100.
-    temp_start : float | None
+    temp_start
         Temperature to start heating, in K. Default is None, which disables heating.
-    temp_end : float | None
+    temp_end
         Maximum temperature for heating, in K. Default is None, which disables heating.
-    temp_step : float | None
+    temp_step
         Size of temperature steps when heating, in K. Default is None, which disables
         heating.
-    temp_time : float | None
+    temp_time
         Time between heating steps, in fs. Default is None, which disables heating.
-    write_kwargs : OutputKwargs | None
+    write_kwargs
         Keyword arguments to pass to `output_structs` when saving trajectory and final
         files. Default is {}.
-    post_process_kwargs : PostProcessKwargs | None
+    post_process_kwargs
         Keyword arguments to control post-processing operations.
-    correlation_kwargs : CorrelationKwargs | None
+    correlation_kwargs
         Keyword arguments to control on-the-fly correlations.
-    seed : int | None
+    seed
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.
 
@@ -233,109 +233,109 @@ class MolecularDynamics(BaseCalculation):
 
         Parameters
         ----------
-        struct : Atoms | None
+        struct
             ASE Atoms structure to simulate. Required if `struct_path` is None. Default
             is None.
-        struct_path : PathLike | None
+        struct_path
             Path of structure to simulate. Required if `struct` is None. Default is
             None.
-        arch : Architectures
+        arch
             MLIP architecture to use for simulation. Default is "mace_mp".
-        device : Devices
+        device
             Device to run MLIP model on. Default is "cpu".
-        model_path : PathLike | None
+        model_path
             Path to MLIP model. Default is `None`.
-        read_kwargs : ASEReadArgs | None
+        read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-        calc_kwargs : dict[str, Any] | None
+        calc_kwargs
             Keyword arguments to pass to the selected calculator. Default is {}.
-        set_calc : bool | None
+        set_calc
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool | None
+        attach_logger
             Whether to attach a logger. Default is True if "filename" is passed in
             log_kwargs, else False.
-        log_kwargs : dict[str, Any] | None
+        log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool | None
+        track_carbon
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
-        tracker_kwargs : dict[str, Any] | None
+        tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-        ensemble : Ensembles
+        ensemble
             Name for thermodynamic ensemble. Default is None.
-        steps : int
+        steps
             Number of steps in simulation. Default is 0.
-        timestep : float
+        timestep
             Timestep for integrator, in fs. Default is 1.0.
-        temp : float
+        temp
             Temperature, in K. Default is 300.
-        equil_steps : int
+        equil_steps
             Maximum number of steps at which to perform optimization and reset
             velocities. Default is 0.
-        minimize : bool
+        minimize
             Whether to minimize structure during equilibration. Default is False.
-        minimize_every : int
+        minimize_every
             Frequency of minimizations. Default is -1, which disables minimization
             after beginning dynamics.
-        minimize_kwargs : dict[str, Any] | None
+        minimize_kwargs
             Keyword arguments to pass to geometry optimizer. Default is {}.
-        rescale_velocities : bool
+        rescale_velocities
             Whether to rescale velocities. Default is False.
-        remove_rot : bool
+        remove_rot
             Whether to remove rotation. Default is False.
-        rescale_every : int
+        rescale_every
             Frequency to rescale velocities. Default is 10.
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames. Default is inferred from structure, ensemble,
             and temperature.
-        restart : bool
+        restart
             Whether restarting dynamics. Default is False.
-        restart_auto : bool
+        restart_auto
             Whether to infer restart file name if restarting dynamics. Default is True.
-        restart_stem : str
+        restart_stem
             Stem for restart file name. Default inferred from `file_prefix`.
-        restart_every : int
+        restart_every
             Frequency of steps to save restart info. Default is 1000.
-        rotate_restart : bool
+        rotate_restart
             Whether to rotate restart files. Default is False.
-        restarts_to_keep : int
+        restarts_to_keep
             Restart files to keep if rotating. Default is 4.
-        final_file : PathLike | None
+        final_file
             File to save final configuration at each temperature of similation. Default
             inferred from `file_prefix`.
-        stats_file : PathLike | None
+        stats_file
             File to save thermodynamical statistics. Default inferred from
             `file_prefix`.
-        stats_every : int
+        stats_every
             Frequency to output statistics. Default is 100.
-        traj_file : PathLike | None
+        traj_file
             Trajectory file to save. Default inferred from `file_prefix`.
-        traj_append : bool
+        traj_append
             Whether to append trajectory. Default is False.
-        traj_start : int
+        traj_start
             Step to start saving trajectory. Default is 0.
-        traj_every : int
+        traj_every
             Frequency of steps to save trajectory. Default is 100.
-        temp_start : float | None
+        temp_start
             Temperature to start heating, in K. Default is None, which disables
             heating.
-        temp_end : float | None
+        temp_end
             Maximum temperature for heating, in K. Default is None, which disables
             heating.
-        temp_step : float | None
+        temp_step
             Size of temperature steps when heating, in K. Default is None, which
             disables heating.
-        temp_time : float | None
+        temp_time
             Time between heating steps, in fs. Default is None, which disables heating.
-        write_kwargs : OutputKwargs | None
+        write_kwargs
             Keyword arguments to pass to `output_structs` when saving trajectory and
             final files. Default is {}.
-        post_process_kwargs : PostProcessKwargs | None
+        post_process_kwargs
             Keyword arguments to control post-processing operations.
-        correlation_kwargs : list[CorrelationKwargs] | None
+        correlation_kwargs
             Keyword arguments to control on-the-fly correlations.
-        seed : int | None
+        seed
             Random seed used by numpy.random and random functions, such as in Langevin.
             Default is None.
         """
@@ -650,7 +650,7 @@ class MolecularDynamics(BaseCalculation):
 
         Parameters
         ----------
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames on class init. If not None, param_prefix = "".
 
         Returns
@@ -1151,20 +1151,20 @@ class NPT(MolecularDynamics):
     ----------
     *args
         Additional arguments.
-    thermostat_time : float
+    thermostat_time
         Thermostat time, in fs. Default is 50.0.
-    barostat_time : float
+    barostat_time
         Barostat time, in fs. Default is 75.0.
-    bulk_modulus : float
+    bulk_modulus
         Bulk modulus, in GPa. Default is 2.0.
-    pressure : float
+    pressure
         Pressure, in GPa. Default is 0.0.
-    ensemble : Ensembles
+    ensemble
         Name for thermodynamic ensemble. Default is "npt".
-    file_prefix : PathLike | None
+    file_prefix
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
-    ensemble_kwargs : dict[str, Any] | None
+    ensemble_kwargs
         Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -1194,20 +1194,20 @@ class NPT(MolecularDynamics):
         ----------
         *args
             Additional arguments.
-        thermostat_time : float
+        thermostat_time
             Thermostat time, in fs. Default is 50.0.
-        barostat_time : float
+        barostat_time
             Barostat time, in fs. Default is 75.0.
-        bulk_modulus : float
+        bulk_modulus
             Bulk modulus, in GPa. Default is 2.0.
-        pressure : float
+        pressure
             Pressure, in GPa. Default is 0.0.
-        ensemble : Ensembles
+        ensemble
             Name for thermodynamic ensemble. Default is "npt".
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
-        ensemble_kwargs : dict[str, Any] | None
+        ensemble_kwargs
             Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
@@ -1244,7 +1244,7 @@ class NPT(MolecularDynamics):
 
         Parameters
         ----------
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames on class init. If not None, param_prefix = "".
 
         Returns
@@ -1307,11 +1307,11 @@ class NVT(MolecularDynamics):
     ----------
     *args
         Additional arguments.
-    friction : float
+    friction
         Friction coefficient in fs^-1. Default is 0.005.
-    ensemble : Ensembles
+    ensemble
         Name for thermodynamic ensemble. Default is "nvt".
-    ensemble_kwargs : dict[str, Any] | None
+    ensemble_kwargs
         Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -1337,11 +1337,11 @@ class NVT(MolecularDynamics):
         ----------
         *args
             Additional arguments.
-        friction : float
+        friction
             Friction coefficient in fs^-1. Default is 0.005.
-        ensemble : Ensembles
+        ensemble
             Name for thermodynamic ensemble. Default is "nvt".
-        ensemble_kwargs : dict[str, Any] | None
+        ensemble_kwargs
             Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
@@ -1404,9 +1404,9 @@ class NVE(MolecularDynamics):
     ----------
     *args
         Additional arguments.
-    ensemble : Ensembles
+    ensemble
         Name for thermodynamic ensemble. Default is "nve".
-    ensemble_kwargs : dict[str, Any] | None
+    ensemble_kwargs
         Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -1431,9 +1431,9 @@ class NVE(MolecularDynamics):
         ----------
         *args
             Additional arguments.
-        ensemble : Ensembles
+        ensemble
             Name for thermodynamic ensemble. Default is "nve".
-        ensemble_kwargs : dict[str, Any] | None
+        ensemble_kwargs
             Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
@@ -1457,11 +1457,11 @@ class NVT_NH(NPT):  # noqa: N801 (invalid-class-name)
     ----------
     *args
         Additional arguments.
-    thermostat_time : float
+    thermostat_time
         Thermostat time, in fs. Default is 50.0.
-    ensemble : Ensembles
+    ensemble
         Name for thermodynamic ensemble. Default is "nvt-nh".
-    ensemble_kwargs : dict[str, Any] | None
+    ensemble_kwargs
         Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -1482,11 +1482,11 @@ class NVT_NH(NPT):  # noqa: N801 (invalid-class-name)
         ----------
         *args
             Additional arguments.
-        thermostat_time : float
+        thermostat_time
             Thermostat time, in fs. Default is 50.0.
-        ensemble : Ensembles
+        ensemble
             Name for thermodynamic ensemble. Default is "nvt-nh".
-        ensemble_kwargs : dict[str, Any] | None
+        ensemble_kwargs
             Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
@@ -1547,11 +1547,11 @@ class NVT_CSVR(NVT):  # noqa: N801 (invalid-class-name)
     ----------
     *args
         Additional arguments.
-    taut : float
+    taut
         Time constant for CSVR thermostat coupling, in fs. Default is 100.0.
-    ensemble : Ensembles
+    ensemble
         Name for thermodynamic ensemble. Default is "nvt-csvr".
-    ensemble_kwargs : dict[str, Any] | None
+    ensemble_kwargs
         Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -1572,11 +1572,11 @@ class NVT_CSVR(NVT):  # noqa: N801 (invalid-class-name)
         ----------
         *args
             Additional arguments.
-        taut : float
+        taut
             Time constant for CSVR thermostat coupling, in fs. Defaylt is 100.0.
-        ensemble : Ensembles
+        ensemble
             Name for thermodynamic ensemble. Default is "nvt-csvr".
-        ensemble_kwargs : dict[str, Any] | None
+        ensemble_kwargs
             Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.
@@ -1615,18 +1615,18 @@ class NPH(NPT):
     ----------
     *args
         Additional arguments.
-    thermostat_time : float
+    thermostat_time
         Thermostat time, in fs. Default is 50.0.
-    bulk_modulus : float
+    bulk_modulus
         Bulk modulus, in GPa. Default is 2.0.
-    pressure : float
+    pressure
         Pressure, in GPa. Default is 0.0.
-    ensemble : Ensembles
+    ensemble
         Name for thermodynamic ensemble. Default is "nph".
-    file_prefix : PathLike | None
+    file_prefix
         Prefix for output filenames. Default is inferred from structure, ensemble,
         temperature, and pressure.
-    ensemble_kwargs : dict[str, Any] | None
+    ensemble_kwargs
         Keyword arguments to pass to ensemble initialization. Default is {}.
     **kwargs
         Additional keyword arguments.
@@ -1655,18 +1655,18 @@ class NPH(NPT):
         ----------
         *args
             Additional arguments.
-        thermostat_time : float
+        thermostat_time
             Thermostat time, in fs. Default is 50.0.
-        bulk_modulus : float
+        bulk_modulus
             Bulk modulus, in GPa. Default is 2.0.
-        pressure : float
+        pressure
             Pressure, in GPa. Default is 0.0.
-        ensemble : Ensembles
+        ensemble
             Name for thermodynamic ensemble. Default is "nph".
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames. Default is inferred from structure, ensemble,
             temperature, and pressure.
-        ensemble_kwargs : dict[str, Any] | None
+        ensemble_kwargs
             Keyword arguments to pass to ensemble initialization. Default is {}.
         **kwargs
             Additional keyword arguments.

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -36,38 +36,38 @@ class Phonons(BaseCalculation):
 
     Parameters
     ----------
-    struct : Atoms | None
+    struct
         ASE Atoms structure to calculate phonons for. Required if `struct_path` is
         None. Default is None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to calculate phonons for. Required if `struct` is None.
         Default is None.
-    arch : Architectures
+    arch
         MLIP architecture to use for calculations. Default is "mace_mp".
-    device : Devices
+    device
         Device to run MLIP model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : ASEReadArgs | None
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is -1.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
-    calcs : MaybeSequence[PhononCalcs] | None
+    calcs
         Phonon calculations to run. Default calculates force constants only.
-    supercell : MaybeList[int]
+    supercell
         The size of a supercell for calculation, or the supercell itself.
         If a single number is provided, it is interpreted as the size, so a
         diagonal supercell of that size in all dimensions is constructed.
@@ -76,50 +76,50 @@ class Phonons(BaseCalculation):
         are assumed to be the full supercell matrix in the style of Phonopy,
         so the first three values will be used as the first row, the second
         three as the second row, etc. Default is 2.
-    displacement : float
+    displacement
         Displacement for force constants calculation, in A. Default is 0.01.
-    displacement_kwargs : dict[str, Any] | None
+    displacement_kwargs
         Keyword arguments to pass to generate_displacements. Default is {}.
-    mesh : tuple[int, int, int]
+    mesh
         Mesh for sampling. Default is (10, 10, 10).
-    symmetrize : bool
+    symmetrize
         Whether to symmetrize structure and force constants after calculation.
         Default is False.
-    minimize : bool
+    minimize
         Whether to perform geometry optimisation before calculating phonons.
         Default is False.
-    minimize_kwargs : dict[str, Any] | None
+    minimize_kwargs
         Keyword arguments to pass to geometry optimizer. Default is {}.
-    n_qpoints : int
+    n_qpoints
         Number of q-points to sample along generated path, including end points.
         Unused if `qpoint_file` is specified. Default is 51.
-    qpoint_file : PathLike | None
+    qpoint_file
         Path to yaml file with info to generate a path of q-points for band structure.
         Default is None.
-    dos_kwargs : dict[str, Any] | None
+    dos_kwargs
         Keyword arguments to pass to run_total_dos. Default is {}.
-    pdos_kwargs : dict[str, Any] | None
+    pdos_kwargs
         Keyword arguments to pass to run_projected_dos. Default is {}.
-    temp_min : float
+    temp_min
         Start temperature for thermal properties calculations, in K. Default is 0.0.
-    temp_max : float
+    temp_max
         End temperature for thermal properties calculations, in K. Default is 1000.0.
-    temp_step : float
+    temp_step
         Temperature step for thermal properties calculations, in K. Default is 50.0.
-    force_consts_to_hdf5 : bool
+    force_consts_to_hdf5
         Whether to write force constants in hdf format or not. Default is True.
-    plot_to_file : bool
+    plot_to_file
         Whether to plot various graphs as band stuctures, dos/pdos in svg.
         Default is False.
-    write_results : bool
+    write_results
         Default for whether to write out results to file. Default is True.
-    write_full : bool
+    write_full
         Whether to maximize information written in various output files.
         Default is True.
-    file_prefix : PathLike | None
+    file_prefix
         Prefix for output filenames. Default is inferred from chemical formula of the
         structure.
-    enable_progress_bar : bool
+    enable_progress_bar
         Whether to show a progress bar during phonon calculations. Default is False.
 
     Attributes
@@ -196,38 +196,38 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        struct : Atoms | None
+        struct
             ASE Atoms structure to calculate phonons for. Required if `struct_path` is
             None. Default is None.
-        struct_path : PathLike | None
+        struct_path
             Path of structure to calculate phonons for. Required if `struct` is None.
             Default is None.
-        arch : Architectures
+        arch
             MLIP architecture to use for calculations. Default is "mace_mp".
-        device : Devices
+        device
             Device to run MLIP model on. Default is "cpu".
-        model_path : PathLike | None
+        model_path
             Path to MLIP model. Default is `None`.
-        read_kwargs : ASEReadArgs | None
+        read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-        calc_kwargs : dict[str, Any] | None
+        calc_kwargs
             Keyword arguments to pass to the selected calculator. Default is {}.
-        set_calc : bool | None
+        set_calc
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool | None
+        attach_logger
             Whether to attach a logger. Default is True if "filename" is passed in
             log_kwargs, else False.
-        log_kwargs : dict[str, Any] | None
+        log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool | None
+        track_carbon
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
-        tracker_kwargs : dict[str, Any] | None
+        tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-        calcs : MaybeSequence[PhononCalcs] | None
+        calcs
             Phonon calculations to run. Default calculates force constants only.
-        supercell : MaybeList[int]
+        supercell
             The size of a supercell for calculation, or the supercell itself.
             If a single number is provided, it is interpreted as the size, so a
             diagonal supercell of that size in all dimensions is constructed.
@@ -236,50 +236,50 @@ class Phonons(BaseCalculation):
             are assumed to be the full supercell matrix in the style of Phonopy,
             so the first three values will be used as the first row, the second
             three as the second row, etc. Default is 2.
-        displacement : float
+        displacement
             Displacement for force constants calculation, in A. Default is 0.01.
-        displacement_kwargs : dict[str, Any] | None
+        displacement_kwargs
             Keyword arguments to pass to generate_displacements. Default is {}.
-        mesh : tuple[int, int, int]
+        mesh
             Mesh for sampling. Default is (10, 10, 10).
-        symmetrize : bool
+        symmetrize
             Whether to symmetrize structure and force constants after calculation.
             Default is False.
-        minimize : bool
+        minimize
             Whether to perform geometry optimisation before calculating phonons.
             Default is False.
-        minimize_kwargs : dict[str, Any] | None
+        minimize_kwargs
             Keyword arguments to pass to geometry optimizer. Default is {}.
-        n_qpoints : int
+        n_qpoints
             Number of q-points to sample along generated path, including end points.
             Unused if `qpoint_file` is specified. Default is 51.
-        qpoint_file : PathLike | None
+        qpoint_file
            Path to yaml file with info to generate a path of q-points for band
            structure. Default is None.
-        dos_kwargs : dict[str, Any] | None
+        dos_kwargs
             Keyword arguments to pass to run_total_dos. Default is {}.
-        pdos_kwargs : dict[str, Any] | None
+        pdos_kwargs
             Keyword arguments to pass to run_projected_dos. Default is {}.
-        temp_min : float
+        temp_min
             Start temperature for thermal calculations, in K. Default is 0.0.
-        temp_max : float
+        temp_max
             End temperature for thermal calculations, in K. Default is 1000.0.
-        temp_step : float
+        temp_step
             Temperature step for thermal calculations, in K. Default is 50.0.
-        force_consts_to_hdf5 : bool
+        force_consts_to_hdf5
             Whether to write force constants in hdf format or not. Default is True.
-        plot_to_file : bool
+        plot_to_file
             Whether to plot various graphs as band stuctures, dos/pdos in svg.
             Default is False.
-        write_results : bool
+        write_results
             Default for whether to write out results to file. Default is True.
-        write_full : bool
+        write_full
             Whether to maximize information written in various output files.
             Default is True.
-        file_prefix : PathLike | None
+        file_prefix
             Prefix for output filenames. Default is inferred from structure name, or
             chemical formula of the structure.
-        enable_progress_bar : bool
+        enable_progress_bar
             Whether to show a progress bar during phonon calculations. Default is False.
         """
         read_kwargs, displacement_kwargs, minimize_kwargs, dos_kwargs, pdos_kwargs = (
@@ -397,7 +397,7 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        value : MaybeSequence[PhononCalcs]
+        value
             Phonon calculations to be run.
         """
         if isinstance(value, str):
@@ -423,7 +423,7 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        write_force_consts : bool | None
+        write_force_consts
             Whether to write out results to file. Default is self.write_results.
         **kwargs
             Additional keyword arguments to pass to `write_force_constants`.
@@ -503,13 +503,13 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        phonopy_file : PathLike | None
+        phonopy_file
             Name of yaml file to save params of phonopy and optionally force constants.
             Default is inferred from `file_prefix`.
-        force_consts_to_hdf5 : bool | None
+        force_consts_to_hdf5
             Whether to save the force constants separately to an hdf5 file. Default is
             self.force_consts_to_hdf5.
-        force_consts_file : PathLike | None
+        force_consts_file
             Name of hdf5 file to save force constants. Unused if `force_consts_to_hdf5`
             is False. Default is inferred from `file_prefix`.
         """
@@ -543,7 +543,7 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        write_bands : bool | None
+        write_bands
             Whether to write out results to file. Default is self.write_results.
         **kwargs
             Additional keyword arguments to pass to `write_bands`.
@@ -571,12 +571,12 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        bands_file : PathLike | None
+        bands_file
             Name of yaml file to save band structure. Default is inferred from
             `file_prefix`.
-        save_plots : bool | None
+        save_plots
             Whether to save plot to file. Default is self.plot_to_file.
-        plot_file : PathLike | None
+        plot_file
             Name of svg file if saving band structure plot. Default is inferred from
             `file_prefix`.
         """
@@ -640,9 +640,9 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        mesh : tuple[int, int, int] | None
+        mesh
             Mesh for sampling. Default is self.mesh.
-        write_thermal : bool | None
+        write_thermal
             Whether to write out thermal properties to file. Default is
             self.write_results.
         **kwargs
@@ -688,7 +688,7 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        thermal_file : PathLike | None
+        thermal_file
             Name of data file to save thermal properties. Default is inferred from
             `file_prefix`.
         """
@@ -707,9 +707,9 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        mesh : tuple[int, int, int] | None
+        mesh
             Mesh for sampling. Default is self.mesh.
-        write_dos : bool | None
+        write_dos
             Whether to write out results to file. Default is True.
         **kwargs
             Additional keyword arguments to pass to `write_dos`.
@@ -757,17 +757,17 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        dos_file : PathLike | None
+        dos_file
             Name of data file to save the calculated DOS. Default is inferred from
             `file_prefix`.
-        plot_to_file : bool | None
+        plot_to_file
             Whether to save plot to file. Default is self.plot_to_file.
-        plot_file : PathLike | None
+        plot_file
             Name of svg file if saving plot of the DOS. Default is inferred from
             `file_prefix`.
-        plot_bands : bool
+        plot_bands
             Whether to plot the band structure and DOS together. Default is True.
-        plot_bands_file : PathLike | None
+        plot_bands_file
             Name of svg file if saving plot of the band structure and DOS.
             Default is inferred from `file_prefix`.
         """
@@ -814,9 +814,9 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        mesh : tuple[int, int, int] | None
+        mesh
             Mesh for sampling. Default is self.mesh.
-        write_pdos : bool | None
+        write_pdos
             Whether to write out results to file. Default is self.write_results.
         **kwargs
             Additional keyword arguments to pass to `write_pdos`.
@@ -864,12 +864,12 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        pdos_file : PathLike | None
+        pdos_file
             Name of file to save the calculated PDOS. Default is inferred from
             `file_prefix`.
-        plot_to_file : bool | None
+        plot_to_file
             Whether to save plot to file. Default is self.plot_to_file.
-        plot_file : PathLike | None
+        plot_file
             Name of svg file if saving plot of the calculated PDOS. Default is inferred
             from `file_prefix`.
         """
@@ -898,7 +898,7 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        struct : PhonopyAtoms
+        struct
             PhonopyAtoms structure to be converted.
 
         Returns
@@ -922,7 +922,7 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        struct : Atoms
+        struct
             ASE Atoms structure to be converted.
 
         Returns
@@ -943,7 +943,7 @@ class Phonons(BaseCalculation):
 
         Parameters
         ----------
-        struct : PhonopyAtoms
+        struct
             Structure to calculate forces on.
 
         Returns

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -31,42 +31,42 @@ class SinglePoint(BaseCalculation):
 
     Parameters
     ----------
-    struct : MaybeSequence[Atoms] | None
+    struct
         ASE Atoms structure(s) to simulate. Required if `struct_path` is None.
         Default is None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to simulate. Required if `struct` is None.
         Default is None.
-    arch : Architectures
+    arch
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
-    device : Devices
+    device
         Device to run model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : ASEReadArgs
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is ":".
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-    properties : MaybeSequence[Properties]
+    properties
         Physical properties to calculate. If not specified, "energy",
         "forces", and "stress" will be returned.
-    write_results : bool
+    write_results
         True to write out structure with results of calculations. Default is False.
-    write_kwargs : OutputKwargs | None
+    write_kwargs
         Keyword arguments to pass to ase.io.write if saving structure with results of
         calculations. Default is {}.
 
@@ -105,42 +105,42 @@ class SinglePoint(BaseCalculation):
 
         Parameters
         ----------
-        struct : MaybeSequence[Atoms] | None
+        struct
             ASE Atoms structure(s) to simulate. Required if `struct_path`
             is None. Default is None.
-        struct_path : PathLike | None
+        struct_path
             Path of structure to simulate. Required if `struct` is None.
             Default is None.
-        arch : Architectures
+        arch
             MLIP architecture to use for single point calculations.
             Default is "mace_mp".
-        device : Devices
+        device
             Device to run MLIP model on. Default is "cpu".
-        model_path : PathLike | None
+        model_path
             Path to MLIP model. Default is `None`.
-        read_kwargs : ASEReadArgs | None
+        read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is ":".
-        calc_kwargs : dict[str, Any] | None
+        calc_kwargs
             Keyword arguments to pass to the selected calculator. Default is {}.
-        set_calc : bool | None
+        set_calc
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool | None
+        attach_logger
             Whether to attach a logger. Default is True if "filename" is passed in
             log_kwargs, else False.
-        log_kwargs : dict[str, Any] | None
+        log_kwargs
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool | None
+        track_carbon
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
-        tracker_kwargs : dict[str, Any] | None
+        tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
-        properties : MaybeSequence[Properties]
+        properties
             Physical properties to calculate. If not specified, "energy",
             "forces", and "stress" will be returned.
-        write_results : bool
+        write_results
             True to write out structure with results of calculations. Default is False.
-        write_kwargs : OutputKwargs | None
+        write_kwargs
             Keyword arguments to pass to ase.io.write if saving structure with results
             of calculations. Default is {}.
         """
@@ -201,7 +201,7 @@ class SinglePoint(BaseCalculation):
 
         Parameters
         ----------
-        value : MaybeSequence[Properties]
+        value
             Physical properties to be calculated.
         """
         if isinstance(value, str):
@@ -276,7 +276,7 @@ class SinglePoint(BaseCalculation):
 
         Parameters
         ----------
-        struct : Atoms
+        struct
             Structure to calculate Hessian for.
 
         Returns

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -68,42 +68,42 @@ def descriptors(
 
     Parameters
     ----------
-    ctx : Context
+    ctx
         Typer (Click) Context. Automatically set.
-    struct : Path
+    struct
         Path of structure to simulate.
-    invariants_only : bool
+    invariants_only
         Whether only the invariant descriptors should be returned. Default is True.
-    calc_per_element : bool
+    calc_per_element
         Whether to calculate mean descriptors for each element. Default is False.
-    calc_per_atom : bool
+    calc_per_atom
         Whether to calculate descriptors for each atom. Default is False.
-    arch : Optional[str]
+    arch
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
-    device : Optional[str]
+    device
         Device to run model on. Default is "cpu".
-    model_path : Optional[str]
+    model_path
         Path to MLIP model. Default is `None`.
-    out : Optional[Path]
+    out
         Path to save structure with calculated results. Default is inferred from name
         of the structure file.
-    read_kwargs : Optional[dict[str, Any]]
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is ":".
-    calc_kwargs : Optional[dict[str, Any]]
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    write_kwargs : Optional[dict[str, Any]]
+    write_kwargs
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is inferred from the name of the structure file.
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Optional[Path]
+    config
         Path to yaml configuration file to define the above options. Default is None.
     """
     from janus_core.calculations.descriptors import Descriptors

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -84,58 +84,58 @@ def eos(
 
     Parameters
     ----------
-    ctx : Context
+    ctx
         Typer (Click) Context. Automatically set.
-    struct : Path
+    struct
         Path of structure to simulate.
-    min_volume : float
+    min_volume
         Minimum volume scale factor. Default is 0.95.
-    max_volume : float
+    max_volume
         Maximum volume scale factor. Default is 1.05.
-    n_volumes : int
+    n_volumes
         Number of volumes to use. Default is 7.
-    eos_type : Optional[str]
+    eos_type
         Type of fit for equation of state. Default is "birchmurnaghan".
-    minimize : bool
+    minimize
         Whether to minimize initial structure before calculations. Default is True.
-    minimize_all : bool
+    minimize_all
         Whether to optimize geometry for all generated structures. Default is False.
-    fmax : float
+    fmax
         Set force convergence criteria for optimizer in units eV/Å.
         Default is 0.1.
-    minimize_kwargs : Optional[dict[str, Any]]
+    minimize_kwargs
         Other keyword arguments to pass to geometry optimizer. Default is {}.
-    write_structures : bool
+    write_structures
         True to write out all genereated structures. Default is False.
-    write_kwargs : Optional[dict[str, Any]],
+    write_kwargs
         Keyword arguments to pass to ase.io.write to save generated structures.
         Default is {}.
-    plot_to_file : bool
+    plot_to_file
         Whether to save plot equation of state to svg. Default is False.
-    arch : Optional[str]
+    arch
         MLIP architecture to use for geometry optimization.
         Default is "mace_mp".
-    device : Optional[str]
+    device
         Device to run model on. Default is "cpu".
-    model_path : Optional[str]
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : Optional[dict[str, Any]]
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-    calc_kwargs : Optional[dict[str, Any]]
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    file_prefix : Optional[PathLike]
+    file_prefix
         Prefix for output filenames. Default is inferred from structure name, or
         chemical formula.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is inferred from the name of the structure file.
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Optional[Path]
+    config
         Path to yaml configuration file to define the above options. Default is None.
     """
     from janus_core.calculations.eos import EoS

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -36,14 +36,14 @@ def _set_minimize_kwargs(
 
     Parameters
     ----------
-    minimize_kwargs : dict[str, Any]
+    minimize_kwargs
         Other keyword arguments to pass to geometry optimizer.
-    traj : Optional[str]
+    traj
         Path if saving optimization frames.
-    opt_cell_lengths : bool
+    opt_cell_lengths
         Whether to optimize cell vectors, as well as atomic positions, by setting
         `hydrostatic_strain` in the filter function.
-    pressure : float
+    pressure
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
         function if either `opt_cell_lengths` or `opt_cell_fully` is True.
     """
@@ -158,66 +158,66 @@ def geomopt(
 
     Parameters
     ----------
-    ctx : Context
+    ctx
         Typer (Click) Context. Automatically set.
-    struct : Path
+    struct
         Path of structure to simulate.
-    optimizer : Optional[str]
+    optimizer
         Name of optimization function from ase.optimize. Default is `LBFGS`.
-    fmax : float
+    fmax
         Set force convergence criteria for optimizer, in eV/Å. Default is 0.1.
-    steps : int
+    steps
         Set maximum number of optimization steps to run. Default is 1000.
-    arch : Optional[str]
+    arch
         MLIP architecture to use for geometry optimization.
         Default is "mace_mp".
-    device : Optional[str]
+    device
         Device to run model on. Default is "cpu".
-    model_path : Optional[str]
+    model_path
         Path to MLIP model. Default is `None`.
-    opt_cell_lengths : bool
+    opt_cell_lengths
         Whether to optimize cell vectors, as well as atomic positions, by setting
         `hydrostatic_strain` in the filter function. Default is False.
-    opt_cell_fully : bool
+    opt_cell_fully
         Whether to fully optimize the cell vectors, angles, and atomic positions.
         Default is False.
-    filter_func : Optional[str]
+    filter_func
         Name of filter function from ase.filters or ase.constraints, to apply
         constraints to atoms. If using --opt-cell-lengths or --opt-cell-fully, defaults
         to `FrechetCellFilter` if available, otherwise `ExpCellFilter`.
-    pressure : float
+    pressure
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
         function if either `opt_cell_lengths` or `opt_cell_fully` is True. Default is
         0.0.
-    symmetrize : bool
+    symmetrize
         Whether to refine symmetry after geometry optimization. Default is False.
-    symmetry_tolerance : float
+    symmetry_tolerance
         Atom displacement tolerance for spglib symmetry determination, in Å.
         Default is 0.001.
-    out : Optional[Path]
+    out
         Path to save optimized structure, or last structure if optimization did not
         converge. Default is inferred from name of structure file.
-    traj : Optional[str]
+    traj
         Path if saving optimization frames. Default is None.
-    read_kwargs : Optional[dict[str, Any]]
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-    calc_kwargs : Optional[dict[str, Any]]
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    minimize_kwargs : Optional[dict[str, Any]]
+    minimize_kwargs
         Other keyword arguments to pass to geometry optimizer. Default is {}.
-    write_kwargs : Optional[dict[str, Any]]
+    write_kwargs
         Keyword arguments to pass to ase.io.write when saving optimized structure.
         Default is {}.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is inferred from the name of the structure file.
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Optional[Path]
+    config
         Path to yaml configuration file to define the above options. Default is None.
     """
     from janus_core.calculations.geom_opt import GeomOpt

--- a/janus_core/cli/janus.py
+++ b/janus_core/cli/janus.py
@@ -42,7 +42,7 @@ def print_version(
 
     Parameters
     ----------
-    version : bool
+    version
         Whether to print the current janus-core version.
     """
     if version:

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -188,119 +188,119 @@ def md(
 
     Parameters
     ----------
-    ctx : Context
+    ctx
         Typer (Click) Context. Automatically set.
-    ensemble : str
+    ensemble
         Name of thermodynamic ensemble.
-    struct : Path
+    struct
         Path of structure to simulate.
-    steps : int
+    steps
         Number of steps in simulation. Default is 0.
-    timestep : float
+    timestep
         Timestep for integrator, in fs. Default is 1.0.
-    temp : float
+    temp
         Temperature, in K. Default is 300.
-    thermostat_time : float
+    thermostat_time
         Thermostat time, in fs. Default is 50.0.
-    barostat_time : float
+    barostat_time
         Barostat time, in fs. Default is 75.0.
-    bulk_modulus : float
+    bulk_modulus
         Bulk modulus, in GPa. Default is 2.0.
-    pressure : float
+    pressure
         Pressure, in GPa. Default is 0.0.
-    friction : float
+    friction
         Friction coefficient in fs^-1. Default is 0.005.
-    taut : float
+    taut
         Time constant for CSVR thermostat coupling, in fs. Default is 100.0.
-    ensemble_kwargs : Optional[dict[str, Any]]
+    ensemble_kwargs
         Keyword arguments to pass to ensemble initialization. Default is {}.
-    arch : Optional[str]
+    arch
         MLIP architecture to use for molecular dynamics.
         Default is "mace_mp".
-    device : Optional[str]
+    device
         Device to run model on. Default is "cpu".
-    model_path : Optional[str]
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : Optional[dict[str, Any]]
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
-    calc_kwargs : Optional[dict[str, Any]]
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    equil_steps : int
+    equil_steps
         Maximum number of steps at which to perform optimization and reset velocities.
         Default is 0.
-    minimize : bool
+    minimize
         Whether to minimize structure during equilibration. Default is False.
-    minimize_every : int
+    minimize_every
         Frequency of minimizations. Default is -1, which disables minimization after
         beginning dynamics.
-    minimize_kwargs : Optional[dict[str, Any]]
+    minimize_kwargs
         Keyword arguments to pass to geometry optimizer. Default is {}.
-    rescale_velocities : bool
+    rescale_velocities
         Whether to rescale velocities. Default is False.
-    remove_rot : bool
+    remove_rot
         Whether to remove rotation. Default is False.
-    rescale_every : int
+    rescale_every
         Frequency to rescale velocities. Default is 10.
-    file_prefix : Optional[PathLike]
+    file_prefix
         Prefix for output filenames. Default is inferred from structure, ensemble,
         and temperature.
-    restart : bool
+    restart
         Whether restarting dynamics. Default is False.
-    restart_auto : bool
+    restart_auto
         Whether to infer restart file name if restarting dynamics. Default is True.
-    restart_stem : str
+    restart_stem
         Stem for restart file name. Default inferred from `file_prefix`.
-    restart_every : int
+    restart_every
         Frequency of steps to save restart info. Default is 1000.
-    rotate_restart : bool
+    rotate_restart
         Whether to rotate restart files. Default is False.
-    restarts_to_keep : int
+    restarts_to_keep
         Restart files to keep if rotating. Default is 4.
-    final_file : Optional[PathLike]
+    final_file
         File to save final configuration at each temperature of similation. Default
         inferred from `file_prefix`.
-    stats_file : Optional[PathLike]
+    stats_file
         File to save thermodynamical statistics. Default inferred from `file_prefix`.
-    stats_every : int
+    stats_every
         Frequency to output statistics. Default is 100.
-    traj_file : Optional[PathLike]
+    traj_file
         Trajectory file to save. Default inferred from `file_prefix`.
-    traj_append : bool
+    traj_append
         Whether to append trajectory. Default is False.
-    traj_start : int
+    traj_start
         Step to start saving trajectory. Default is 0.
-    traj_every : int
+    traj_every
         Frequency of steps to save trajectory. Default is 100.
-    temp_start : Optional[float]
+    temp_start
         Temperature to start heating, in K. Default is None, which disables
         heating.
-    temp_end : Optional[float]
+    temp_end
         Maximum temperature for heating, in K. Default is None, which disables
         heating.
-    temp_step : Optional[float]
+    temp_step
         Size of temperature steps when heating, in K. Default is None, which disables
         heating.
-    temp_time : Optional[float]
+    temp_time
         Time between heating steps, in fs. Default is None, which disables
         heating.
-    write_kwargs : Optional[dict[str, Any]],
+    write_kwargs
         Keyword arguments to pass to `output_structs` when saving trajectory and final
         files. Default is {}.
-    post_process_kwargs : Optional[PostProcessKwargs]
+    post_process_kwargs
         Kwargs to pass to post-processing.
-    seed : Optional[int]
+    seed
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is inferred from the name of the structure file.
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Optional[Path]
+    config
         Path to yaml configuration file to define the above options. Default is None.
     """
     from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_CSVR, NVT_NH

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -143,89 +143,89 @@ def phonons(
 
     Parameters
     ----------
-    ctx : Context
+    ctx
         Typer (Click) Context. Automatically set.
-    struct : Path
+    struct
         Path of structure to simulate.
-    supercell : str
+    supercell
         Supercell matrix, in the Phonopy style. Must be passed as a string in one of
         three forms: single integer ('2'), which specifies all diagonal elements;
         three integers ('1 2 3'), which specifies each individual diagonal element;
         or nine values ('1 2 3 4 5 6 7 8 9'), which specifies all elements, filling the
         matrix row-wise.
-    displacement : float
+    displacement
         Displacement for force constants calculation, in A. Default is 0.01.
-    displacement_kwargs : Optional[dict[str, Any]]
+    displacement_kwargs
         Keyword arguments to pass to generate_displacements. Default is {}.
-    mesh : tuple[int, int, int]
+    mesh
         Mesh for sampling. Default is (10, 10, 10).
-    bands : bool
+    bands
         Whether to calculate and save the band structure. Default is False.
-    n_qpoints : int
+    n_qpoints
         Number of q-points to sample along generated path, including end points.
         Unused if `qpoint_file` is specified. Default is 51.
-    qpoint_file : Optional[PathLike]
+    qpoint_file
         Path to yaml file with info to generate a path of q-points for band structure.
         Default is None.
-    dos : bool
+    dos
         Whether to calculate and save the DOS. Default is False.
-    dos_kwargs : Optional[dict[str, Any]]
+    dos_kwargs
         Other keyword arguments to pass to run_total_dos. Default is {}.
-    pdos : bool
+    pdos
         Whether to calculate and save the PDOS. Default is False.
-    pdos_kwargs : Optional[dict[str, Any]]
+    pdos_kwargs
         Other keyword arguments to pass to run_projected_dos. Default is {}.
-    thermal : bool
+    thermal
         Whether to calculate thermal properties. Default is False.
-    temp_min : float
+    temp_min
         Start temperature for thermal calculations, in K. Unused if `thermal` is False.
         Default is 0.0.
-    temp_max : float
+    temp_max
         End temperature for thermal calculations, in K. Unused if `thermal` is False.
         Default is 1000.0.
-    temp_step : float
+    temp_step
         Temperature step for thermal calculations, in K. Unused if `thermal` is False.
         Default is 50.0.
-    symmetrize : bool
+    symmetrize
         Whether to symmetrize force constants. Default is False.
-    minimize : bool
+    minimize
         Whether to minimize structure before calculations. Default is False.
-    fmax : float
+    fmax
         Set force convergence criteria for optimizer in units eV/Å.
         Default is 0.1.
-    minimize_kwargs : Optional[dict[str, Any]]
+    minimize_kwargs
         Other keyword arguments to pass to geometry optimizer. Default is {}.
-    hdf5 : bool
+    hdf5
         Whether to save force constants in hdf5 format. Default is True.
-    plot_to_file : bool
+    plot_to_file
         Whether to plot. Default is False.
-    write_full : bool
+    write_full
         Whether to maximize information written in various output files.
         Default is True.
-    arch : Optional[str]
+    arch
         MLIP architecture to use for geometry optimization.
         Default is "mace_mp".
-    device : Optional[str]
+    device
         Device to run model on. Default is "cpu".
-    model_path : Optional[str]
+    model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs : Optional[dict[str, Any]]
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is 0.
-    calc_kwargs : Optional[dict[str, Any]]
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    file_prefix : Optional[PathLike]
+    file_prefix
         Prefix for output filenames. Default is inferred from structure name, or
         chemical formula.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is inferred from the name of the structure file.
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Optional[Path]
+    config
         Path to yaml configuration file to define the above options. Default is None.
     """
     from janus_core.calculations.phonons import Phonons

--- a/janus_core/cli/preprocess.py
+++ b/janus_core/cli/preprocess.py
@@ -35,14 +35,14 @@ def preprocess(
 
     Parameters
     ----------
-    mlip_config : Path
+    mlip_config
         Configuration file to pass to MLIP CLI.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is Path("preprocess-log.yml").
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is Path("preprocess-summary.yml").
     """

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -65,38 +65,38 @@ def singlepoint(
 
     Parameters
     ----------
-    ctx : Context
+    ctx
         Typer (Click) Context. Automatically set.
-    struct : Path
+    struct
         Path of structure to simulate.
-    arch : Optional[str]
+    arch
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
-    device : Optional[str]
+    device
         Device to run model on. Default is "cpu".
-    model_path : Optional[str]
+    model_path
         Path to MLIP model. Default is `None`.
-    properties : Optional[list[str]]
+    properties
         Physical properties to calculate. Default is ("energy", "forces", "stress").
-    out : Optional[Path]
+    out
         Path to save structure with calculated results. Default is inferred from name
         of the structure file.
-    read_kwargs : Optional[dict[str, Any]]
+    read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is ":".
-    calc_kwargs : Optional[dict[str, Any]]
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    write_kwargs : Optional[dict[str, Any]]
+    write_kwargs
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is inferred from the name of the structure file.
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
-    config : Optional[Path]
+    config
         Path to yaml configuration file to define the above options. Default is None.
     """
     from janus_core.calculations.single_point import SinglePoint

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -37,16 +37,16 @@ def train(
 
     Parameters
     ----------
-    mlip_config : Path
+    mlip_config
         Configuration file to pass to MLIP CLI.
-    fine_tune : bool
+    fine_tune
         Whether to fine-tune a foundational model. Default is False.
-    log : Optional[Path]
+    log
         Path to write logs to. Default is Path("train-log.yml").
-    tracker : bool
+    tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
-    summary : Optional[Path]
+    summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is Path("train-summary.yml").
     """

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -79,7 +79,7 @@ ReadKwargsAll = Annotated[
         help=(
             """
             Keyword arguments to pass to ase.io.read. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}". By default,
+            wrapped in quotes, e.g. "{'key': value}". By default,
             read_kwargs['index'] = ':', so all structures are read.
             """
         ),
@@ -94,7 +94,7 @@ ReadKwargsLast = Annotated[
         help=(
             """
             Keyword arguments to pass to ase.io.read. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}". By default,
+            wrapped in quotes, e.g. "{'key': value}". By default,
             read_kwargs['index'] = -1, so only the last structure is read.
             """
         ),
@@ -109,8 +109,8 @@ CalcKwargs = Annotated[
         help=(
             """
             Keyword arguments to pass to selected calculator. Must be passed as a
-            dictionary wrapped in quotes, e.g. "{'key' : value}". For the default
-            architecture ('mace_mp'), "{'model':'small'}" is set unless overwritten.
+            dictionary wrapped in quotes, e.g. "{'key': value}". For the default
+            architecture ('mace_mp'), "{'model': 'small'}" is set unless overwritten.
             """
         ),
         metavar="DICT",
@@ -124,7 +124,7 @@ WriteKwargs = Annotated[
         help=(
             """
             Keyword arguments to pass to ase.io.write when saving results. Must be
-            passed as a dictionary wrapped in quotes, e.g. "{'key' : value}".
+            passed as a dictionary wrapped in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",
@@ -138,7 +138,7 @@ OptKwargs = Annotated[
         help=(
             """
             Keyword arguments to pass to optimizer. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}".
+            wrapped in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",
@@ -152,7 +152,7 @@ MinimizeKwargs = Annotated[
         help=(
             """
             Keyword arguments to pass to optimizer. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}".
+            wrapped in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",
@@ -194,7 +194,7 @@ EnsembleKwargs = Annotated[
         help=(
             """
             Keyword arguments to pass to ensemble initialization. Must be passed as a
-            dictionary wrapped in quotes, e.g. "{'key' : value}".
+            dictionary wrapped in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",
@@ -222,7 +222,7 @@ PostProcessKwargs = Annotated[
         help=(
             """
             Keyword arguments to pass to post-processer. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key' : value}".
+            wrapped in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -18,7 +18,7 @@ def parse_dict_class(value: str | ASEReadArgs) -> TyperDict:
 
     Parameters
     ----------
-    value : str | ASEReadArgs
+    value
         String representing dictionary to be parsed.
 
     Returns
@@ -37,7 +37,7 @@ class TyperDict:
 
     Parameters
     ----------
-    value : str
+    value
         Value of string representing a dictionary.
     """
 
@@ -47,7 +47,7 @@ class TyperDict:
 
         Parameters
         ----------
-        value : str
+        value
             Value of string representing a dictionary.
         """
         self.value = value

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -30,7 +30,7 @@ def dict_paths_to_strs(dictionary: dict) -> None:
 
     Parameters
     ----------
-    dictionary : dict
+    dictionary
         Dictionary to be converted.
     """
     for key, value in dictionary.items():
@@ -46,7 +46,7 @@ def dict_tuples_to_lists(dictionary: dict) -> None:
 
     Parameters
     ----------
-    dictionary : dict
+    dictionary
         Dictionary to be converted.
     """
     for key, value in dictionary.items():
@@ -62,7 +62,7 @@ def dict_remove_hyphens(dictionary: dict) -> dict:
 
     Parameters
     ----------
-    dictionary : dict
+    dictionary
         Dictionary to be converted.
 
     Returns
@@ -84,7 +84,7 @@ def set_read_kwargs_index(read_kwargs: dict[str, Any]) -> None:
 
     Parameters
     ----------
-    read_kwargs : dict[str, Any]
+    read_kwargs
         Keyword arguments to be passed to ase.io.read. If specified,
         read_kwargs["index"] must be an integer, and if not, a default value
         of -1 is set.
@@ -102,7 +102,7 @@ def parse_typer_dicts(typer_dicts: list[TyperDict]) -> list[dict]:
 
     Parameters
     ----------
-    typer_dicts : list[TyperDict]
+    typer_dicts
         List of TyperDict objects to convert.
 
     Returns
@@ -120,7 +120,7 @@ def parse_typer_dicts(typer_dicts: list[TyperDict]) -> list[dict]:
         if not isinstance(typer_dicts[i], dict):
             raise ValueError(
                 f"""{typer_dicts[i]} must be passed as a dictionary wrapped in quotes.\
- For example, "{{'key' : value}}" """
+ For example, "{{'key': value}}" """
             )
     return typer_dicts
 
@@ -131,7 +131,7 @@ def yaml_converter_loader(config_file: str) -> dict[str, Any]:
 
     Parameters
     ----------
-    config_file : str
+    config_file
         Yaml configuration file to read.
 
     Returns
@@ -156,11 +156,11 @@ def start_summary(*, command: str, summary: Path, inputs: dict) -> None:
 
     Parameters
     ----------
-    command : str
+    command
         Name of CLI command being used.
-    summary : Path
+    summary
         Path to summary file being saved.
-    inputs : dict
+    inputs
         Inputs to CLI command to save.
     """
     save_info = {
@@ -178,9 +178,9 @@ def carbon_summary(*, summary: Path, log: Path) -> None:
 
     Parameters
     ----------
-    summary : Path
+    summary
         Path to summary file being saved.
-    log : Path
+    log
         Path to log file with carbon emissions saved.
     """
     with open(log, encoding="utf8") as file:
@@ -202,7 +202,7 @@ def end_summary(summary: Path) -> None:
 
     Parameters
     ----------
-    summary : Path
+    summary
         Path to summary file being saved.
     """
     with open(summary, "a", encoding="utf8") as outfile:
@@ -231,23 +231,23 @@ def save_struct_calc(
 
     Parameters
     ----------
-    inputs : dict
+    inputs
         Inputs dictionary to add information to.
-    struct : MaybeSequence[Atoms]
+    struct
         Structure to be simulated.
-    struct_path : Path
+    struct_path
         Path of structure file.
-    arch : Architectures
+    arch
         MLIP architecture.
-    device : Devices
+    device
         Device to run calculations on.
-    model_path : str
+    model_path
         Path to MLIP model.
-    read_kwargs : ASEReadArgs
+    read_kwargs
         Keyword arguments to pass to ase.io.read.
-    calc_kwargs : dict[str, Any]]
+    calc_kwargs
         Keyword arguments to pass to the calculator.
-    log : Path
+    log
         Path to log file.
     """
     from ase import Atoms
@@ -301,7 +301,7 @@ def check_config(ctx: Context) -> None:
 
     Parameters
     ----------
-    ctx : Context
+    ctx
         Typer (Click) Context within command.
     """
     # Compare options from config file (default_map) to function definition (params)

--- a/janus_core/helpers/log.py
+++ b/janus_core/helpers/log.py
@@ -18,29 +18,24 @@ class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
 
     Parameters
     ----------
-    fmt : str | None
+    fmt
         A format string in the given style for the logged output as a whole. Default is
         defined by `FORMAT`.
-    datefmt : str | None
+    datefmt
         A format string in the given style for the date/time portion of the logged
         output. Default is taken from logging.Formatter.formatTime().
-    style : Literal['%', '{', '$']
+    style
         Determines how the format string will be merged with its data. Can be one of
         '%', '{' or '$'. Default is '%'.
-    validate : bool
+    validate
         If True, incorrect or mismatched fmt and style will raise a ValueError. Default
         is True.
-    defaults : dict[str, logging.Any] | None
+    defaults
          A dictionary with default values to use in custom fields. Default is None.
     *args
         Arguments to pass to logging.Formatter.__init__.
     **kwargs
         Keyword arguments to pass to logging.Formatter.__init__.
-
-    Methods
-    -------
-    format(record)
-        Format log message to convert new lines into a yaml list.
     """
 
     FORMAT = """
@@ -71,7 +66,7 @@ class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
 
         Parameters
         ----------
-        record : logging.LogRecord
+        record
             Log record to be formatted.
 
         Returns
@@ -112,17 +107,17 @@ def config_logger(
 
     Parameters
     ----------
-    name : str
+    name
         Name of logger. Default is None.
-    filename : str | None
+    filename
         Name of log file if writing logs. Default is None.
-    level : LogLevel
+    level
         Threshold for logger. Default is logging.INFO.
-    capture_warnings : bool
+    capture_warnings
         Whether to capture warnings in log. Default is True.
-    filemode : str
+    filemode
         Mode of file to open. Default is "w".
-    force : bool
+    force
         If true, remove and close existing handlers attached to the root logger before
         configuration. Default is True.
 
@@ -168,15 +163,15 @@ def config_tracker(
 
     Parameters
     ----------
-    janus_logger : logging.Logger | None
+    janus_logger
         Logger for codecarbon output.
-    track_carbon : bool
+    track_carbon
         Whether to track carbon emissions for calculation. Default is True.
-    country_iso_code : str
+    country_iso_code
         3 letter ISO Code of the country where the code is running. Default is "GBR".
-    save_to_file : bool
+    save_to_file
         Whether to also output results to a csv file. Default is False.
-    log_level : Literal["debug", "info", "warning", "error", "critical"]
+    log_level
         Log level of internal carbon tracker log. Default is "critical".
     **kwargs
         Additional keyword arguments to pass to OfflineEmissionsTracker.

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -30,9 +30,9 @@ def _set_model_path(
 
     Parameters
     ----------
-    model_path : PathLike | None
+    model_path
         Path to MLIP file.
-    kwargs : dict[str, Any] | None
+    kwargs
         Dictionary of additional keyword arguments passed to the selected calculator.
 
     Returns
@@ -80,11 +80,11 @@ def choose_calculator(
 
     Parameters
     ----------
-    arch : Architectures
+    arch
         MLIP architecture. Default is "mace".
-    device : Devices
+    device
         Device to run calculator on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP file.
     **kwargs
         Additional keyword arguments passed to the selected calculator.
@@ -248,9 +248,9 @@ def check_calculator(calc: Calculator, attribute: str) -> None:
 
     Parameters
     ----------
-    calc : Calculator
+    calc
         ASE Calculator to check.
-    attribute : str
+    attribute
         Attribute to check calculator for.
     """
     # If dispersion added to MLIP calculator, use only MLIP calculator for calculation

--- a/janus_core/helpers/stats.py
+++ b/janus_core/helpers/stats.py
@@ -26,7 +26,7 @@ class Stats:
 
     Parameters
     ----------
-    source : PathLike
+    source
         File that contains the stats of a molecular dynamics simulation.
     """
 
@@ -36,7 +36,7 @@ class Stats:
 
         Parameters
         ----------
-        source : PathLike
+        source
             File that contains the stats of a molecular dynamics simulation.
         """
         self._data = zeros((0, 0))
@@ -54,7 +54,7 @@ class Stats:
 
         Parameters
         ----------
-        lab : str
+        lab
             Label to find.
 
         Returns
@@ -91,7 +91,7 @@ class Stats:
 
         Parameters
         ----------
-        ind : Any
+        ind
             Index or label to find.
 
         Returns

--- a/janus_core/helpers/struct_io.py
+++ b/janus_core/helpers/struct_io.py
@@ -36,11 +36,11 @@ def results_to_info(
 
     Parameters
     ----------
-    struct : Atoms
+    struct
         Atoms object to copy or move calculated results to info dict.
-    properties : Collection[Properties]
+    properties
         Properties to copy from results to info dict. Default is ().
-    invalidate_calc : bool
+    invalidate_calc
         Whether to remove all calculator results after copying properties to info dict.
         Default is False.
     """
@@ -81,15 +81,15 @@ def attach_calculator(
 
     Parameters
     ----------
-    struct : MaybeSequence[Atoms] | None
+    struct
         ASE Atoms structure(s) to attach calculators to.
-    arch : Architectures
+    arch
         MLIP architecture to use for calculations. Default is "mace_mp".
-    device : Devices
+    device
         Device to run model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
     """
     (calc_kwargs,) = none_to_dict(calc_kwargs)
@@ -126,28 +126,28 @@ def input_structs(
 
     Parameters
     ----------
-    struct : MaybeSequence[Atoms] | None
+    struct
         ASE Atoms structure(s) to simulate. Required if `struct_path` is None. Default
         is None.
-    struct_path : PathLike | None
+    struct_path
         Path of structure to simulate. Required if `struct` is None. Default is None.
-    read_kwargs : ASEReadArgs
+    read_kwargs
         Keyword arguments to pass to ase.io.read. Default is {}.
-    sequence_allowed : bool
+    sequence_allowed
         Whether a sequence of Atoms objects is allowed. Default is True.
-    arch : Architectures
+    arch
         MLIP architecture to use for calculations. Default is "mace_mp".
-    device : Devices
+    device
         Device to run model on. Default is "cpu".
-    model_path : PathLike | None
+    model_path
         Path to MLIP model. Default is `None`.
-    calc_kwargs : dict[str, Any] | None
+    calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
-    set_calc : bool | None
+    set_calc
         Whether to set (new) calculators for structures.  Default is True if
         `struct_path` is specified or `struct` is missing calculators, else default is
         False.
-    logger : logging.Logger | None
+    logger
         Logger if log file has been specified. Default is None.
 
     Returns
@@ -234,21 +234,21 @@ def output_structs(
 
     Parameters
     ----------
-    images : MaybeSequence[Atoms]
+    images
         Atoms object or a list of Atoms objects to interact with.
-    struct_path : PathLike | None
+    struct_path
         Path of structure being simulated. If specified, the file stem is added to the
         info dict under "system_name". Default is None.
-    set_info : bool
+    set_info
         True to set info dict from calculated results. Default is True.
-    write_results : bool
+    write_results
         True to write out structure with results of calculations. Default is False.
-    properties : Collection[Properties]
+    properties
         Properties to copy from calculated results to info dict. Default is ().
-    invalidate_calc : bool
+    invalidate_calc
         Whether to remove all calculator results after copying properties to info dict.
         Default is False.
-    write_kwargs : ASEWriteArgs | None
+    write_kwargs
         Keyword arguments passed to ase.io.write. Default is {}.
     """
     # Separate kwargs for output_structs from kwargs for ase.io.write

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -32,12 +32,12 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
     Parameters
     ----------
-    struct : MaybeSequence[Atoms]
+    struct
         Structure from which to derive the default name. If `struct` is a sequence,
         the first structure will be used.
-    struct_path : PathLike | None
+    struct_path
         Path to file containing structures.
-    file_prefix : PathLike | None
+    file_prefix
         Default prefix to use.
     *additional
         Components to add to default file_prefix (joined by hyphens).
@@ -63,12 +63,12 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
         Parameters
         ----------
-        struct : MaybeSequence[Atoms]
+        struct
             Structure(s) from which to derive the default name. If `struct` is a
             sequence, the first structure will be used.
-        struct_path : PathLike | None
+        struct_path
             Path to file structures were read from. Used as default prefix is not None.
-        file_prefix : PathLike | None
+        file_prefix
             Default prefix to use.
         *additional
             Components to add to default file_prefix (joined by hyphens).
@@ -89,12 +89,12 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
         Parameters
         ----------
-        file_prefix : PathLike | None
+        file_prefix
             Given file_prefix.
-        struct : MaybeSequence[Atoms]
+        struct
             Structure(s) from which to derive the default name. If `struct` is a
             sequence, the first structure will be used.
-        struct_path : PathLike | None
+        struct_path
             Path to file containing structures.
         *additional
             Components to add to default file_prefix (joined by hyphens).
@@ -129,13 +129,13 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
 
         Parameters
         ----------
-        suffix : str
+        suffix
             Default suffix to use if `filename` is not specified.
         *additional
             Extra components to add to suffix (joined with hyphens).
-        filename : PathLike | None
+        filename
             Filename to use, if specified. Default is None.
-        prefix_override : str | None
+        prefix_override
             Replace file_prefix if not None.
 
         Returns
@@ -162,7 +162,7 @@ def none_to_dict(*dictionaries: Sequence[dict | None]) -> Generator[dict, None, 
 
     Parameters
     ----------
-    *dictionaries : Sequence[dict | None]
+    *dictionaries
         Sequence of dictionaries that could be None.
 
     Yields
@@ -195,12 +195,12 @@ def write_table(
 
     Parameters
     ----------
-    fmt : {'ascii', 'csv'}
+    fmt
         Format to write table in.
-    file : TextIO
+    file
         File to dump to. If unspecified function returns
         io.StringIO object simulating file.
-    units : dict[str, str]
+    units
         Units as ``{key: unit}``:
 
         key
@@ -322,13 +322,13 @@ def _dump_ascii(
 
     Parameters
     ----------
-    file : TextIO
+    file
         File to dump to.
-    header : list[str]
+    header
         Column name information.
-    columns : dict[str, Sequence[Any]]
+    columns
         Column data by key (ordered with header info).
-    formats : Sequence[str]
+    formats
         Python magic string formats to apply
         (must align with header info).
 
@@ -354,13 +354,13 @@ def _dump_csv(
 
     Parameters
     ----------
-    file : TextIO
+    file
         File to dump to.
-    header : list[str]
+    header
         Column name information.
-    columns : dict[str, Sequence[Any]]
+    columns
         Column data by key (ordered with header info).
-    formats : Sequence[str]
+    formats
         Python magic string formats to apply
         (must align with header info).
 
@@ -385,9 +385,9 @@ def track_progress(sequence: Sequence | Iterable, description: str) -> Iterable:
 
     Parameters
     ----------
-    sequence : Iterable
+    sequence
         The sequence to iterate over. Must support "len".
-    description : str
+    description
         The text to display to the left of the progress bar.
 
     Yields
@@ -422,9 +422,9 @@ def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:
 
     Parameters
     ----------
-    config : dict
+    config
         Dictionary read from configuration file.
-    req_file_keys : Sequence[Pathlike]
+    req_file_keys
         Files that must exist if defined in the configuration file.
 
     Raises
@@ -445,7 +445,7 @@ def validate_slicelike(maybe_slicelike: SliceLike) -> None:
 
     Parameters
     ----------
-    maybe_slicelike : SliceLike
+    maybe_slicelike
         Candidate to test.
 
     Raises
@@ -473,7 +473,7 @@ def slicelike_to_startstopstep(index: SliceLike) -> StartStopStep:
 
     Parameters
     ----------
-    index : SliceLike
+    index
         `SliceLike` to standardize.
 
     Returns
@@ -499,9 +499,9 @@ def selector_len(slc: SliceLike | list, selectable_length: int) -> int:
 
     Parameters
     ----------
-    slc : Union[SliceLike, list]
+    slc
         The applied SliceLike or list for selection.
-    selectable_length : int
+    selectable_length
         The length of the selectable object.
 
     Returns
@@ -527,11 +527,11 @@ def set_log_tracker(
 
     Parameters
     ----------
-    attach_logger : bool
+    attach_logger
         Whether to attach a logger.
-    log_kwargs : dict[str, Any]
+    log_kwargs
         Keyword arguments to pass to `config_logger`.
-    track_carbon : bool
+    track_carbon
         Whether to track carbon emissions of calculation.
 
     Returns

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -27,11 +27,11 @@ class Correlator:
 
     Parameters
     ----------
-    blocks : int
+    blocks
         Number of correlation blocks.
-    points : int
+    points
         Number of points per block.
-    averaging : int
+    averaging
         Averaging window per block level.
 
     Attributes
@@ -62,11 +62,11 @@ class Correlator:
 
         Parameters
         ----------
-        blocks : int
+        blocks
             Number of resolution levels.
-        points : int
+        points
             Data points at each resolution.
-        averaging : int
+        averaging
             Coarse-graining between resolution levels.
         """
         self._blocks = blocks
@@ -89,9 +89,9 @@ class Correlator:
 
         Parameters
         ----------
-        a : float
+        a
             Newly observed value of left correland.
-        b : float
+        b
             Newly observed value of right correland.
         """
         self._propagate(a, b, 0)
@@ -102,11 +102,11 @@ class Correlator:
 
         Parameters
         ----------
-        a : float
+        a
             Newly observed value of left correland/average.
-        b : float
+        b
             Newly observed value of right correland/average.
-        block : int
+        block
             Block in the hierachy being updated.
         """
         if block == self._blocks:
@@ -171,11 +171,11 @@ class Correlator:
 
         Parameters
         ----------
-        block : int
+        block
             Block to check the shift register of.
-        p_i : int
+        p_i
             Index i in the shift (left correland).
-        p_j : int
+        p_j
             Index j in the shift (right correland).
 
         Returns
@@ -247,19 +247,19 @@ class Correlation:
 
     Parameters
     ----------
-    a : Observable
+    a
         Observable for a.
-    b : Observable
+    b
         Observable for b.
-    name : str
+    name
         Name of correlation.
-    blocks : int
+    blocks
         Number of correlation blocks.
-    points : int
+    points
         Number of points per block.
-    averaging : int
+    averaging
         Averaging window per block level.
-    update_frequency : int
+    update_frequency
         Frequency to update the correlation, md steps.
     """
 
@@ -279,19 +279,19 @@ class Correlation:
 
         Parameters
         ----------
-        a : Observable
+        a
             Observable for a.
-        b : Observable
+        b
             Observable for b.
-        name : str
+        name
             Name of correlation.
-        blocks : int
+        blocks
             Number of correlation blocks.
-        points : int
+        points
             Number of points per block.
-        averaging : int
+        averaging
             Averaging window per block level.
-        update_frequency : int
+        update_frequency
             Frequency to update the correlation, md steps.
         """
         self.name = name
@@ -322,7 +322,7 @@ class Correlation:
 
         Parameters
         ----------
-        atoms : Atoms
+        atoms
             Atoms object to observe values from.
         """
         # All pairs of data to be correlated.

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -23,7 +23,7 @@ class Observable(ABC):
 
     Parameters
     ----------
-    atoms_slice : list[int] | SliceLike | None = None
+    atoms_slice
         A slice of atoms to observe.
     """
 
@@ -33,7 +33,7 @@ class Observable(ABC):
 
         Parameters
         ----------
-        atoms_slice : list[int] | SliceLike | None
+        atoms_slice
             A slice of atoms to observe. By default all atoms are included.
         """
         if not atoms_slice:
@@ -52,7 +52,7 @@ class Observable(ABC):
 
         Parameters
         ----------
-        atoms : Atoms
+        atoms
             Atoms object to extract values from.
 
         Returns
@@ -68,7 +68,7 @@ class ComponentMixin:
 
     Parameters
     ----------
-    components : dict[str, int]
+    components
         Symbolic components mapped to indices.
     """
 
@@ -78,7 +78,7 @@ class ComponentMixin:
 
         Parameters
         ----------
-        components : dict[str, int]
+        components
             Symbolic components mapped to indices.
         """
         self._allowed_components = components
@@ -114,7 +114,7 @@ class ComponentMixin:
 
         Parameters
         ----------
-        components : str
+        components
             The component symbols to check.
 
         Raises
@@ -138,11 +138,11 @@ class Stress(Observable, ComponentMixin):
 
     Parameters
     ----------
-    components : list[str]
+    components
         Symbols for correlated tensor components, xx, yy, etc.
-    atoms_slice : list[int] | SliceLike | None = None
+    atoms_slice
         List or slice of atoms to observe velocities from.
-    include_ideal_gas : bool
+    include_ideal_gas
         Calculate with the ideal gas contribution.
     """
 
@@ -158,11 +158,11 @@ class Stress(Observable, ComponentMixin):
 
         Parameters
         ----------
-        components : list[str]
+        components
             Symbols for tensor components, xx, yy, etc.
-        atoms_slice : list[int] | SliceLike | None = None
+        atoms_slice
             List or slice of atoms to observe velocities from.
-        include_ideal_gas : bool
+        include_ideal_gas
             Calculate with the ideal gas contribution.
         """
         ComponentMixin.__init__(
@@ -190,7 +190,7 @@ class Stress(Observable, ComponentMixin):
 
         Parameters
         ----------
-        atoms : Atoms
+        atoms
             Atoms object to extract values from.
 
         Returns
@@ -228,9 +228,9 @@ class Velocity(Observable, ComponentMixin):
 
     Parameters
     ----------
-    components : list[str]
+    components
         Symbols for velocity components, x, y, z.
-    atoms_slice : list[int] | SliceLike | None = None
+    atoms_slice
         List or slice of atoms to observe velocities from.
     """
 
@@ -245,9 +245,9 @@ class Velocity(Observable, ComponentMixin):
 
         Parameters
         ----------
-        components : list[str]
+        components
             Symbols for tensor components, x, y, and z.
-        atoms_slice : Union[list[int], SliceLike]
+        atoms_slice
             List or slice of atoms to observe velocities from.
         """
         ComponentMixin.__init__(self, components={"x": 0, "y": 1, "z": 2})
@@ -261,7 +261,7 @@ class Velocity(Observable, ComponentMixin):
 
         Parameters
         ----------
-        atoms : Atoms
+        atoms
             Atoms object to extract values from.
 
         Returns

--- a/janus_core/processing/post_process.py
+++ b/janus_core/processing/post_process.py
@@ -37,29 +37,29 @@ def compute_rdf(
 
     Parameters
     ----------
-    data : MaybeSequence[Atoms]
+    data
         Dataset to compute RDF of.
-    ana : Analysis | None
+    ana
         ASE Analysis object for data reuse.
-    filenames : MaybeSequence[PathLike] | None
+    filenames
         Filenames to output data to. Must match number of RDFs computed.
-    by_elements : bool
+    by_elements
         Split RDF into pairwise by elements group. Default is False.
         N.B. mixed RDFs (e.g. C-H) include all self-RDFs (e.g. C-C),
         to get the pure (C-H) RDF subtract the self-RDFs.
-    rmax : float
+    rmax
         Maximum distance of RDF.
-    nbins : int
+    nbins
         Number of bins to divide RDF.
-    elements : MaybeSequence[int | str] | None
+    elements
         Make partial RDFs. If `by_elements` is true will filter to
         only display pairs in list.
-    index : SliceLike
+    index
         Images to analyze as:
         `index` if `int`,
         `start`, `stop`, `step` if `tuple`,
         `slice` if `slice` or `range`.
-    volume : float | None
+    volume
         Volume of cell for normalisation. Only needs to be provided
         if aperiodic cell. Default is (2*rmax)**3.
 
@@ -173,23 +173,23 @@ def compute_vaf(
 
     Parameters
     ----------
-    data : Sequence[Atoms]
+    data
         Dataset to compute VAF of.
-    filenames : MaybeSequence[PathLike] | None
+    filenames
         If present, dump resultant VAF to file.
-    use_velocities : bool
+    use_velocities
         Compute VAF using velocities rather than momenta.
         Default is False.
-    fft : bool
+    fft
         Compute the fourier transformed VAF.
         Default is False.
-    index : SliceLike
+    index
         Images to analyze as `start`, `stop`, `step`.
         Default is all images.
-    filter_atoms : MaybeSequence[MaybeSequence[int | None]]
+    filter_atoms
         Compute the VAF averaged over subsets of the system.
         Default is all atoms.
-    time_step : float
+    time_step
         Time step for scaling lags to align with input data.
         Default is 1 (i.e. no scaling).
 

--- a/janus_core/processing/symmetry.py
+++ b/janus_core/processing/symmetry.py
@@ -15,12 +15,12 @@ def spacegroup(
 
     Parameters
     ----------
-    struct : Atoms
+    struct
         Structure as an ase Atoms object.
-    sym_tolerance : float
+    sym_tolerance
         Atom displacement tolerance for spglib symmetry determination, in Å.
         Default is 0.001.
-    angle_tolerance : float
+    angle_tolerance
         Angle precision for spglib symmetry determination, in degrees. Default is -1.0,
         which means an internally optimized routine is used to judge symmetry.
 
@@ -46,9 +46,9 @@ def snap_symmetry(struct: Atoms, sym_tolerance: float = 0.001) -> None:
 
     Parameters
     ----------
-    struct : Atoms
+    struct
         Structure as an ase Atoms object.
-    sym_tolerance : float
+    sym_tolerance
         Atom displacement tolerance for spglib symmetry determination, in Å.
         Default is 0.001.
     """

--- a/janus_core/training/preprocess.py
+++ b/janus_core/training/preprocess.py
@@ -30,20 +30,20 @@ def preprocess(
 
     Parameters
     ----------
-    mlip_config : PathLike
+    mlip_config
         Configuration file to pass to MLIP.
-    req_file_keys : Sequence[PathLike]
+    req_file_keys
         List of files that must exist if defined in the configuration file.
         Default is ("train_file", "test_file", "valid_file").
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
     """
     log_kwargs, tracker_kwargs = none_to_dict(log_kwargs, tracker_kwargs)

--- a/janus_core/training/train.py
+++ b/janus_core/training/train.py
@@ -35,20 +35,20 @@ def train(
 
     Parameters
     ----------
-    mlip_config : PathLike
+    mlip_config
         Configuration file to pass to MLIP.
-    req_file_keys : Sequence[PathLike]
+    req_file_keys
         List of files that must exist if defined in the configuration file.
         Default is ("train_file", "test_file", "valid_file", "statistics_file").
-    attach_logger : bool | None
+    attach_logger
         Whether to attach a logger. Default is True if "filename" is passed in
         log_kwargs, else False.
-    log_kwargs : dict[str, Any] | None
+    log_kwargs
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool | None
+    track_carbon
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
-    tracker_kwargs : dict[str, Any] | None
+    tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
     """
     log_kwargs, tracker_kwargs = none_to_dict(log_kwargs, tracker_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
     "furo<2025.0.0,>=2024.1.29",
     "markupsafe<2.1",
     "numpydoc<2.0.0,>=1.6.0",
-    "sphinx<8.0.0,>=7.2.6",
+    "sphinx<9.0.0,>=8.0.2",
     "sphinxcontrib-contentui<1.0.0,>=0.2.5",
     "sphinxcontrib-details-directive<1.0,>=0.1",
     "sphinx-copybutton<1.0.0,>=0.5.2",
@@ -152,6 +152,7 @@ checks = [
     "EX01",
     "SA01",
     "ES01",
+    "PR04", # Ignore no type (types come from signature as via sphinx_autodoc_typehints)
 ]
 # Don't report on objects that match any of these regex
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ docs = [
     "sphinxcontrib-contentui<1.0.0,>=0.2.5",
     "sphinxcontrib-details-directive<1.0,>=0.1",
     "sphinx-copybutton<1.0.0,>=0.5.2",
+    "sphinx-autodoc-typehints<3.0.0,>=2.5.0"
 ]
 
 pre-commit = [

--- a/tests/test_preprocess_cli.py
+++ b/tests/test_preprocess_cli.py
@@ -22,9 +22,9 @@ def write_tmp_config(config_path: Path, tmp_path: Path) -> Path:
 
     Parameters
     ----------
-    config_path : Path
+    config_path
         Path to yaml config file to be fixed.
-    tmp_path : Path
+    tmp_path
         Temporary path from pytest in which to write corrected config.
 
     Returns

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -24,9 +24,9 @@ def write_tmp_config(config_path: Path, tmp_path: Path) -> Path:
 
     Parameters
     ----------
-    config_path : Path
+    config_path
         Path to yaml config file to be fixed.
-    tmp_path : Path
+    tmp_path
         Temporary path from pytest in which to write corrected config.
 
     Returns

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@ def read_atoms(path: Path) -> Atoms | None:
 
     Parameters
     ----------
-    path : Path
+    path
         Path to file containing Atoms structure to be read.
 
     Returns
@@ -49,11 +49,11 @@ def assert_log_contains(
 
     Parameters
     ----------
-    log_path : PathLike
+    log_path
         Path to log file to check messsages of.
-    includes : MaybeSequence[str]
+    includes
         Messages that must appear in the log file. Default is None.
-    excludes : MaybeSequence[str]
+    excludes
         Messages that must not appear in the log file. Default is None.
     """
     # Convert single strings to iterable
@@ -81,7 +81,7 @@ def strip_ansi_codes(output: str) -> str:
 
     Parameters
     ----------
-    output : str
+    output
         Output that may contain ANSI sequences to be removed.
 
     Returns


### PR DESCRIPTION
Use `sphinx_autodoc_typehints` to extract linked typehints from signatures rather then repeating in documentation.