### PR TITLE
Improve logging and carbon tracking consistency

### DIFF
--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -7,3 +7,4 @@ User guide
 
     command_line
     python
+    troubleshooting

--- a/docs/source/user_guide/troubleshooting.rst
+++ b/docs/source/user_guide/troubleshooting.rst
@@ -1,0 +1,56 @@
+===============
+Troubleshooting
+===============
+
+Carbon tracking
+---------------
+
+Enabling tracking (Python)
+++++++++++++++++++++++++++
+
+Carbon tracking can be enabled through the ``track_carbon`` option.
+By default, this is ``True`` if logging is enabled, but requires setting ``attach_logger``, as this defaults to ``False``.
+
+For example, to track the carbon emissions during a single point calculation:
+
+.. code-block:: python
+
+    from janus_core.calculations.single_point import SinglePoint
+
+    sp = SinglePoint(
+        struct_path="tests/data/NaCl.cif",
+        attach_logger=True,
+        track_carbon=True,
+    )
+
+This generates a log file, ``NaCl-singlepoint-log.yml``, which stores the emissions for the calculation.
+
+
+In the case of multiple calculations, such as geometry optimisation triggered during molecular dynamics,
+the emissions for each component of the calculation will be separate items in the log.
+
+
+Disabling tracking (CLI)
+++++++++++++++++++++++++
+
+Currently, carbon tracking is enabled by default when using the command line interface,
+saving the total calculating emissions to the generated summary file, as well as additional details and
+per-calculation emissions to the log file.
+
+This can be disabled by passing the ``--no-tracker`` flag to any command. For example:
+
+.. code-block:: bash
+
+    janus singlepoint --struct tests/data/NaCl.cif --no-tracker
+
+
+Sudo access
++++++++++++
+
+On some systems, such as MacOS, the carbon tracker may prompt for your password, if you have sudo access.
+To avoid this, you can:
+
+1. Disable carbon tracking, as described in `Disabling tracking (CLI)`_.
+3. Modify your sudoers file, as described `here <https://mlco2.github.io/codecarbon/methodology.html#cpu>`_, to provide sudo rights for all future calculations.
+2. Provide your password. This may be saved for a period of time, but will need to be entered again in future.
+4. Fail authentication, for example by entering an invalid or no password three times, which triggers the tracking to default to a constant power.

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -47,11 +47,12 @@ class BaseCalculation(FileNameMixin):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : bool | None
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -84,7 +85,7 @@ class BaseCalculation(FileNameMixin):
         sequence_allowed: bool = True,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
-        attach_logger: bool = False,
+        attach_logger: bool | None = None,
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
@@ -119,11 +120,12 @@ class BaseCalculation(FileNameMixin):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : bool | None
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool
-            Whether to attach a logger. Default is False.
+        attach_logger : bool | None
+            Whether to attach a logger. Default is True if "filename" is passed in
+            log_kwargs, else False.
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool
+        track_carbon : bool | None
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
@@ -152,6 +154,11 @@ class BaseCalculation(FileNameMixin):
 
         if not self.model_path and "model_path" in self.calc_kwargs:
             raise ValueError("`model_path` must be passed explicitly")
+
+        if "filename" in log_kwargs:
+            attach_logger = True
+        else:
+            attach_logger = attach_logger if attach_logger else False
 
         if not attach_logger:
             if track_carbon:

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -16,7 +16,7 @@ from janus_core.helpers.janus_types import (
 )
 from janus_core.helpers.log import config_logger, config_tracker
 from janus_core.helpers.struct_io import input_structs
-from janus_core.helpers.utils import FileNameMixin, none_to_dict
+from janus_core.helpers.utils import FileNameMixin, none_to_dict, set_log_tracker
 
 
 class BaseCalculation(FileNameMixin):
@@ -155,17 +155,9 @@ class BaseCalculation(FileNameMixin):
         if not self.model_path and "model_path" in self.calc_kwargs:
             raise ValueError("`model_path` must be passed explicitly")
 
-        if "filename" in log_kwargs:
-            attach_logger = True
-        else:
-            attach_logger = attach_logger if attach_logger else False
-
-        if not attach_logger:
-            if track_carbon:
-                raise ValueError("Carbon tracking requires logging to be enabled")
-            self.track_carbon = False
-        else:
-            self.track_carbon = track_carbon if track_carbon is not None else True
+        attach_logger, self.track_carbon = set_log_tracker(
+            attach_logger, log_kwargs, track_carbon
+        )
 
         # Read structures and/or attach calculators
         # Note: logger not set up so yet so not passed here

