### PR TITLE
Fix publishing

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.repository == 'stfc/janus-core' && startsWith(github.ref, 'refs/tags/v')
     environment:
       name: release
+    permissions:
+      # For PyPI's trusted publishing.
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "janus-core"
-version = "0.7.0"
+version = "0.6.6"
 description = "Tools for machine learnt interatomic potentials"
 authors = [
     { name = "Elliott Kasoar" },

--- a/release.sh
+++ b/release.sh
@@ -2,7 +2,7 @@
 
 version=$1
 
-sed -i "s;^version =.*;version = \"$version\";g" pyproject.toml
+sed -i.bak "s;^version =.*;version = \"$version\";g" pyproject.toml && rm pyproject.toml.bak
 
 git add pyproject.toml
 git commit -m "bump version for release $version"


### PR DESCRIPTION
- Revert version bump to reattempt new release
- Adds ID token [required by PyPI](https://docs.pypi.org/trusted-publishers/using-a-publisher/) for trusted publishing - see also: https://github.com/astral-sh/uv/pull/7548
- Fixes release script for MacOS - see https://stackoverflow.com/questions/16745988/sed-command-with-i-option-in-place-editing-works-fine-on-ubuntu-but-not-mac