### PR TITLE
Update ASE

### DIFF
--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -15,6 +15,7 @@ from warnings import warn
 from ase import Atoms
 from ase.geometry.analysis import Analysis
 from ase.io import read
+from ase.md.bussi import Bussi
 from ase.md.langevin import Langevin
 from ase.md.npt import NPT as ASE_NPT
 from ase.md.velocitydistribution import (
@@ -1581,13 +1582,6 @@ class NVT_CSVR(NVT):  # noqa: N801 (invalid-class-name)
         **kwargs
             Additional keyword arguments.
         """
-        try:
-            from ase.md.bussi import Bussi
-        except ImportError as e:
-            raise NotImplementedError(
-                "Please download the latest ASE commits to use this module."
-            ) from e
-
         super().__init__(*args, ensemble=ensemble, **kwargs)
 
         (ensemble_kwargs,) = none_to_dict(ensemble_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 readme = "README.md"
 
 dependencies = [
-    "ase<4.0,>=3.23",
+    "ase<4.0,>=3.24",
     "codecarbon<3.0.0,>=2.5.0",
     "mace-torch==0.3.8",
     "numpy<2.0.0,>=1.26.4",

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -9,20 +9,11 @@ from ase.io import read
 import numpy as np
 import pytest
 
-from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_NH
+from janus_core.calculations.md import NPH, NPT, NVE, NVT, NVT_CSVR, NVT_NH
 from janus_core.calculations.single_point import SinglePoint
 from janus_core.helpers.mlip_calculators import choose_calculator
 from janus_core.helpers.stats import Stats
 from tests.utils import assert_log_contains
-
-try:
-    from ase.md.bussi import Bussi  # noqa: F401
-
-    from janus_core.calculations.md import NVT_CSVR
-
-    ASE_IMPORT_ERROR = False
-except ImportError:
-    ASE_IMPORT_ERROR = True
 
 DATA_PATH = Path(__file__).parent / "data"
 MODEL_PATH = Path(__file__).parent / "models" / "mace_mp_small.model"
@@ -235,7 +226,6 @@ def test_nph():
         stats_path.unlink(missing_ok=True)
 
 
-@pytest.mark.skipif(ASE_IMPORT_ERROR, reason="Requires updated version of ASE")
 def test_nvt_csvr():
     """Test NVT CSVR molecular dynamics."""
     restart_path_1 = Path("NaCl-nvt-csvr-T300.0-res-2.extxyz")

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -14,13 +14,6 @@ import yaml
 from janus_core.cli.janus import app
 from tests.utils import assert_log_contains, clear_log_handlers, strip_ansi_codes
 
-try:
-    from ase.md.bussi import Bussi  # noqa: F401
-
-    ASE_IMPORT_ERROR = False
-except ImportError:
-    ASE_IMPORT_ERROR = True
-
 DATA_PATH = Path(__file__).parent / "data"
 
 runner = CliRunner()
@@ -55,9 +48,6 @@ def test_md(ensemble):
         "nph": "NaCl-nph-T300.0-p0.0-",
         "nvt-csvr": "NaCl-nvt-csvr-T300.0-",
     }
-
-    if ensemble == "nvt-csvr" and ASE_IMPORT_ERROR:
-        return
 
     final_path = Path(f"{file_prefix[ensemble]}final.extxyz").absolute()
     restart_path = Path(f"{file_prefix[ensemble]}res-2.extxyz").absolute()


### PR DESCRIPTION
The CI has been running 3.24 since its release in December, but this makes sure it's updated, which means we can drop checks for the Bussi thermostat, as well as include any other [improvements made](https://wiki.fysik.dtu.dk/ase/releasenotes.html#releasenotes).