### PR TITLE
Update MLIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Tools for machine learnt interatomic potentials
 
 - Python >= 3.10
 - ASE >= 3.23
-- mace-torch = 0.3.8
+- mace-torch = 0.3.9
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
-- sevenn = 0.10.0 (optional)
-- alignn = 2024.5.27 (optional)
+- sevenn = 0.10.3 (optional)
+- alignn = 2024.12.02 (optional)
 
 All required and optional dependencies can be found in [pyproject.toml](pyproject.toml).
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Tools for machine learnt interatomic potentials
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
 - sevenn = 0.10.3 (optional)
-- alignn = 2024.12.02 (optional)
+- alignn = 2024.5.27 (optional)
 
 All required and optional dependencies can be found in [pyproject.toml](pyproject.toml).
 

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -9,11 +9,11 @@ Dependencies
 
 - Python >= 3.10
 - ASE >= 3.23
-- mace-torch = 0.3.8
+- mace-torch = 0.3.9
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
-- sevenn = 0.10.0 (optional)
-- alignn = 2024.5.27 (optional)
+- sevenn = 0.10.3 (optional)
+- alignn = 2024.12.02 (optional)
 
 All required and optional dependencies can be found in `pyproject.toml <https://github.com/stfc/janus-core/blob/main/pyproject.toml>`_.
 

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -13,7 +13,7 @@ Dependencies
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
 - sevenn = 0.10.3 (optional)
-- alignn = 2024.12.02 (optional)
+- alignn = 2024.5.27 (optional)
 
 All required and optional dependencies can be found in `pyproject.toml <https://github.com/stfc/janus-core/blob/main/pyproject.toml>`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 alignn = [
-    "alignn == 2024.12.02",
+    "alignn == 2024.5.27",
 ]
 chgnet = [
     "chgnet == 0.3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 dependencies = [
     "ase<4.0,>=3.23",
     "codecarbon<3.0.0,>=2.5.0",
-    "mace-torch==0.3.8",
+    "mace-torch==0.3.9",
     "numpy<2.0.0,>=1.26.4",
     "phonopy<3.0.0,>=2.23.1",
     "pyyaml<7.0.0,>=6.0.1",
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 alignn = [
-    "alignn == 2024.5.27",
+    "alignn == 2024.12.02",
 ]
 chgnet = [
     "chgnet == 0.3.8",
@@ -49,7 +49,7 @@ m3gnet = [
     "dgl == 2.1.0",
 ]
 sevennet = [
-    "sevenn == 0.10.0",
+    "sevenn == 0.10.3",
 ]
 all = [
     "janus-core[alignn]",


### PR DESCRIPTION
Updates MACE, ALIGNN and SevenNet

Currently, the energy predicted by ALIGNN seems to have changed (see https://github.com/usnistgov/alignn/issues/178). If this is expected, I'll update the value, but otherwise I may revert that bump, and just update MACE and SevenNet.