### PR TITLE
Add ipykernel dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ Documentation = "https://stfc.github.io/janus-core/"
 [dependency-groups]
 dev = [
     "coverage[toml]<8.0.0,>=7.4.1",
+    "ipykernel>=6.29.5",
     "pgtest<2.0.0,>=1.3.2",
     "pytest<9.0,>=8.0",
     "pytest-cov<5.0.0,>=4.1.0",


### PR DESCRIPTION
Required for using uv virtual environments with Jupyter notebooks