### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -15,6 +15,8 @@ jobs:
     permissions:
       # For PyPI's trusted publishing.
       id-token: write
+      # For release.
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "janus-core"
-version = "0.7.0"
+version = "0.6.6"
 description = "Tools for machine learnt interatomic potentials"
 authors = [
     { name = "Elliott Kasoar" },


### PR DESCRIPTION
I think by setting the `permissions` explicitly for `id-token`, it removed write permissions, which blocked the release action (previously this was successful, but publishing to PyPI was not).

Adding this back in seemed to work on my fork.