--- a/janus_core/calculations/base.py
+++ b/janus_core/calculations/base.py
@@ -52,7 +52,8 @@ class BaseCalculation(FileNameMixin):
     log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Requires attach_logger.
+        Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
     file_prefix : PathLike | None
@@ -85,7 +86,7 @@ class BaseCalculation(FileNameMixin):
         set_calc: bool | None = None,
         attach_logger: bool = False,
         log_kwargs: dict[str, Any] | None = None,
-        track_carbon: bool = True,
+        track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
         file_prefix: PathLike | None = None,
         additional_prefix: str | None = None,
@@ -123,7 +124,8 @@ class BaseCalculation(FileNameMixin):
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
         track_carbon : bool
-            Whether to track carbon emissions of calculation. Default is True.
+            Whether to track carbon emissions of calculation. Requires attach_logger.
+            Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
         file_prefix : PathLike | None
@@ -146,11 +148,17 @@ class BaseCalculation(FileNameMixin):
         self.read_kwargs = read_kwargs
         self.calc_kwargs = calc_kwargs
         self.log_kwargs = log_kwargs
-        self.track_carbon = track_carbon
         self.tracker_kwargs = tracker_kwargs
 
         if not self.model_path and "model_path" in self.calc_kwargs:
             raise ValueError("`model_path` must be passed explicitly")
