### PR TITLE
Implement temporary fix for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
         env:
           # show timings of tests
           PYTEST_ADDOPTS: "--durations=0"
-        run: uv run pytest --run-extra-mlips --cov janus_core --cov-append .
+        run: |
+          unset CI
+          uv run pytest --run-extra-mlips --cov janus_core --cov-append .
 
       - name: Report coverage to Coveralls
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
Resolves #372

See also, discussion in `pymatgen`: https://github.com/materialsproject/pymatgen/issues/4243

I think unsetting `CI` is the only solution, as I think otherwise `os.getenv("CI") is not None` evaluates to `True`, even if `CI` is set to `""`, `False`, etc.

This change should be reverted once #374 is implemented, as we should be able to update monty to include the fix: https://github.com/materialsvirtuallab/monty/pull/735.