### PR TITLE
Tidy PyPI info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ authors = [
 requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,8 @@ all = [
 janus = "janus_core.cli.janus:app"
 
 [project.urls]
-repository = "https://github.com/stfc/janus-core/"
-documentation = "https://stfc.github.io/janus-core/"
+Repository = "https://github.com/stfc/janus-core/"
+Documentation = "https://stfc.github.io/janus-core/"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Since the migration to uv, our Python badge doesn't work. I think we need to add these classifiers - see https://github.com/badges/shields/issues/5550.

Also capitalises the links that appear on [PyPI](https://pypi.org/project/janus-core/).