### PR TITLE
Update MACE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 *.png
 *.svg
 *.xz
+*.txt
 ~*
 *~
 .project

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tools for machine learnt interatomic potentials
 
 - Python >= 3.9
 - ASE >= 3.23
-- mace-torch = 0.3.6
+- mace-torch = 0.3.8
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
 - sevenn = 0.10.0 (optional)

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -9,7 +9,7 @@ Dependencies
 
 - Python >= 3.9
 - ASE >= 3.23
-- mace-torch = 0.3.6
+- mace-torch = 0.3.8
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
 - sevenn = 0.10.0 (optional)

--- a/janus_core/helpers/log.py
+++ b/janus_core/helpers/log.py
@@ -80,6 +80,7 @@ class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
             Formatted log message.
         """
         # Parse JSON dump from codecarbon
+        record.msg = str(record.msg)
         if len(record.msg) > 1 and (record.msg[0] == "{" and record.msg[-1] == "}"):
             msg_dict = json.loads(record.msg)
             record.msg = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ janus = "janus_core.cli.janus:app"
 [tool.poetry.dependencies]
 ase = "^3.23"
 codecarbon = "^2.5.0"
-mace-torch = "0.3.6"
+mace-torch = "0.3.8"
 numpy = "^1.26.4"
 phonopy = "^2.23.1"
 python = "^3.9"

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -187,7 +187,9 @@ def test_single_point_molecule(tmp_path):
     assert atoms.info["mace_energy"] == pytest.approx(-14.035236305927514)
     assert "mace_forces" in atoms.arrays
     assert "mace_stress" in atoms.info
-    assert atoms.info["mace_stress"] == pytest.approx([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+    assert atoms.info["mace_stress"] == pytest.approx(
+        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0], abs=1e-5
+    )
 
 
 def test_invalid_prop():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,9 @@ def assert_log_contains(
     with open(log_path, encoding="utf8") as log_file:
         logs = yaml.safe_load(log_file)
     # Nested join as log["message"] may be a list
-    messages = "".join("".join(log["message"]) for log in logs)
+    messages = "".join(
+        "".join(log["message"]) if log["message"] else "" for log in logs
+    )
 
     assert all(inc in messages for inc in includes)
     assert all(exc not in messages for exc in excludes)


### PR DESCRIPTION
Resolves #335

We should be able to update MACE, which has quite a few new features since 0.3.6.

In terms of dependencies, everything seems ok, ~but there seems to be an issue with loading the model, which I haven't looked into, and the stress for molecules has changed slightly (see [issue](https://github.com/ACEsuit/mace/issues/700))~

- The model loading error was because we never actually had MACE-OFF saved, but as MACE was previously ignoring the path, this wasn't visible
- It might be easiest to remove the stress check for molecules, but I think it's useful to have some indication of changes to MACE's outputs, even if the output itself ought to be discarded in general, so I've added a relatively small allowed absolute error

Still to do:
- [x] Fix training bug

This hopefully also fixes an issue reported by @alinelena, along the lines of `TypeError: object of type 'Loss' has no len()` during training, due to MACE outputting the [loss object explicitly](https://github.com/ACEsuit/mace/blob/main/mace/cli/run_train.py#L550).