+
+        if not attach_logger:
+            if track_carbon:
+                raise ValueError("Carbon tracking requires logging to be enabled")
+            self.track_carbon = False
+        else:
+            self.track_carbon = track_carbon if track_carbon is not None else True
 
         # Read structures and/or attach calculators
         # Note: logger not set up so yet so not passed here

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -47,11 +47,12 @@ class Descriptors(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : bool | None
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Default is True if
         attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -84,7 +85,7 @@ class Descriptors(BaseCalculation):
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
-        attach_logger: bool = False,
+        attach_logger: bool | None = None,
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
@@ -118,11 +119,12 @@ class Descriptors(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : bool | None
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool
-            Whether to attach a logger. Default is False.
+        attach_logger : bool | None
+            Whether to attach a logger. Default is True if "filename" is passed in
+            log_kwargs, else False.
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool
+        track_carbon : bool | None
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -52,7 +52,8 @@ class Descriptors(BaseCalculation):
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Default is True if
+        attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_tracker`. Default is {}.
     invariants_only : bool
@@ -85,7 +86,7 @@ class Descriptors(BaseCalculation):
         set_calc: bool | None = None,
         attach_logger: bool = False,
         log_kwargs: dict[str, Any] | None = None,
-        track_carbon: bool = True,
+        track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
         invariants_only: bool = True,
         calc_per_element: bool = False,
@@ -122,7 +123,8 @@ class Descriptors(BaseCalculation):
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
         track_carbon : bool
-            Whether to track carbon emissions of calculation. Default is True.
+            Whether to track carbon emissions of calculation. Requires attach_logger.
+            Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
         invariants_only : bool

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -55,7 +55,8 @@ class EoS(BaseCalculation):
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Default is True if
+        attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_tracker`. Default is {}.
     min_volume : float
@@ -117,7 +118,7 @@ class EoS(BaseCalculation):
         set_calc: bool | None = None,
         attach_logger: bool = False,
         log_kwargs: dict[str, Any] | None = None,
-        track_carbon: bool = True,
+        track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
         min_volume: float = 0.95,
         max_volume: float = 1.05,
@@ -162,7 +163,8 @@ class EoS(BaseCalculation):
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
         track_carbon : bool
-            Whether to track carbon emissions of calculation. Default is True.
+            Whether to track carbon emissions of calculation. Requires attach_logger.
+            Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
         min_volume : float

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -50,11 +50,12 @@ class EoS(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : bool | None
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Default is True if
         attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -116,7 +117,7 @@ class EoS(BaseCalculation):
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
-        attach_logger: bool = False,
+        attach_logger: bool | None = None,
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
@@ -158,11 +159,12 @@ class EoS(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : bool | None
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool
-            Whether to attach a logger. Default is False.
+        attach_logger : bool | None
+            Whether to attach a logger. Default is True if "filename" is passed in
+            log_kwargs, else False.
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool
+        track_carbon : bool | None
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -265,6 +265,7 @@ class EoS(BaseCalculation):
                 "name": self.logger.name,
                 "filemode": "a",
             }
+        self.minimize_kwargs["track_carbon"] = self.track_carbon
 
         # Set output files
         self.write_kwargs.setdefault("filename", None)

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -51,10 +51,11 @@ class GeomOpt(BaseCalculation):
     set_calc : bool | None
         Whether to set (new) calculators for structures. Default is None.
     attach_logger : bool
-        Whether to attach a logger. Default is False.
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -108,7 +109,7 @@ class GeomOpt(BaseCalculation):
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
-        attach_logger: bool = False,
+        attach_logger: bool | None = None,
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
@@ -150,10 +151,11 @@ class GeomOpt(BaseCalculation):
         set_calc : bool | None
             Whether to set (new) calculators for structures. Default is None.
         attach_logger : bool
-            Whether to attach a logger. Default is False.
+            Whether to attach a logger. Default is True if "filename" is passed in
+            log_kwargs, else False.
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool
+        track_carbon : bool | None
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -55,7 +55,8 @@ class GeomOpt(BaseCalculation):
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Requires attach_logger.
+        Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_tracker`. Default is {}.
     fmax : float
@@ -109,7 +110,7 @@ class GeomOpt(BaseCalculation):
         set_calc: bool | None = None,
         attach_logger: bool = False,
         log_kwargs: dict[str, Any] | None = None,
-        track_carbon: bool = True,
+        track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
         fmax: float = 0.1,
         steps: int = 1000,
@@ -153,7 +154,8 @@ class GeomOpt(BaseCalculation):
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
         track_carbon : bool
-            Whether to track carbon emissions of calculation. Default is True.
+            Whether to track carbon emissions of calculation. Requires attach_logger.
+            Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
         fmax : float

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -499,6 +499,7 @@ class MolecularDynamics(BaseCalculation):
                 "name": self.logger.name,
                 "filemode": "a",
             }
+        self.minimize_kwargs["track_carbon"] = self.track_carbon
 
         self.dyn: Langevin | VelocityVerlet | ASE_NPT
         self.n_atoms = len(self.struct)

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -70,11 +70,12 @@ class MolecularDynamics(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : bool | None
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -186,7 +187,7 @@ class MolecularDynamics(BaseCalculation):
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
-        attach_logger: bool = False,
+        attach_logger: bool | None = None,
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
@@ -248,11 +249,12 @@ class MolecularDynamics(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : bool | None
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool
-            Whether to attach a logger. Default is False.
+        attach_logger : bool | None
+            Whether to attach a logger. Default is True if "filename" is passed in
+            log_kwargs, else False.
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool
+        track_carbon : bool | None
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -75,7 +75,8 @@ class MolecularDynamics(BaseCalculation):
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Requires attach_logger.
+        Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_tracker`. Default is {}.
     struct : Atoms
@@ -187,7 +188,7 @@ class MolecularDynamics(BaseCalculation):
         set_calc: bool | None = None,
         attach_logger: bool = False,
         log_kwargs: dict[str, Any] | None = None,
-        track_carbon: bool = True,
+        track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
         ensemble: Ensembles | None = None,
         steps: int = 0,
@@ -252,7 +253,8 @@ class MolecularDynamics(BaseCalculation):
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
         track_carbon : bool
-            Whether to track carbon emissions of calculation. Default is True.
+            Whether to track carbon emissions of calculation. Requires attach_logger.
+            Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
         ensemble : Ensembles

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -60,7 +60,8 @@ class Phonons(BaseCalculation):
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Requires attach_logger.
+        Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_tracker`. Default is {}.
     calcs : MaybeSequence[PhononCalcs] | None
@@ -165,7 +166,7 @@ class Phonons(BaseCalculation):
         set_calc: bool | None = None,
         attach_logger: bool = False,
         log_kwargs: dict[str, Any] | None = None,
-        track_carbon: bool = True,
+        track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
         calcs: MaybeSequence[PhononCalcs] = (),
         supercell: MaybeList[int] = 2,
@@ -218,7 +219,8 @@ class Phonons(BaseCalculation):
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
         track_carbon : bool
-            Whether to track carbon emissions of calculation. Default is True.
+            Whether to track carbon emissions of calculation. Requires attach_logger.
+            Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
         calcs : MaybeSequence[PhononCalcs] | None

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -353,6 +353,7 @@ class Phonons(BaseCalculation):
                     "name": self.logger.name,
                     "filemode": "a",
                 }
+            self.minimize_kwargs["track_carbon"] = self.track_carbon
 
             # Write out file by default
             self.minimize_kwargs.setdefault("write_results", True)

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -55,11 +55,12 @@ class Phonons(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : bool | None
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -164,7 +165,7 @@ class Phonons(BaseCalculation):
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
-        attach_logger: bool = False,
+        attach_logger: bool | None = None,
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
@@ -214,11 +215,12 @@ class Phonons(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : bool | None
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool
-            Whether to attach a logger. Default is False.
+        attach_logger : bool | None
+            Whether to attach a logger. Default is True if "filename" is passed in
+            log_kwargs, else False.
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool
+        track_carbon : bool | None
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -51,11 +51,12 @@ class SinglePoint(BaseCalculation):
         Keyword arguments to pass to the selected calculator. Default is {}.
     set_calc : bool | None
         Whether to set (new) calculators for structures. Default is None.
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -91,7 +92,7 @@ class SinglePoint(BaseCalculation):
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
-        attach_logger: bool = False,
+        attach_logger: bool | None = None,
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
@@ -124,11 +125,12 @@ class SinglePoint(BaseCalculation):
             Keyword arguments to pass to the selected calculator. Default is {}.
         set_calc : bool | None
             Whether to set (new) calculators for structures. Default is None.
-        attach_logger : bool
-            Whether to attach a logger. Default is False.
+        attach_logger : bool | None
+            Whether to attach a logger. Default is True if "filename" is passed in
+            log_kwargs, else False.
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
-        track_carbon : bool
+        track_carbon : bool | None
             Whether to track carbon emissions of calculation. Requires attach_logger.
             Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -56,7 +56,8 @@ class SinglePoint(BaseCalculation):
     log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Requires attach_logger.
+        Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
     properties : MaybeSequence[Properties]
@@ -92,7 +93,7 @@ class SinglePoint(BaseCalculation):
         set_calc: bool | None = None,
         attach_logger: bool = False,
         log_kwargs: dict[str, Any] | None = None,
-        track_carbon: bool = True,
+        track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
         properties: MaybeSequence[Properties] = (),
         write_results: bool = False,
@@ -128,7 +129,8 @@ class SinglePoint(BaseCalculation):
         log_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_logger`. Default is {}.
         track_carbon : bool
-            Whether to track carbon emissions of calculation. Default is True.
+            Whether to track carbon emissions of calculation. Requires attach_logger.
+            Default is True if attach_logger is True, else False.
         tracker_kwargs : dict[str, Any] | None
             Keyword arguments to pass to `config_tracker`. Default is {}.
         properties : MaybeSequence[Properties]

--- a/janus_core/helpers/log.py
+++ b/janus_core/helpers/log.py
@@ -200,6 +200,12 @@ def config_tracker(
         while carbon_logger.hasHandlers():
             carbon_logger.removeHandler(carbon_logger.handlers[0])
 
+        if not hasattr(tracker, "_emissions"):
+            raise ValueError(
+                "Carbon tracker has not been configured correctly. Please try "
+                "reconfiguring, or disable the tracker."
+            )
+
     else:
         tracker = None
 

--- a/janus_core/helpers/log.py
+++ b/janus_core/helpers/log.py
@@ -161,6 +161,7 @@ def config_tracker(
     country_iso_code: str = "GBR",
     save_to_file: bool = False,
     log_level: Literal["debug", "info", "warning", "error", "critical"] = "critical",
+    **kwargs,
 ) -> OfflineEmissionsTracker | None:
     """
     Configure codecarbon tracker to log outputs.
@@ -177,6 +178,8 @@ def config_tracker(
         Whether to also output results to a csv file. Default is False.
     log_level : Literal["debug", "info", "warning", "error", "critical"]
         Log level of internal carbon tracker log. Default is "critical".
+    **kwargs
+        Additional keyword arguments to pass to OfflineEmissionsTracker.
 
     Returns
     -------
@@ -193,6 +196,7 @@ def config_tracker(
             project_name="janus-core",
             log_level=log_level,
             allow_multiple_runs=True,
+            **kwargs,
         )
 
         # Suppress further logging from codecarbon

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -517,3 +517,38 @@ def selector_len(slc: SliceLike | list, selectable_length: int) -> int:
     if stop is None:
         stop = selectable_length
     return len(range(start, stop, step))
+
+
+def set_log_tracker(
+    attach_logger: bool, log_kwargs: dict, track_carbon: bool
+) -> tuple[bool, bool]:
+    """
+    Set attach_logger and track_carbon default values.
+
+    Parameters
+    ----------
+    attach_logger : bool
+        Whether to attach a logger.
+    log_kwargs : dict[str, Any]
+        Keyword arguments to pass to `config_logger`.
+    track_carbon : bool
+        Whether to track carbon emissions of calculation.
+
+    Returns
+    -------
+    tuple[bool, bool]
+        Default values for attach_logger and track_carbon.
+    """
+    if "filename" in log_kwargs:
+        attach_logger = True
+    else:
+        attach_logger = attach_logger if attach_logger else False
+
+    if not attach_logger:
+        if track_carbon:
+            raise ValueError("Carbon tracking requires logging to be enabled")
+        track_carbon = False
+    else:
+        track_carbon = track_carbon if track_carbon is not None else True
+
+    return attach_logger, track_carbon

--- a/janus_core/training/preprocess.py
+++ b/janus_core/training/preprocess.py
@@ -35,11 +35,12 @@ def preprocess(
     req_file_keys : Sequence[PathLike]
         List of files that must exist if defined in the configuration file.
         Default is ("train_file", "test_file", "valid_file").
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -51,6 +52,11 @@ def preprocess(
     with open(mlip_config, encoding="utf8") as file:
         options = yaml.safe_load(file)
     check_files_exist(options, req_file_keys)
+
+    if "filename" in log_kwargs:
+        attach_logger = True
+    else:
+        attach_logger = attach_logger if attach_logger else False
 
     if not attach_logger:
         if track_carbon:

--- a/janus_core/training/preprocess.py
+++ b/janus_core/training/preprocess.py
@@ -19,7 +19,7 @@ def preprocess(
     req_file_keys: Sequence[PathLike] = ("train_file", "test_file", "valid_file"),
     attach_logger: bool = False,
     log_kwargs: dict[str, Any] | None = None,
-    track_carbon: bool = True,
+    track_carbon: bool | None = None,
     tracker_kwargs: dict[str, Any] | None = None,
 ) -> None:
     """
@@ -40,7 +40,8 @@ def preprocess(
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Requires attach_logger.
+        Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_tracker`. Default is {}.
     """
@@ -50,6 +51,13 @@ def preprocess(
     with open(mlip_config, encoding="utf8") as file:
         options = yaml.safe_load(file)
     check_files_exist(options, req_file_keys)
+
+    if not attach_logger:
+        if track_carbon:
+            raise ValueError("Carbon tracking requires logging to be enabled")
+        track_carbon = False
+    else:
+        track_carbon = track_carbon if track_carbon is not None else True
 
     # Configure logging
     if attach_logger:

--- a/janus_core/training/preprocess.py
+++ b/janus_core/training/preprocess.py
@@ -11,7 +11,7 @@ import yaml
 
 from janus_core.helpers.janus_types import PathLike
 from janus_core.helpers.log import config_logger, config_tracker
-from janus_core.helpers.utils import check_files_exist, none_to_dict
+from janus_core.helpers.utils import check_files_exist, none_to_dict, set_log_tracker
 
 
 def preprocess(
@@ -53,17 +53,9 @@ def preprocess(
         options = yaml.safe_load(file)
     check_files_exist(options, req_file_keys)
 
-    if "filename" in log_kwargs:
-        attach_logger = True
-    else:
-        attach_logger = attach_logger if attach_logger else False
-
-    if not attach_logger:
-        if track_carbon:
-            raise ValueError("Carbon tracking requires logging to be enabled")
-        track_carbon = False
-    else:
-        track_carbon = track_carbon if track_carbon is not None else True
+    attach_logger, track_carbon = set_log_tracker(
+        attach_logger, log_kwargs, track_carbon
+    )
 
     # Configure logging
     if attach_logger:

--- a/janus_core/training/train.py
+++ b/janus_core/training/train.py
@@ -40,11 +40,12 @@ def train(
     req_file_keys : Sequence[PathLike]
         List of files that must exist if defined in the configuration file.
         Default is ("train_file", "test_file", "valid_file", "statistics_file").
-    attach_logger : bool
-        Whether to attach a logger. Default is False.
+    attach_logger : bool | None
+        Whether to attach a logger. Default is True if "filename" is passed in
+        log_kwargs, else False.
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
-    track_carbon : bool
+    track_carbon : bool | None
         Whether to track carbon emissions of calculation. Requires attach_logger.
         Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
@@ -56,6 +57,11 @@ def train(
     with open(mlip_config, encoding="utf8") as file:
         options = yaml.safe_load(file)
     check_files_exist(options, req_file_keys)
+
+    if "filename" in log_kwargs:
+        attach_logger = True
+    else:
+        attach_logger = attach_logger if attach_logger else False
 
     if not attach_logger:
         if track_carbon:

--- a/janus_core/training/train.py
+++ b/janus_core/training/train.py
@@ -24,7 +24,7 @@ def train(
     ),
     attach_logger: bool = False,
     log_kwargs: dict[str, Any] | None = None,
-    track_carbon: bool = True,
+    track_carbon: bool | None = None,
     tracker_kwargs: dict[str, Any] | None = None,
 ) -> None:
     """
@@ -45,7 +45,8 @@ def train(
     log_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_logger`. Default is {}.
     track_carbon : bool
-        Whether to track carbon emissions of calculation. Default is True.
+        Whether to track carbon emissions of calculation. Requires attach_logger.
+        Default is True if attach_logger is True, else False.
     tracker_kwargs : dict[str, Any] | None
         Keyword arguments to pass to `config_tracker`. Default is {}.
     """
@@ -55,6 +56,13 @@ def train(
     with open(mlip_config, encoding="utf8") as file:
         options = yaml.safe_load(file)
     check_files_exist(options, req_file_keys)
+
+    if not attach_logger:
+        if track_carbon:
+            raise ValueError("Carbon tracking requires logging to be enabled")
+        track_carbon = False
+    else:
+        track_carbon = track_carbon if track_carbon is not None else True
 
     # Configure logging
     if attach_logger:

--- a/janus_core/training/train.py
+++ b/janus_core/training/train.py
@@ -11,7 +11,7 @@ import yaml
 
 from janus_core.helpers.janus_types import PathLike
 from janus_core.helpers.log import config_logger, config_tracker
-from janus_core.helpers.utils import check_files_exist, none_to_dict
+from janus_core.helpers.utils import check_files_exist, none_to_dict, set_log_tracker
 
 
 def train(
@@ -58,17 +58,9 @@ def train(
         options = yaml.safe_load(file)
     check_files_exist(options, req_file_keys)
 
-    if "filename" in log_kwargs:
-        attach_logger = True
-    else:
-        attach_logger = attach_logger if attach_logger else False
-
-    if not attach_logger:
-        if track_carbon:
-            raise ValueError("Carbon tracking requires logging to be enabled")
-        track_carbon = False
-    else:
-        track_carbon = track_carbon if track_carbon is not None else True
+    attach_logger, track_carbon = set_log_tracker(
+        attach_logger, log_kwargs, track_carbon
+    )
 
     # Configure logging
     if attach_logger:

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from codecarbon import OfflineEmissionsTracker
+import pytest
 import yaml
 
-from janus_core.helpers.log import config_logger
+from janus_core.helpers.log import config_logger, config_tracker
 from tests.utils import assert_log_contains
 
 
@@ -30,3 +32,24 @@ def test_multiline_log(tmp_path):
     assert len(log_dicts[0]["message"]) == 3
 
     assert_log_contains(log_path, includes=["Line 1", "Line 4"])
+
+
+def test_tracker(tmp_path):
+    """Test tracker can be correctly set up."""
+    from pathlib import Path
+
+    tmp_path = Path(".")
+    log_path = tmp_path / "test.log"
+
+    logger = config_logger(name=__name__, filename=log_path)
+    tracker = config_tracker(janus_logger=logger)
+    assert isinstance(tracker, OfflineEmissionsTracker)
+
+
+def test_tracker_error(tmp_path):
+    """Test tracker raises error if not set up correctly."""
+    log_path = tmp_path / "test.log"
+
+    logger = config_logger(name=__name__, filename=log_path)
+    with pytest.raises(ValueError):
+        config_tracker(janus_logger=logger, country_iso_code="TEST")


### PR DESCRIPTION
Resolves #368

Also resolves various issues relating to logging/tracking, including:

- Setting `attach_logger` default based on whether filename is in `log_kwargs`, which we effectively already did, but did not say we were doing, which is confusing
- Require logging for carbon tracking, which (again) we essentially already did
- Allow kwargs to be passed to carbon tracking, which allows default power etc. to be passed (this may soon provide another alternative to bypass MacOS sudo requests, although not yet)
- Add troubleshooting section for carbon tracking issues
- Raise an error after carbon tracker initialisation if errors occurred, as otherwise it doesn't raise until the calculation is run