### PR TITLE
Add Correlator CLI and defaults

### DIFF
--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -335,7 +335,7 @@ The RDF is also computed from the trajectory file and the options ``rdf_start``,
 On-the-fly Processing
 +++++++++++++++++++++
 
-Alongside post-processing correlations may be calculate during MD. This means that, for example, the VAF may be computed without storing trajectory data. To compute the VAF at runtime the following options can be passed:
+Alongside post-processing, correlations may be calculated during MD. This means that, for example, the VAF may be computed without storing trajectory data. To compute the VAF at runtime the following options can be passed:
 
 .. code-block:: bash
 

--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -332,6 +332,33 @@ will compute the RDFs for ``Na`` and ``Cl`` atoms. Seperately for each paring, u
 
 The RDF is also computed from the trajectory file and the options ``rdf_start``, ``rdf_stop``, and ``rdf_step`` may be used to control which trajectory frames are utilised.
 
+On-the-fly Processing
++++++++++++++++++++++
+
+Alongside post-processing correlations may be calculate during MD. This means that, for example, the VAF may be computed without storing trajectory data. To compute the VAF at runtime the following options can be passed:
+
+.. code-block:: bash
+
+   janus md --ensemble nve --struct tests/data/NaCl.cif --steps 100 --correlation-kwargs "{'vaf': {'a': 'Velocity', 'points': 100, 'correlation_frequency': 2}}"
+
+This would result in the file ```janus_results/NaCl-nve-T300.0-cor.dat``` containing the combined VAF for Na and Cl atoms correlated every other step, meaning 50 correlation lag times.
+
+The option ``a`` specifies the Observable to be correlated. Possible values are ``Velocity``, ``Stress``, ``StressHydrostatic``, and ``StressShear``. The latter two stresses combine the diagonal and off-diagonal components of the stress tensor. When ``b`` is not specified it is set to a copy of ``a`` to form an auto-correlation.
+
+Correlation observables may also specify their own keyword arguments. For example to specify the components of stress to correlated over (with the correlations averaged) the following options may be passed:
+
+.. code-block:: bash
+
+   janus md --ensemble nve --struct tests/data/NaCl.cif --steps 100 --correlation-kwargs "{'saf': {'a': 'Stress', 'points': 100, 'a_kwargs': {'components': ['xy', 'yz', 'zx']}}}"
+
+Resulting in the stress auto-correlation function :math:`\frac{1}{3}(\langle\sigma_{xy}\sigma_{xy}\rangle+\langle\sigma_{yz}\sigma_{yz}\rangle+\langle\sigma_{zx}\sigma_{zx}\rangle)`, calculated every step for 100 correlation lag times.
+
+The Velocity observable may also be computed over specific components (it defaults to all) and atom slices. To compute over odd indexed atoms (Na here) the following options may be passed:
+
+.. code-block:: bash
+
+   janus md --ensemble nve --struct tests/data/NaCl.cif --steps 100 --correlation-kwargs "{'vaf': {'a': 'Velocity', 'points': 100, 'a_kwargs': {'atoms_slice': (0, None, 2)}}}"
+
 Heating
 -------
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -156,7 +156,7 @@ class MolecularDynamics(BaseCalculation):
         Keyword arguments to pass to `output_structs` when saving trajectory and final
         files. Default is {}.
     post_process_kwargs
-        Keyword arguments to control post-processing operations.
+        Keyword arguments to control post-processing operations. Default is None.
     correlation_kwargs
         Keyword arguments to control on-the-fly correlations. Default is None.
     seed
@@ -324,9 +324,9 @@ class MolecularDynamics(BaseCalculation):
             Keyword arguments to pass to `output_structs` when saving trajectory and
             final files. Default is {}.
         post_process_kwargs
-            Keyword arguments to control post-processing operations.
+            Keyword arguments to control post-processing operations. Default is None.
         correlation_kwargs
-            Keyword arguments to control on-the-fly correlations.
+            Keyword arguments to control on-the-fly correlations. Default is None.
         seed
             Random seed used by numpy.random and random functions, such as in Langevin.
             Default is None.

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -157,8 +157,8 @@ class MolecularDynamics(BaseCalculation):
         files. Default is {}.
     post_process_kwargs
         Keyword arguments to control post-processing operations.
-    correlation_kwargs : list[CorrelationKwargs] | None
-        Keyword arguments to control on-the-fly correlations.
+    correlation_kwargs
+        Keyword arguments to control on-the-fly correlations. Default is None.
     seed
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -157,7 +157,7 @@ class MolecularDynamics(BaseCalculation):
         files. Default is {}.
     post_process_kwargs
         Keyword arguments to control post-processing operations.
-    correlation_kwargs
+    correlation_kwargs : list[CorrelationKwargs] | None
         Keyword arguments to control on-the-fly correlations.
     seed
         Random seed used by numpy.random and random functions, such as in Langevin.

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -12,6 +12,7 @@ import yaml
 from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
+    CorrelationKwargs,
     Device,
     EnsembleKwargs,
     FilePrefix,
