### PR TITLE
Add MD forces by default

### DIFF
--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from ase import Atoms
@@ -164,6 +165,16 @@ class BaseCalculation(FileNameMixin):
             calc_kwargs=self.calc_kwargs,
             set_calc=set_calc,
         )
+
+        # Set architecture to match calculator architecture
+        if isinstance(self.struct, Sequence):
+            if all(
+                image.calc and "arch" in image.calc.parameters for image in self.struct
+            ):
+                self.arch = self.struct[0].calc.parameters["arch"]
+        else:
+            if self.struct.calc and "arch" in self.struct.calc.parameters:
+                self.arch = self.struct.calc.parameters["arch"]
 
         FileNameMixin.__init__(
             self,

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -474,7 +474,7 @@ class MolecularDynamics(BaseCalculation):
         if not write_kwargs.get("invalidate_calc", False):
             default_columns.append("forces")
         if "arch" in self.struct.calc.parameters and write_kwargs.get("set_info", True):
-            default_columns.append(f"{arch}_forces")
+            default_columns.append(f"{self.arch}_forces")
 
         self.write_kwargs.setdefault("columns", default_columns)
 
@@ -1084,6 +1084,9 @@ class MolecularDynamics(BaseCalculation):
                 self.temp = temp
                 self._set_velocity_distribution()
                 if isclose(temp, 0.0):
+                    # Calculate forces and energies to be output
+                    self.struct.get_potential_energy()
+                    self.struct.get_forces()
                     self._write_final_state()
                     self.created_final_file = True
                     continue

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -470,7 +470,9 @@ class MolecularDynamics(BaseCalculation):
         opt_file = self._build_filename("opt.extxyz", self.param_prefix, filename=None)
 
         # Set defaults
-        default_columns = ["symbols", "positions", "momenta", "masses", "forces"]
+        default_columns = ["symbols", "positions", "momenta", "masses"]
+        if not write_kwargs.get("invalidate_calc", False):
+            default_columns.append("forces")
         if "arch" in self.struct.calc.parameters and write_kwargs.get("set_info", True):
             default_columns.append(f"{arch}_forces")
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -426,10 +426,6 @@ class MolecularDynamics(BaseCalculation):
         if self.ramp_temp and (self.temp_start < 0 or self.temp_end < 0):
             raise ValueError("Start and end temperatures must be positive")
 
-        self.write_kwargs.setdefault(
-            "columns", ["symbols", "positions", "momenta", "masses"]
-        )
-
         # Read last image by default
         read_kwargs.setdefault("index", -1)
 
@@ -472,6 +468,13 @@ class MolecularDynamics(BaseCalculation):
 
         # If not specified otherwise, save optimized structure consistently with others
         opt_file = self._build_filename("opt.extxyz", self.param_prefix, filename=None)
+
+        # Set defaults
+        default_columns = ["symbols", "positions", "momenta", "masses", "forces"]
+        if "arch" in self.struct.calc.parameters and write_kwargs.get("set_info", True):
+            default_columns.append(f"{arch}_forces")
+
+        self.write_kwargs.setdefault("columns", default_columns)
 
         if "write_kwargs" in self.minimize_kwargs:
             # Use _build_filename even if given filename to ensure directory exists

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -483,7 +483,7 @@ def test_write_kwargs(tmp_path):
     traj_path = tmp_path / "md-traj.extxyz"
 
     write_kwargs = (
-        "{'invalidate_calc': False, 'columns': ['symbols', 'positions', 'masses']}"
+        "{'invalidate_calc': True, 'columns': ['symbols', 'positions', 'masses']}"
     )
 
     result = runner.invoke(
@@ -515,13 +515,11 @@ def test_write_kwargs(tmp_path):
     assert not final_atoms.has("momenta")
     assert not traj[0].has("momenta")
 
-    # Check calculated results have been saved
-    assert "energy" in final_atoms.calc.results
-    assert "energy" in traj[0].calc.results
-
-    # Check labelled info has been set
-    assert "mace_mp_energy" in final_atoms.info
+    # Check results saved with arch label, but calc is not attached
+    assert final_atoms.calc is None
+    assert traj[0].calc is None
     assert "mace_mp_energy" in traj[0].info
+    assert "mace_mp_energy" in final_atoms.info
 
     assert "system_name" in final_atoms.info
     assert final_atoms.info["system_name"] == "NaCl"

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -101,6 +101,12 @@ def test_md(ensemble):
         # Check at least one image has been saved in trajectory
         atoms = read(traj_path)
         assert isinstance(atoms, Atoms)
+        assert "energy" in atoms.calc.results
+        assert "mace_mp_energy" in atoms.info
+        assert "forces" in atoms.calc.results
+        assert "mace_mp_forces" in atoms.arrays
+        assert "momenta" in atoms.arrays
+        assert "masses" in atoms.arrays
 
     finally:
         final_path.unlink(missing_ok=True)


### PR DESCRIPTION
Resolves #365

Updates the default MD `write_kwargs["columns"]` to output both `forces` and (for example) `mace_mp_forces`, to be consistent with all other methods, unless `invalidate_calc` is set as a `write_kwarg`.

Also updates the architecture for all calculations to match the structure's calculator architecture, which means if, for example, we pass `Singlepoint.struct` when creating an `MD` object, the `MD.arch` is set to match `Singlepoint.arch`, rather than the default, which is misleading. (Arguably this could be a separate PR, but it currently only substantially affects changes used in this. It is a separate commit though, so I can split it out if we like). 