@@ -24,7 +25,7 @@ from janus_core.cli.types import (
     Summary,
     WriteKwargs,
 )
-from janus_core.cli.utils import yaml_converter_callback
+from janus_core.cli.utils import parse_correlation_kwargs, yaml_converter_callback
 
 app = Typer()
 
@@ -221,6 +222,7 @@ def md(
     ] = None,
     write_kwargs: WriteKwargs = None,
     post_process_kwargs: PostProcessKwargs = None,
+    correlation_kwargs: CorrelationKwargs = None,
     seed: Annotated[
         int | None,
         Option(help="Random seed for numpy.random and random functions."),
@@ -350,7 +352,9 @@ def md(
         files. Default is {}.
     post_process_kwargs
         Kwargs to pass to post-processing.
-    seed
+    correlation_kwargs : Optional[CorrelationKwargs]
+        Kwrag to pass for on-the-fly correlations.
+    seed : Optional[int]
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.
     log
@@ -379,7 +383,6 @@ def md(
 
     # Check options from configuration file are all valid
     check_config(ctx)
-
     [
         read_kwargs,
         calc_kwargs,
@@ -397,6 +400,7 @@ def md(
             post_process_kwargs,
         ]
     )
+    correlation_kwargs = parse_correlation_kwargs(correlation_kwargs)
 
     if ensemble not in get_args(Ensembles):
         raise ValueError(f"ensemble must be in {get_args(Ensembles)}")
@@ -482,6 +486,7 @@ def md(
         "temp_time": temp_time,
         "write_kwargs": write_kwargs,
         "post_process_kwargs": post_process_kwargs,
+        "correlation_kwargs": correlation_kwargs,
         "seed": seed,
     }
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -351,9 +351,9 @@ def md(
         Keyword arguments to pass to `output_structs` when saving trajectory and final
         files. Default is {}.
     post_process_kwargs
-        Kwargs to pass to post-processing.
-    correlation_kwargs : Optional[CorrelationKwargs]
-        Kwrag to pass for on-the-fly correlations.
+        Keyword arguments to pass to post-processing. Default is None.
+    correlation_kwargs
+        Keyword arguments to pass for on-the-fly correlations. Default is None.
     seed : Optional[int]
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -400,7 +400,9 @@ def md(
             post_process_kwargs,
         ]
     )
-    correlation_kwargs = parse_correlation_kwargs(correlation_kwargs)
+
+    if correlation_kwargs:
+        correlation_kwargs = parse_correlation_kwargs(correlation_kwargs)
 
     if ensemble not in get_args(Ensembles):
         raise ValueError(f"ensemble must be in {get_args(Ensembles)}")

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -390,6 +390,7 @@ def md(
         ensemble_kwargs,
         write_kwargs,
         post_process_kwargs,
+        correlation_kwargs,
     ] = parse_typer_dicts(
         [
             read_kwargs,
@@ -398,6 +399,7 @@ def md(
             ensemble_kwargs,
             write_kwargs,
             post_process_kwargs,
+            correlation_kwargs,
         ]
     )
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -354,7 +354,7 @@ def md(
         Keyword arguments to pass to post-processing. Default is None.
     correlation_kwargs
         Keyword arguments to pass for on-the-fly correlations. Default is None.
-    seed : Optional[int]
+    seed
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.
     log

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -412,7 +412,7 @@ def md(
         "ensemble_kwargs": ensemble_kwargs.copy(),
         "write_kwargs": write_kwargs.copy(),
         "post_process_kwargs": post_process_kwargs.copy(),
-        "correlation_kwargs": correlation_kwargs.value.copy(),
+        "correlation_kwargs": correlation_kwargs.copy(),
     }
     config = get_config(params=ctx.params, all_kwargs=all_kwargs)
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -401,6 +401,7 @@ def md(
         ]
     )
 
+    # Handle separately to process short-hands, and Observables.
     if correlation_kwargs:
         correlation_kwargs = parse_correlation_kwargs(correlation_kwargs)
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -401,10 +401,6 @@ def md(
         ]
     )
 
-    # Handle separately to process short-hands, and Observables.
-    if correlation_kwargs:
-        correlation_kwargs = parse_correlation_kwargs(correlation_kwargs)
-
     if ensemble not in get_args(Ensembles):
         raise ValueError(f"ensemble must be in {get_args(Ensembles)}")
 
@@ -416,8 +412,13 @@ def md(
         "ensemble_kwargs": ensemble_kwargs.copy(),
         "write_kwargs": write_kwargs.copy(),
         "post_process_kwargs": post_process_kwargs.copy(),
+        "correlation_kwargs": correlation_kwargs.value.copy(),
     }
     config = get_config(params=ctx.params, all_kwargs=all_kwargs)
+
+    # Handle separately to process short-hands, and Observables.
+    if correlation_kwargs:
+        correlation_kwargs = parse_correlation_kwargs(correlation_kwargs)
 
     # Read only first structure by default and ensure only one image is read
     set_read_kwargs_index(read_kwargs)

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 from typing import Annotated, get_args
 
@@ -414,7 +415,7 @@ def md(
         "ensemble_kwargs": ensemble_kwargs.copy(),
         "write_kwargs": write_kwargs.copy(),
         "post_process_kwargs": post_process_kwargs.copy(),
-        "correlation_kwargs": correlation_kwargs.copy(),
+        "correlation_kwargs": deepcopy(correlation_kwargs),
     }
     config = get_config(params=ctx.params, all_kwargs=all_kwargs)
 

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -298,6 +298,21 @@ PostProcessKwargs = Annotated[
     ),
 ]
 
+CorrelationKwargs = Annotated[
+    TyperDict | None,
+    Option(
+        parser=parse_dict_class,
+        help=(
+            """
+            Keyword arguments to pass to md for on-the-fly correlations. Must be
+            passed as a list of dictionaries wrapped in quotes, e.g.
+            "[{'key' : values}]".
+            """
+        ),
+        metavar="DICT",
+    ),
+]
+
 LogPath = Annotated[
     Path | None,
     Option(help=("Path to save logs to. Default is inferred from `file_prefix`")),

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -391,8 +391,8 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
             a_kwargs = b_kwargs
 
         blocks = kwarg["blocks"] if "blocks" in kwarg else 1
-        points = kwarg["points"] if "blocks" in kwarg else 1
-        averaging = kwarg["blocks"] if "blocks" in kwarg else 1
+        points = kwarg["points"] if "points" in kwarg else 1
+        averaging = kwarg["averaging"] if "averaging" in kwarg else 1
         update_frequency = (
             kwarg["update_frequency"] if "update_frequency" in kwarg else 1
         )

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -347,7 +347,7 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
             raise ValueError("At least one observable must be supplied as 'a' or 'b'")
 
         if "points" not in cli_kwargs:
-            raise ValueError("Correlation keyword argument points must be specified")
+            raise ValueError("Correlation keyword argument 'points' must be specified")
 
         # Accept an Observable to be replicated.
         if "b" not in cli_kwargs:

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         PathLike,
     )
 
-from janus_core.processing.observables import Observable, Stress, Velocity
+from janus_core.processing import observables
 
 
 def dict_paths_to_strs(dictionary: dict) -> None:
@@ -326,29 +326,6 @@ def check_config(ctx: Context) -> None:
             raise ValueError(f"'{option}' in configuration file is not a valid option")
 
 
-def _select_observable(name: str, kwargs: dict) -> Observable:
-    """
-    Select an Observable from a string.
-
-    Parameters
-    ----------
-    name : str
-        The name of an Observable to convert.
-    kwargs : dict
-        A list of kwargs of the Observables init.
-
-    Returns
-    -------
-    Observable
-        The selected observable.
-    """
-    if name.lower() == "velocity":
-        return Velocity(**kwargs)
-    if name.lower() == "stress":
-        return Stress(**kwargs)
-    raise ValueError(f"Observable {name} is not valid")
-
-
 def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
     """
     Parse CLI CorrelationKwargs to md correlation_kwargs.
@@ -400,8 +377,8 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
         parsed_kwargs.append(
             {
                 "name": name,
-                "a": _select_observable(a, a_kwargs),
-                "b": _select_observable(b, b_kwargs),
+                "a": getattr(observables, a)(**a_kwargs),
+                "b": getattr(observables, b)(**b_kwargs),
                 "blocks": blocks,
                 "points": points,
                 "averaging": averaging,

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from copy import deepcopy
 import datetime
 import logging
 from pathlib import Path
@@ -348,10 +349,10 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
         # Accept on Observable to be replicated.
         if "b" not in cli_kwargs:
             a = cli_kwargs["a"]
-            b = a
+            b = deepcopy(a)
         elif "a" not in cli_kwargs:
             a = cli_kwargs["b"]
-            b = a
+            b = deepcopy(a)
         else:
             a = cli_kwargs["a"]
             b = cli_kwargs["b"]

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -368,6 +368,7 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
         if "a" not in kwarg and "b" not in kwarg:
             raise ValueError("At least on observable must be supplied as 'a' or 'b'")
 
+        # Accept on Observable to be replicated.
         if "b" not in kwarg:
             a = kwarg["a"]
             b = a
@@ -381,6 +382,9 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
         a_kwargs = kwarg["a_kwargs"] if "a_kwargs" in kwarg else {}
         b_kwargs = kwarg["b_kwargs"] if "b_kwargs" in kwarg else {}
 
+        # Accept "." in place of one kwargs to repeat.
+        if a_kwargs == "." and b_kwargs == ".":
+            raise ValueError("a_kwargs and b_kwargs cannot 'ditto' eachother")
         if a_kwargs and b_kwargs == ".":
             b_kwargs = a_kwargs
         elif b_kwargs and a_kwargs == ".":

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -342,7 +342,7 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
     from janus_core.processing import observables
 
     parsed_kwargs = []
-    for name, cli_kwargs in kwargs.value.items():
+    for name, cli_kwargs in kwargs.items():
         arguments = {
             "blocks",
             "points",

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -343,6 +343,22 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
     """
     parsed_kwargs = []
     for name, cli_kwargs in kwargs.value.items():
+        arguments = {
+            "blocks",
+            "points",
+            "averaging",
+            "update_frequency",
+            "a_kwargs",
+            "b_kwargs",
+            "a",
+            "b",
+        }
+        if not (set(cli_kwargs.keys()) <= arguments):
+            raise ValueError(
+                "correlation_kwargs got unexpected argument(s)"
+                f"{set(cli_kwargs.keys()).difference(arguments)}"
+            )
+
         if "a" not in cli_kwargs and "b" not in cli_kwargs:
             raise ValueError("At least one observable must be supplied as 'a' or 'b'")
 

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -344,7 +344,7 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
     parsed_kwargs = []
     for name, cli_kwargs in kwargs.value.items():
         if "a" not in cli_kwargs and "b" not in cli_kwargs:
-            raise ValueError("At least on3 observable must be supplied as 'a' or 'b'")
+            raise ValueError("At least one observable must be supplied as 'a' or 'b'")
 
         # Accept on Observable to be replicated.
         if "b" not in cli_kwargs:

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -332,18 +332,18 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
 
     Parameters
     ----------
-    kwargs : CorrelationKwargs
+    kwargs
         CLI correlation keyword options.
 
     Returns
     -------
-    List[dict]
+    list[dict]
         The parsed correlation_kwargs for md.
     """
     parsed_kwargs = []
     for name, cli_kwargs in kwargs.value.items():
         if "a" not in cli_kwargs and "b" not in cli_kwargs:
-            raise ValueError("At least on observable must be supplied as 'a' or 'b'")
+            raise ValueError("At least on3 observable must be supplied as 'a' or 'b'")
 
         # Accept on Observable to be replicated.
         if "b" not in cli_kwargs:
@@ -361,7 +361,7 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
 
         # Accept "." in place of one kwargs to repeat.
         if a_kwargs == "." and b_kwargs == ".":
-            raise ValueError("a_kwargs and b_kwargs cannot 'ditto' eachother")
+            raise ValueError("a_kwargs and b_kwargs cannot 'ditto' each other")
         if a_kwargs and b_kwargs == ".":
             b_kwargs = a_kwargs
         elif b_kwargs and a_kwargs == ".":

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -346,13 +346,21 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
         if "a" not in cli_kwargs and "b" not in cli_kwargs:
             raise ValueError("At least one observable must be supplied as 'a' or 'b'")
 
-        # Accept on Observable to be replicated.
+        if "points" not in cli_kwargs:
+            raise ValueError("Correlation keyword argument points must be specified")
+
+        # Accept an Observable to be replicated.
         if "b" not in cli_kwargs:
             a = cli_kwargs["a"]
             b = deepcopy(a)
+            # Copying Observable, so can copy kwargs as well.
+            if "b_kwargs" not in cli_kwargs and "a_kwargs" in cli_kwargs:
+                cli_kwargs["b_kwargs"] = cli_kwargs["a_kwargs"]
         elif "a" not in cli_kwargs:
-            a = cli_kwargs["b"]
-            b = deepcopy(a)
+            b = cli_kwargs["b"]
+            a = deepcopy(b)
+            if "a_kwargs" not in cli_kwargs and "b_kwargs" in cli_kwargs:
+                cli_kwargs["a_kwargs"] = cli_kwargs["b_kwargs"]
         else:
             a = cli_kwargs["a"]
             b = cli_kwargs["b"]
@@ -370,13 +378,13 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
 
         cor_kwargs = {
             "name": name,
+            "points": cli_kwargs["points"],
             "a": getattr(observables, a)(**a_kwargs),
             "b": getattr(observables, b)(**b_kwargs),
         }
 
-        for optional in ["blocks", "points", "averaging", "update_frequency"]:
-            if optional in cli_kwargs:
-                cor_kwargs[optional] = cli_kwargs[optional]
+        for optional in cli_kwargs.keys() & {"blocks", "averaging", "update_frequency"}:
+            cor_kwargs[optional] = cli_kwargs[optional]
 
         parsed_kwargs.append(cor_kwargs)
     return parsed_kwargs

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -24,8 +24,6 @@ if TYPE_CHECKING:
         PathLike,
     )
 
-from janus_core.processing import observables
-
 
 def dict_paths_to_strs(dictionary: dict) -> None:
     """
@@ -341,6 +339,8 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
     list[dict]
         The parsed correlation_kwargs for md.
     """
+    from janus_core.processing import observables
+
     parsed_kwargs = []
     for name, cli_kwargs in kwargs.value.items():
         arguments = {

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -80,7 +80,7 @@ class PostProcessKwargs(TypedDict, total=False):
     vaf_output_files: Sequence[PathLike] | None
 
 
-class CorrelationKwargs(TypedDict, total=True):
+class Correlation(TypedDict, total=True):
     """Arguments for on-the-fly correlations <ab>."""
 
     #: observable a in <ab>, with optional args and kwargs
@@ -98,6 +98,8 @@ class CorrelationKwargs(TypedDict, total=True):
     #: frequency to update the correlation (steps)
     update_frequency: int
 
+
+CorrelationKwargs = list[Correlation]
 
 # eos_names from ase.eos
 EoSNames = Literal[

--- a/janus_core/helpers/janus_types.py
+++ b/janus_core/helpers/janus_types.py
@@ -89,10 +89,10 @@ class Correlation(TypedDict, total=True):
     b: Observable
     #: name used for correlation in output
     name: str
-    #: blocks used in multi-tau algorithm
-    blocks: int
     #: points per block
     points: int
+    #: blocks used in multi-tau algorithm
+    blocks: int
     #: averaging between blocks
     averaging: int
     #: frequency to update the correlation (steps)

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -253,10 +253,10 @@ class Correlation:
         Observable for b.
     name
         Name of correlation.
+    points
+        Number of points per block.
     blocks
         Number of correlation blocks. Default is 1.
-    points
-        Number of points per block. Default is 1.
     averaging
         Averaging window per block level. Default is 1.
     update_frequency
@@ -269,8 +269,8 @@ class Correlation:
         a: Observable,
         b: Observable,
         name: str,
+        points: int,
         blocks: int = 1,
-        points: int = 1,
         averaging: int = 1,
         update_frequency: int = 1,
     ) -> None:
@@ -285,10 +285,10 @@ class Correlation:
             Observable for b.
         name
             Name of correlation.
+        points
+            Number of points per block.
         blocks
             Number of correlation blocks. Default is 1.
-        points
-            Number of points per block. Default is 1.
         averaging
             Averaging window per block level. Default is 1.
         update_frequency

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -253,14 +253,14 @@ class Correlation:
         Observable for b.
     name
         Name of correlation.
-    blocks : int, default 1
-        Number of correlation blocks.
-    points : int, default 1
-        Number of points per block.
-    averaging : int, default 1
-        Averaging window per block level.
-    update_frequency : int, default 1
-        Frequency to update the correlation, md steps.
+    blocks
+        Number of correlation blocks. Default is 1.
+    points
+        Number of points per block. Default is 1.
+    averaging
+        Averaging window per block level. Default is 1.
+    update_frequency
+        Frequency to update the correlation, md steps. Default is 1.
     """
 
     def __init__(
@@ -285,14 +285,14 @@ class Correlation:
             Observable for b.
         name
             Name of correlation.
-        blocks : int, default 1
-            Number of correlation blocks.
-        points : int, default 1
-            Number of points per block.
-        averaging : int, default 1
-            Averaging window per block level.
-        update_frequency : int, default 1
-            Frequency to update the correlation, md steps.
+        blocks
+            Number of correlation blocks. Default is 1.
+        points
+            Number of points per block. Default is 1.
+        averaging
+            Averaging window per block level. Default is 1.
+        update_frequency
+            Frequency to update the correlation, md steps. Default is 1.
         """
         self.name = name
         self.blocks = blocks

--- a/janus_core/processing/correlator.py
+++ b/janus_core/processing/correlator.py
@@ -253,13 +253,13 @@ class Correlation:
         Observable for b.
     name
         Name of correlation.
-    blocks
+    blocks : int, default 1
         Number of correlation blocks.
-    points
+    points : int, default 1
         Number of points per block.
-    averaging
+    averaging : int, default 1
         Averaging window per block level.
-    update_frequency
+    update_frequency : int, default 1
         Frequency to update the correlation, md steps.
     """
 
@@ -269,10 +269,10 @@ class Correlation:
         a: Observable,
         b: Observable,
         name: str,
-        blocks: int,
-        points: int,
-        averaging: int,
-        update_frequency: int,
+        blocks: int = 1,
+        points: int = 1,
+        averaging: int = 1,
+        update_frequency: int = 1,
     ) -> None:
         """
         Initialise a correlation.
@@ -285,13 +285,13 @@ class Correlation:
             Observable for b.
         name
             Name of correlation.
-        blocks
+        blocks : int, default 1
             Number of correlation blocks.
-        points
+        points : int, default 1
             Number of points per block.
-        averaging
+        averaging : int, default 1
             Averaging window per block level.
-        update_frequency
+        update_frequency : int, default 1
             Frequency to update the correlation, md steps.
         """
         self.name = name

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -237,7 +237,7 @@ class Velocity(Observable, ComponentMixin):
     def __init__(
         self,
         *,
-        components: list[str],
+        components: list[str] | None = None,
         atoms_slice: list[int] | SliceLike | None = None,
     ):
         """
@@ -245,13 +245,13 @@ class Velocity(Observable, ComponentMixin):
 
         Parameters
         ----------
-        components
-            Symbols for tensor components, x, y, and z.
-        atoms_slice
+        components : list[str] | None
+            Symbols for returned velocity components, x, y, and z (default is all).
+        atoms_slice : Union[list[int], SliceLike, None]
             List or slice of atoms to observe velocities from.
         """
         ComponentMixin.__init__(self, components={"x": 0, "y": 1, "z": 2})
-        self.components = components
+        self.components = components if components else ["x", "y", "z"]
 
         Observable.__init__(self, atoms_slice)
 

--- a/janus_core/processing/observables.py
+++ b/janus_core/processing/observables.py
@@ -245,9 +245,9 @@ class Velocity(Observable, ComponentMixin):
 
         Parameters
         ----------
-        components : list[str] | None
+        components
             Symbols for returned velocity components, x, y, and z (default is all).
-        atoms_slice : Union[list[int], SliceLike, None]
+        atoms_slice
             List or slice of atoms to observe velocities from.
         """
         ComponentMixin.__init__(self, components={"x": 0, "y": 1, "z": 2})

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -116,6 +116,7 @@ def test_vaf(tmp_path):
             {
                 "a": Velocity(),
                 "b": Velocity(),
+                "points": 1,
                 "name": "vaf_default",
             },
         ],

--- a/tests/test_correlator.py
+++ b/tests/test_correlator.py
@@ -113,6 +113,11 @@ def test_vaf(tmp_path):
                 "averaging": 1,
                 "update_frequency": 1,
             },
+            {
+                "a": Velocity(),
+                "b": Velocity(),
+                "name": "vaf_default",
+            },
         ],
         write_kwargs={"invalidate_calc": False},
     )
@@ -132,6 +137,12 @@ def test_vaf(tmp_path):
     vaf_cl = np.array(vaf["vaf_Cl"]["value"])
     assert vaf_na * 3 == approx(vaf_post[1][0], rel=1e-5)
     assert vaf_cl * 3 == approx(vaf_post[1][1], rel=1e-5)
+
+    # Default arguments are equivalent to mean square velocities.
+    v = np.mean([np.mean(atoms.get_velocities() ** 2) for atoms in traj])
+    vaf_default = vaf["vaf_default"]
+    assert len(vaf_default["value"]) == 1
+    assert v == approx(vaf_default["value"][0], rel=1e-5)
 
 
 def test_md_correlations(tmp_path):

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -70,15 +70,20 @@ def test_md(ensemble):
     }
 
     results_dir = Path("./janus_results")
-    final_path = results_dir / f"{file_prefix[ensemble]}final.extxyz"
-    restart_path = results_dir / f"{file_prefix[ensemble]}res-2.extxyz"
-    stats_path = results_dir / f"{file_prefix[ensemble]}stats.dat"
-    traj_path = results_dir / f"{file_prefix[ensemble]}traj.extxyz"
-    rdf_path = results_dir / f"{file_prefix[ensemble]}rdf.dat"
-    vaf_path = results_dir / f"{file_prefix[ensemble]}vaf.dat"
-    cor_path = results_dir / f"{file_prefix[ensemble]}cor.dat"
-    log_path = results_dir / f"{file_prefix[ensemble]}md-log.yml"
-    summary_path = results_dir / f"{file_prefix[ensemble]}md-summary.yml"
+    paths = {
+        key: results_dir / (file_prefix[ensemble] + name)
+        for key, name in [
+            ("final", "final.extxyz"),
+            ("res-2", "res-2.extxyz"),
+            ("stats", "stats.dat"),
+            ("traj", "traj.extxyz"),
+            ("rdf", "rdf.dat"),
+            ("vaf", "vaf.dat"),
+            ("cor", "cor.dat"),
+            ("md-log", "md-log.yml"),
+            ("md-summary", "md-summary.yml"),
+        ]
+    }
 
     assert not results_dir.exists()
 
@@ -103,8 +108,8 @@ def test_md(ensemble):
                 "{'rdf_compute': True, 'vaf_compute': True}",
                 "--correlation-kwargs",
                 (
-                    "{'vaf': {'a': 'Velocity'},"
-                    " 'vaf_x': {'a': 'Velocity',"
+                    "{'vaf': {'a': 'Velocity', 'points': 10},"
+                    " 'vaf_x': {'a': 'Velocity', 'points': 10,"
                     "'a_kwargs': {'components': ['x']}, 'b_kwargs': '.'}}"
                 ),
             ],
@@ -112,18 +117,11 @@ def test_md(ensemble):
 
         assert result.exit_code == 0
 
-        assert final_path.exists()
-        assert restart_path.exists()
-        assert stats_path.exists()
-        assert traj_path.exists()
-        assert rdf_path.exists()
-        assert vaf_path.exists()
-        assert cor_path.exists()
-        assert log_path.exists()
-        assert summary_path.exists()
+        for file in paths.values():
+            assert file.exists()
 
         # Check at least one image has been saved in trajectory
-        atoms = read(traj_path)
+        atoms = read(paths["traj"])
         assert isinstance(atoms, Atoms)
         assert "energy" in atoms.calc.results
         assert "mace_mp_energy" in atoms.info

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -76,6 +76,7 @@ def test_md(ensemble):
     traj_path = results_dir / f"{file_prefix[ensemble]}traj.extxyz"
     rdf_path = results_dir / f"{file_prefix[ensemble]}rdf.dat"
     vaf_path = results_dir / f"{file_prefix[ensemble]}vaf.dat"
+    cor_path = results_dir / f"{file_prefix[ensemble]}cor.dat"
     log_path = results_dir / f"{file_prefix[ensemble]}md-log.yml"
     summary_path = results_dir / f"{file_prefix[ensemble]}md-summary.yml"
 
@@ -100,6 +101,12 @@ def test_md(ensemble):
                 2,
                 "--post-process-kwargs",
                 "{'rdf_compute': True, 'vaf_compute': True}",
+                "--correlation-kwargs",
+                (
+                    "[{'a': Velocity(), 'b': Velocity(), 'name':"
+                    "'vaf', 'blocks': 1, 'points': 1, 'averaging'"
+                    ": 1, 'update_frequency': 1}]"
+                ),
             ],
         )
 
@@ -111,6 +118,7 @@ def test_md(ensemble):
         assert traj_path.exists()
         assert rdf_path.exists()
         assert vaf_path.exists()
+        assert cor_path.exists()
         assert log_path.exists()
         assert summary_path.exists()
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -70,18 +70,18 @@ def test_md(ensemble):
     }
 
     results_dir = Path("./janus_results")
-    paths = {
+    output_files = {
         key: results_dir / (file_prefix[ensemble] + name)
         for key, name in [
-            ("final", "final.extxyz"),
-            ("res-2", "res-2.extxyz"),
+            ("final_structure", "final.extxyz"),
+            ("restarts", "res-2.extxyz"),
             ("stats", "stats.dat"),
-            ("traj", "traj.extxyz"),
-            ("rdf", "rdf.dat"),
-            ("vaf", "vaf.dat"),
-            ("cor", "cor.dat"),
-            ("md-log", "md-log.yml"),
-            ("md-summary", "md-summary.yml"),
+            ("trajectory", "traj.extxyz"),
+            ("rdfs", "rdf.dat"),
+            ("vafs", "vaf.dat"),
+            ("correlations", "cor.dat"),
+            ("log", "md-log.yml"),
+            ("summary", "md-summary.yml"),
         ]
     }
 
@@ -117,11 +117,11 @@ def test_md(ensemble):
 
         assert result.exit_code == 0
 
-        for file in paths.values():
+        for file in output_files.values():
             assert file.exists()
 
         # Check at least one image has been saved in trajectory
-        atoms = read(paths["traj"])
+        atoms = read(output_files["trajectory"])
         assert isinstance(atoms, Atoms)
         assert "energy" in atoms.calc.results
         assert "mace_mp_energy" in atoms.info
@@ -148,21 +148,13 @@ def test_md(ensemble):
             assert atoms.info["units"][prop] == units
 
         # Read summary
-        with open(summary_path, encoding="utf8") as file:
+        with open(output_files["summary"], encoding="utf8") as file:
             summary = yaml.safe_load(file)
 
-        output_files = {
-            "stats": stats_path,
-            "trajectory": traj_path,
-            "final_structure": final_path,
-            "restarts": [restart_path],
-            "minimized_initial_structure": None,
-            "rdfs": [rdf_path],
-            "vafs": [vaf_path],
-            "correlations": None,
-            "log": log_path,
-            "summary": summary_path,
-        }
+        for path in ("restarts", "rdfs", "vafs"):
+            output_files[path] = [output_files[path]]
+        output_files["minimized_initial_structure"] = None
+
         check_output_files(summary=summary, output_files=output_files)
 
     finally:

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -103,9 +103,9 @@ def test_md(ensemble):
                 "{'rdf_compute': True, 'vaf_compute': True}",
                 "--correlation-kwargs",
                 (
-                    "[{'a': Velocity(), 'b': Velocity(), 'name':"
-                    "'vaf', 'blocks': 1, 'points': 1, 'averaging'"
-                    ": 1, 'update_frequency': 1}]"
+                    "{'vaf': {'a': 'Velocity'},"
+                    " 'vaf_x': {'a': 'velocity',"
+                    "'a_kwargs': {'components': ['x']}, 'b_kwargs': '.'}}"
                 ),
             ],
         )

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -104,7 +104,7 @@ def test_md(ensemble):
                 "--correlation-kwargs",
                 (
                     "{'vaf': {'a': 'Velocity'},"
-                    " 'vaf_x': {'a': 'velocity',"
+                    " 'vaf_x': {'a': 'Velocity',"
                     "'a_kwargs': {'components': ['x']}, 'b_kwargs': '.'}}"
                 ),
             ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -266,9 +266,10 @@ def test_invalid_slicelikes(slc):
 def test_parse_correlation_kwargs():
     """Test parsing correlation CLI kwargs."""
     kwargs = {
-        "vaf": {"a": "Velocity", "b_kwargs": {"components": ["x"]}},
+        "vaf": {"a": "Velocity", "points": 100, "b_kwargs": {"components": ["x"]}},
         "vaf_ditto": {
             "b": "Velocity",
+            "points": 314,
             "a_kwargs": {"atoms_slice": slice(0, None, 2)},
             "b_kwargs": ".",
         },
@@ -279,8 +280,10 @@ def test_parse_correlation_kwargs():
     assert type(parsed[0]["a"]) is type(parsed[0]["b"]) is Velocity
     assert parsed[0]["a"].components == ["x", "y", "z"]
     assert parsed[0]["b"].components == ["x"]
+    assert parsed[0]["points"] == 100
 
     assert parsed[1]["name"] == "vaf_ditto"
     assert type(parsed[1]["a"]) is type(parsed[1]["b"]) is Velocity
     assert parsed[1]["a"].components == parsed[1]["b"].components == ["x", "y", "z"]
     assert parsed[1]["a"].atoms_slice == parsed[1]["b"].atoms_slice == slice(0, None, 2)
+    assert parsed[1]["points"] == 314

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -266,11 +266,15 @@ def test_invalid_slicelikes(slc):
 @pytest.mark.parametrize(
     "kwargs, message",
     [
-        ({"vaf": {"a": "Velocity"}}, "Correlation keyword argument points"),
+        ({"vaf": {"a": "Velocity"}}, "Correlation keyword argument 'points'"),
         ({"vaf": {"points": 10}}, "At least one observable"),
         (
             {"vaf": {"points": 10, "a": "Velocity", "a_kwargs": ".", "b_kwargs": "."}},
             "cannot 'ditto' each other",
+        ),
+        (
+            {"vaf": {"points": 10, "a": "Velocity", "a_kwarg": {}}},
+            "correlation_kwargs got unexpected argument",
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,6 @@ from ase import Atoms
 from ase.io import read
 import pytest
 
-from janus_core.cli.types import TyperDict
 from janus_core.cli.utils import (
     dict_paths_to_strs,
     dict_remove_hyphens,
@@ -281,7 +280,7 @@ def test_invalid_slicelikes(slc):
 def test_parse_correlation_kwargs_errors(kwargs, message):
     """Test parsing of correlation CLI kwargs with ValueErrors."""
     with pytest.raises(ValueError, match=message):
-        parse_correlation_kwargs(TyperDict(kwargs))
+        parse_correlation_kwargs(kwargs)
 
 
 def test_parse_correlation_kwargs_unsupported_observable():
@@ -289,9 +288,7 @@ def test_parse_correlation_kwargs_unsupported_observable():
     with pytest.raises(
         AttributeError, match="'janus_core.processing.observables' has no attribute"
     ):
-        parse_correlation_kwargs(
-            TyperDict({"noa": {"a": "NOT_AN_OBSERVABLE", "points": 10}})
-        )
+        parse_correlation_kwargs({"noa": {"a": "NOT_AN_OBSERVABLE", "points": 10}})
 
 
 def test_parse_correlation_kwargs():
@@ -319,7 +316,7 @@ def test_parse_correlation_kwargs():
             "b_kwargs": ".",
         },
     }
-    parsed = parse_correlation_kwargs(TyperDict(kwargs))
+    parsed = parse_correlation_kwargs(kwargs)
     assert len(parsed) == 5
 
     assert parsed[0]["name"] == "vaf"


### PR DESCRIPTION
- Adds CLI arguments for requesting correlations defined in ```janus_core.processing.observables```.
- Adds default values for ```blocks=1```, ```points=1```, ```averaging=1``` and ```update_frequency=1``` in```janus_core.processing.correlator.Correlation```.
- Add default for ```Velocity``` (all components, all atoms)
- Fixes docstring in ```md.py```.

Last thing to do is add text in the user_guide 

---

Currently this is example functionality

```shell
janus md \
--ensemble nve --struct tests/data/NaCl.cif \
--steps 10 --correlation-kwargs \
"{'vaf1': {'a': 'velocity', 'points': 10}, 'vaf_x': {'a': 'velocity', 'update_frequency': 2, 'points': 10, 'a_kwargs': {'components': ['x']}, 'b_kwargs': '.'}}"
```
Syntax
- If one of 'a' and 'b' is omitted it is duplicated. 
- The special "ditto" kwarg value "." indicates copying the kwargs.
- 'blocks', 'points' etc have defaults which are not thought out yet.


it results in
```shell
cat NaCl-nve-T300.0-cor.dat
vaf1:
  lags: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
  value: [0.0005823628861742493, 0.0005829660336725057, 0.0005832862278350698, 0.0005833234400626741,
    0.0005830778925578795, 0.0005825500577781349, 0.0005817406577431897, 0.0005806506631988626,
    0.0005792812926375899, 0.0005776340111746314]
vaf_x:
  lags: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
  value: [0.0005445815119304412, 0.0005449602181734653, 0.0005449448511073212, 0.0005445360209632227,
    0.0005437350402279519, 0.0005425439175493092]