### PR TITLE
Test tutorials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
           version: "0.5.7"
           python-version: "3.12"
 
+      - name: Install pandoc
+        uses: pandoc/actions/setup@v1
+
       - name: Install dependencies
         run: uv sync
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pandoc
+        uses: pandoc/actions/setup@v1
+
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install
+      - name: Install pandoc
         uses: pandoc/actions/setup@v1
 
       - name: Install uv

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -7,7 +7,50 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+*
 
 jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    if: github.repository == 'stfc/janus-core' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install
+        uses: pandoc/actions/setup@v1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.7"
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Build docs with tutorials
+        run: cd docs && uv run make all
+
+      - name: Upload
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: './docs/build/html/.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
   publish:
+    needs: build-docs
     runs-on: ubuntu-latest
     if: github.repository == 'stfc/janus-core' && startsWith(github.ref, 'refs/tags/v')
     environment:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@
 
 Tools for machine learnt interatomic potentials
 
+## Contents
+- [Getting started](#getting-started)
+- [Features](#features)
+- [Python interface](#python-interface)
+- [Command line interface](#command-line-interface)
+- [Development](#development)
+- [License](#license)
+- [Funding](#funding)
+
 ## Getting started
 
 ### Dependencies
@@ -103,6 +112,87 @@ Current and planned features include:
   - MACE
 - [ ] Rare events simulations
   - PLUMED
+
+
+## Python interface
+
+Calculations can also be run through the Python interface. For example, running:
+
+```python
+from janus_core.calculations.single_point import SinglePoint
+
+single_point = SinglePoint(
+    struct_path="tests/data/NaCl.cif",
+    arch="mace_mp",
+    model_path="tests/models/mace_mp_small.model",
+)
+
+results = single_point.run()
+print(results)
+```
+
+will read the NaCl structure file and attach the MACE-MP (medium) calculator, before calculating and printing the energy, forces, and stress.
+
+Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the [tutorials](https://github.com/stfc/janus-core/tree/main/docs/source/tutorials) documentation directory. This currently includes examples for:
+
+- [Single Point](docs/source/tutorials/single_point.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb)
+- [Geometry Optimization](docs/source/tutorials/geom_opt.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb)
+- [Molecular Dynamics](docs/source/tutorials/md.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb)
+- [Equation of State](docs/source/tutorials/eos.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb)
+- [Phonons](docs/source/tutorials/phonons.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb)
+
+
+### Calculation outputs
+
+By default, calculations performed will modify the underlying [ase.Atoms](https://wiki.fysik.dtu.dk/ase/ase/atoms.html) object
+to store information in the `Atoms.info` and `Atoms.arrays` dictionaries about the MLIP used.
+
+Additional dictionary keys include `arch`, corresponding to the MLIP architecture used,
+and `model_path`, corresponding to the model path, name or label.
+
+Results from the MLIP calculator, which are typically stored in `Atoms.calc.results`, will also, by default,
+be copied to these dictionaries, prefixed by the MLIP `arch`.
+
+For example:
+
+```python
+from janus_core.calculations.single_point import SinglePoint
+
+single_point = SinglePoint(
+    struct_path="tests/data/NaCl.cif",
+    arch="mace_mp",
+    model_path="tests/models/mace_mp_small.model",
+)
+
+single_point.run()
+print(single_point.struct.info)
+```
+
+will return
+
+```python
+{
+  'spacegroup': Spacegroup(1, setting=1),
+  'unit_cell': 'conventional',
+  'occupancy': {'0': {'Na': 1.0}, '1': {'Cl': 1.0}, '2': {'Na': 1.0}, '3': {'Cl': 1.0}, '4': {'Na': 1.0}, '5': {'Cl': 1.0}, '6': {'Na': 1.0}, '7': {'Cl': 1.0}},
+  'model_path': 'tests/models/mace_mp_small.model',
+  'arch': 'mace_mp',
+  'mace_mp_energy': -27.035127799332745,
+  'mace_mp_stress': array([-4.78327600e-03, -4.78327600e-03, -4.78327600e-03,  1.08000967e-19, -2.74004242e-19, -2.04504710e-19]),
+  'system_name': 'NaCl',
+}
+```
+
+> [!NOTE]
+> If running calculations with multiple MLIPs, `arch` and `mlip_model` will be overwritten with the most recent MLIP information.
+> Results labelled by the architecture (e.g. `mace_mp_energy`) will be saved between MLIPs,
+> unless the same `arch` is chosen, in which case these values will also be overwritten.
+
+This is also the case the calculations performed using the CLI, with the same information written to extxyz output files.
+
+> [!TIP]
+> For complete provenance tracking, calculations and training can be run using the [aiida-mlip](https://github.com/stfc/aiida-mlip/) AiiDA plugin.
+
 
 ## Command line interface
 
@@ -198,86 +288,6 @@ This will run a singlepoint energy calculation on `KCl.cif` using the [MACE-MP](
 > `properties` must be passed as a Yaml list, as above, not as a string.
 
 Example configurations for all commands can be found in [janus-tutorials](https://github.com/stfc/janus-tutorials/tree/main/configs)
-
-
-## Python interface
-
-Calculations can also be run through the Python interface. For example, running:
-
-```python
-from janus_core.calculations.single_point import SinglePoint
-
-single_point = SinglePoint(
-    struct_path="tests/data/NaCl.cif",
-    arch="mace_mp",
-    model_path="tests/models/mace_mp_small.model",
-)
-
-results = single_point.run()
-print(results)
-```
-
-will read the NaCl structure file and attach the MACE-MP (medium) calculator, before calculating and printing the energy, forces, and stress.
-
-Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the [tutorials](https://github.com/stfc/janus-core/tree/main/docs/source/tutorials) documentation directory. This currently includes examples for:
-
-- [Single Point](docs/source/tutorials/single_point.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb)
-- [Geometry Optimization](docs/source/tutorials/geom_opt.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb)
-- [Molecular Dynamics](docs/source/tutorials/md.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb)
-- [Equation of State](docs/source/tutorials/eos.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb)
-- [Phonons](docs/source/tutorials/phonons.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb)
-
-
-## Calculation outputs
-
-By default, calculations performed will modify the underlying [ase.Atoms](https://wiki.fysik.dtu.dk/ase/ase/atoms.html) object
-to store information in the `Atoms.info` and `Atoms.arrays` dictionaries about the MLIP used.
-
-Additional dictionary keys include `arch`, corresponding to the MLIP architecture used,
-and `model_path`, corresponding to the model path, name or label.
-
-Results from the MLIP calculator, which are typically stored in `Atoms.calc.results`, will also, by default,
-be copied to these dictionaries, prefixed by the MLIP `arch`.
-
-For example:
-
-```python
-from janus_core.calculations.single_point import SinglePoint
-
-single_point = SinglePoint(
-    struct_path="tests/data/NaCl.cif",
-    arch="mace_mp",
-    model_path="tests/models/mace_mp_small.model",
-)
-
-single_point.run()
-print(single_point.struct.info)
-```
-
-will return
-
-```python
-{
-  'spacegroup': Spacegroup(1, setting=1),
-  'unit_cell': 'conventional',
-  'occupancy': {'0': {'Na': 1.0}, '1': {'Cl': 1.0}, '2': {'Na': 1.0}, '3': {'Cl': 1.0}, '4': {'Na': 1.0}, '5': {'Cl': 1.0}, '6': {'Na': 1.0}, '7': {'Cl': 1.0}},
-  'model_path': 'tests/models/mace_mp_small.model',
-  'arch': 'mace_mp',
-  'mace_mp_energy': -27.035127799332745,
-  'mace_mp_stress': array([-4.78327600e-03, -4.78327600e-03, -4.78327600e-03,  1.08000967e-19, -2.74004242e-19, -2.04504710e-19]),
-  'system_name': 'NaCl',
-}
-```
-
-> [!NOTE]
-> If running calculations with multiple MLIPs, `arch` and `mlip_model` will be overwritten with the most recent MLIP information.
-> Results labelled by the architecture (e.g. `mace_mp_energy`) will be saved between MLIPs,
-> unless the same `arch` is chosen, in which case these values will also be overwritten.
-
-This is also the case the calculations performed using the CLI, with the same information written to extxyz output files.
-
-> [!TIP]
-> For complete provenance tracking, calculations and training can be run using the [aiida-mlip](https://github.com/stfc/aiida-mlip/) AiiDA plugin.
 
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ print(results)
 
 will read the NaCl structure file and attach the MACE-MP (medium) calculator, before calculating and printing the energy, forces, and stress.
 
-Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the [janus-tutorials](https://github.com/stfc/janus-tutorials) repository. This currently includes examples for:
+Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the [tutorials](https://github.com/stfc/janus-core/tree/main/docs/source/tutorials) documentation directory. This currently includes examples for:
 
-- [Single Point](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb)
-- [Geometry Optimization](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb)
-- [Molecular Dynamics](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb)
-- [Equation of State](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb)
-- [Phonons](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb)
+- [Single Point](docs/source/tutorials/single_point.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb)
+- [Geometry Optimization](docs/source/tutorials/geom_opt.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb)
+- [Molecular Dynamics](docs/source/tutorials/md.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb)
+- [Equation of State](docs/source/tutorials/eos.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb)
+- [Phonons](docs/source/tutorials/phonons.ipynb) [![badge](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb)
 
 
 ## Calculation outputs

--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ will read the NaCl structure file and attach the MACE-MP (medium) calculator, be
 
 Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the [janus-tutorials](https://github.com/stfc/janus-tutorials) repository. This currently includes examples for:
 
-- [Single Point](https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/single_point.ipynb)
-- [Geometry Optimization](https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/geom_opt.ipynb)
-- [Molecular Dynamics](https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/md.ipynb)
-- [Equation of State](https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/eos.ipynb)
-- [Phonons](https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/phonons.ipynb)
+- [Single Point](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb)
+- [Geometry Optimization](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb)
+- [Molecular Dynamics](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb)
+- [Equation of State](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb)
+- [Phonons](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb)
 
 
 ## Calculation outputs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,16 +26,20 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 customdefault:
 	$(SPHINXBUILD) -b html -nW --keep-going $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
-all: html
+all: tutorials
 
 clean:
 	rm -rf $(BUILDDIR)
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -D nbsphinx_execute=never
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+tutorials:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 view:
 	xdg-open $(BUILDDIR)/html/index.html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinxcontrib.contentui",
     "sphinx_copybutton",
     "sphinx_autodoc_typehints",
+    "nbsphinx",
 ]
 
 always_use_bars_union = True

--- a/docs/source/developer_guide/get_started.rst
+++ b/docs/source/developer_guide/get_started.rst
@@ -109,7 +109,10 @@ The full set of `ruff rules <https://docs.astral.sh/ruff/rules/>`_ are specified
 Building the documentation
 ++++++++++++++++++++++++++
 
-Packages in the ``docs`` dependency group install `Sphinx <https://www.sphinx-doc.org>`_ and other packages required to build ``janus-core``'s documentation.
+Packages in the ``docs`` dependency group install `Sphinx <https://www.sphinx-doc.org>`_
+and other Python packages required to build ``janus-core``'s documentation.
+
+It is also necessary to `install pandoc <https://pandoc.org/installing.html>`_ on your system.
 
 Individual individual documentation pages can be edited directly::
 
@@ -141,6 +144,19 @@ To document a new module, a new block must be added. For example, for the ``janu
 
         cd docs
         make clean; make html
+
+
+Notebook tutorials
+++++++++++++++++++
+
+Jupyter notebooks in ``docs/source/tutorials`` are automatically run by ``Sphinx`` using the
+`nbsphinx <https://nbsphinx.readthedocs.io/en/0.2.15/index.html>`_ extension, creating the :doc:`Tutorials </tutorials/index>`.
+
+
+These are tested before ``janus-core`` is published to PyPI, but can be tested locally by running::
+
+        cd docs
+        make clean; make tutorials
 
 
 Continuous integration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,9 +16,9 @@ Welcome to janus-core's documentation!
 
    getting_started/getting_started
    user_guide/index
+   tutorials/index
    developer_guide/index
    API documentation <apidoc/janus_core>
-   tutorials/single_point
 
 ``janus-core`` is released under the `BSD 3-Clause license <https://opensource.org/license/bsd-3-clause/>`_.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Welcome to janus-core's documentation!
    user_guide/index
    developer_guide/index
    API documentation <apidoc/janus_core>
+   tutorials/single_point
 
 ``janus-core`` is released under the `BSD 3-Clause license <https://opensource.org/license/bsd-3-clause/>`_.
 

--- a/docs/source/tutorials/eos.ipynb
+++ b/docs/source/tutorials/eos.ipynb
@@ -7,7 +7,7 @@
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb)"
    ]
   },
   {

--- a/docs/source/tutorials/eos.ipynb
+++ b/docs/source/tutorials/eos.ipynb
@@ -1,0 +1,334 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4vcbRxmIhHLL"
+   },
+   "source": [
+    "# Equation of State"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment (optional)\n",
+    "\n",
+    "These steps are required for Google Colab, but may work on other systems too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TF-EiWxyuMc7"
+   },
+   "outputs": [],
+   "source": [
+    "# import locale\n",
+    "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "# !python3 -m pip install janus-core[all]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase import Atoms\n",
+    "from ase.io import read\n",
+    "from ase.visualize import view\n",
+    "from data_tutorials.data import get_data\n",
+    "\n",
+    "from janus_core.calculations.eos import EoS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `data_tutorials` to get the data required for this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
+    "    filename=[\"beta_quartz.cif\"],\n",
+    "    folder=\"data\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Equation of state for α-quartz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build the structure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "α_quartz = Atoms(\n",
+    "    symbols=(*[\"Si\"] * 3, *[\"O\"] * 6),\n",
+    "    scaled_positions=[\n",
+    "        [0.469700, 0.000000, 0.000000],\n",
+    "        [0.000000, 0.469700, 0.666667],\n",
+    "        [0.530300, 0.530300, 0.333333],\n",
+    "        [0.413500, 0.266900, 0.119100],\n",
+    "        [0.266900, 0.413500, 0.547567],\n",
+    "        [0.733100, 0.146600, 0.785767],\n",
+    "        [0.586500, 0.853400, 0.214233],\n",
+    "        [0.853400, 0.586500, 0.452433],\n",
+    "        [0.146600, 0.733100, 0.880900],\n",
+    "    ],\n",
+    "    cell=[\n",
+    "        [4.916000, 0.000000, 0.000000],\n",
+    "        [-2.45800, 4.257381, 0.000000],\n",
+    "        [0.000000, 0.000000, 5.405400],\n",
+    "    ],\n",
+    "    pbc=True,\n",
+    ")\n",
+    "\n",
+    "view(α_quartz, viewer=\"x3d\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate the equation of state using the MACE-MP potential:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mace_eos = EoS(\n",
+    "    struct=α_quartz.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    minimize_kwargs={\"filter_func\": None},\n",
+    "    min_volume=0.75,\n",
+    "    max_volume=1.25,\n",
+    "    n_volumes=20,\n",
+    ").run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mace_eos[\"eos\"].plot(show=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Equation of state for β-quartz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perform the same calculation for β-quartz:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "β_quartz = read(\"data/beta_quartz.cif\")\n",
+    "view(β_quartz, viewer=\"x3d\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mace_eos_beta = EoS(\n",
+    "    struct=β_quartz.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    minimize_kwargs={\"filter_func\": None},\n",
+    "    min_volume=0.75,\n",
+    "    max_volume=1.25,\n",
+    "    n_volumes=20,\n",
+    ").run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mace_eos_beta[\"eos\"].plot(show=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Combining plots for α-quartz and β-quartz:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "ax = plt.gca()\n",
+    "\n",
+    "data_alpha = mace_eos[\"eos\"].getplotdata()\n",
+    "data_beta = mace_eos_beta[\"eos\"].getplotdata()\n",
+    "\n",
+    "ax.plot(data_alpha[4], data_alpha[5], ls=\"-\", color=\"C3\", label=\"α-quartz\")\n",
+    "ax.plot(data_alpha[6], data_alpha[7], ls=\"\", marker=\"x\", color=\"C4\", mfc=\"C4\")\n",
+    "\n",
+    "ax.plot(data_beta[4], data_beta[5], ls=\"-\", color=\"C0\", label=\"β-quartz\")\n",
+    "ax.plot(data_beta[6], data_beta[7], ls=\"\", marker=\"x\", color=\"C2\", mfc=\"C2\")\n",
+    "\n",
+    "ax.set_xlabel(\"volume [Å$^3$]\")\n",
+    "ax.set_ylabel(\"energy [eV]\")\n",
+    "ax.legend()\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comparing MACE to CHGNET and MGNET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m3gnet_eos = EoS(\n",
+    "    struct=α_quartz.copy(),\n",
+    "    arch=\"m3gnet\",\n",
+    "    device=\"cpu\",\n",
+    "    minimize_kwargs={\"filter_func\": None},\n",
+    ").run()\n",
+    "\n",
+    "m3gnet_eos[\"eos\"].plot(show=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chgnet_eos = EoS(\n",
+    "    struct=α_quartz.copy(),\n",
+    "    arch=\"chgnet\",\n",
+    "    device=\"cpu\",\n",
+    "    minimize_kwargs={\"filter_func\": None},\n",
+    ").run()\n",
+    "\n",
+    "chgnet_eos[\"eos\"].plot(show=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"MACE energy [eV]: {mace_eos['e_0']}\")\n",
+    "print(f\"M3GNET energy [eV]: {m3gnet_eos['e_0']}\")\n",
+    "print(f\"CHGNET energy [eV]: {chgnet_eos['e_0']}\")\n",
+    "\n",
+    "print()\n",
+    "\n",
+    "print(f\"MACE volume [Å^3]: {mace_eos['v_0']}\")\n",
+    "print(f\"M3GNET volume [Å^3]: {m3gnet_eos['v_0']}\")\n",
+    "print(f\"CHGNET volume [Å^3]: {chgnet_eos['v_0']}\")\n",
+    "\n",
+    "print()\n",
+    "\n",
+    "print(f\"MACE bulk_modulus [GPa]: {mace_eos['bulk_modulus']}\")\n",
+    "print(f\"M3GNET bulk_modulus [GPa]: {m3gnet_eos['bulk_modulus']}\")\n",
+    "print(f\"CHGNET bulk_modulus [GPa]: {chgnet_eos['bulk_modulus']}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "authorship_tag": "ABX9TyNvtIsPHVgkt0NvUv51T6ZG",
+   "gpuType": "T4",
+   "include_colab_link": true,
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/source/tutorials/geom_opt.ipynb
+++ b/docs/source/tutorials/geom_opt.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4vcbRxmIhHLL"
+   },
+   "source": [
+    "# Geometry Optimization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment (optional)\n",
+    "\n",
+    "These steps are required for Google Colab, but may work on other systems too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TF-EiWxyuMc7"
+   },
+   "outputs": [],
+   "source": [
+    "# import locale\n",
+    "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "# !python3 -m pip install janus-core[all]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from ase.optimize import FIRE\n",
+    "from ase.visualize import view\n",
+    "from data_tutorials.data import get_data\n",
+    "\n",
+    "from janus_core.calculations.single_point import SinglePoint\n",
+    "from janus_core.calculations.geom_opt import GeomOpt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `data_tutorials` to get the data required for this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
+    "    filename=[\"NaCl-deformed.cif\"],\n",
+    "    folder=\"data\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prepare for optimization of a deformed salt structure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NaCl = read(\"data/NaCl-deformed.cif\")\n",
+    "view(NaCl, viewer=\"x3d\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sp_mace = SinglePoint(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    properties=\"energy\",\n",
+    ")\n",
+    "\n",
+    "init_energy = sp_mace.run()[\"energy\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To optimize only the atomic positions and not the cell, set `filter_func = None`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimized_NaCl = GeomOpt(\n",
+    "    struct=sp_mace.struct,\n",
+    "    fmax=0.001,\n",
+    "    filter_func=None,\n",
+    ")\n",
+    "\n",
+    "optimized_NaCl.run()\n",
+    "view(optimized_NaCl.struct, viewer=\"x3d\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check energy has been lowered, and cell is unchanged:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Initial cell: {NaCl.cell.cellpar()}\")\n",
+    "print(f\"Initial energy: {init_energy}\")\n",
+    "\n",
+    "print(f\"Final cell: {optimized_NaCl.struct.cell.cellpar()}\")\n",
+    "print(f\"Final energy: {optimized_NaCl.struct.get_potential_energy()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Optimizing cell vectors and atomic positions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Setting `filter_kwargs = {\"hydrostatic_strain\": True}` allows the cell lengths to be changed, in addition to atomic positions, but cell angles remain fixed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimized_NaCl_lengths = GeomOpt(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    fmax=0.001,\n",
+    "    filter_kwargs={\"hydrostatic_strain\": True},\n",
+    ")\n",
+    "optimized_NaCl_lengths.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check energy has been lowered, and cell lengths have been updated, but angles remain unchanged:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Initial cell: {NaCl.cell.cellpar()}\")\n",
+    "print(f\"Initial energy: {init_energy}\")\n",
+    "\n",
+    "print(f\"Final cell: {optimized_NaCl_lengths.struct.cell.cellpar()}\")\n",
+    "print(f\"Final energy: {optimized_NaCl_lengths.struct.get_potential_energy()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Optimizing at constant pressure and volume"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculations can also be run at a fixed pressure and volume, by setting `filter_kwargs = {\"scalar_pressure\": x, \"constant_volume\": True}`\n",
+    "\n",
+    "By default, both the cell lengths and angles will be optimized, in addition to the atomic positions.\n",
+    "\n",
+    "We can also set the optimizer function and filter function used, either by passing the function itself (e.g. `FIRE`) or passing the name of the ASE function (e.g. `\"ExpCellFilter\"`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimized_NaCl_pressure = GeomOpt(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    fmax=0.01,\n",
+    "    filter_kwargs={\"scalar_pressure\": 0.05, \"constant_volume\": True},\n",
+    "    optimizer=FIRE,\n",
+    "    filter_func=\"ExpCellFilter\",\n",
+    ")\n",
+    "optimized_NaCl_pressure.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check cell lengths and angles have both been updated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Initial cell: {NaCl.cell.cellpar()}\")\n",
+    "print(f\"Initial energy: {init_energy}\")\n",
+    "\n",
+    "print(f\"Final cell: {optimized_NaCl_pressure.struct.cell.cellpar()}\")\n",
+    "print(f\"Final energy: {optimized_NaCl_pressure.struct.get_potential_energy()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing MACE to CHGNet and M3GNet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimized_NaCl_mace = GeomOpt(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    fmax=0.01,\n",
+    ")\n",
+    "optimized_NaCl_mace.run()\n",
+    "\n",
+    "optimized_NaCl_chgnet = GeomOpt(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"chgnet\",\n",
+    "    device=\"cpu\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    fmax=0.01,\n",
+    ")\n",
+    "optimized_NaCl_chgnet.run()\n",
+    "\n",
+    "optimized_NaCl_m3gnet = GeomOpt(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"m3gnet\",\n",
+    "    device=\"cpu\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    fmax=0.01,\n",
+    ")\n",
+    "optimized_NaCl_m3gnet.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Initial energy: {init_energy}\")\n",
+    "\n",
+    "print(f\"Final energy (MACE): {optimized_NaCl_mace.struct.get_potential_energy()}\")\n",
+    "print(f\"Final energy (CHGNET): {optimized_NaCl_chgnet.struct.get_potential_energy()}\")\n",
+    "print(f\"Final energy (M3GNET): {optimized_NaCl_m3gnet.struct.get_potential_energy()}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "authorship_tag": "ABX9TyNvtIsPHVgkt0NvUv51T6ZG",
+   "gpuType": "T4",
+   "include_colab_link": true,
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/source/tutorials/geom_opt.ipynb
+++ b/docs/source/tutorials/geom_opt.ipynb
@@ -7,7 +7,7 @@
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb)"
    ]
   },
   {

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -1,0 +1,12 @@
+=========
+Tutorials
+=========
+
+.. toctree::
+    :maxdepth: 3
+
+    single_point
+    geom_opt
+    md
+    eos
+    phonons

--- a/docs/source/tutorials/md.ipynb
+++ b/docs/source/tutorials/md.ipynb
@@ -1,0 +1,367 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4vcbRxmIhHLL"
+   },
+   "source": [
+    "# Molecular Dynamics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment (optional)\n",
+    "\n",
+    "These steps are required for Google Colab, but may work on other systems too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TF-EiWxyuMc7"
+   },
+   "outputs": [],
+   "source": [
+    "# import locale\n",
+    "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "# !python3 -m pip install janus-core[all]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cgch8VQ--AES"
+   },
+   "outputs": [],
+   "source": [
+    "from ase.build import bulk\n",
+    "from ase.visualize import view\n",
+    "from ase.io import read\n",
+    "from data_tutorials.data import get_data\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from janus_core.calculations.md import NVE, NVT\n",
+    "from janus_core.helpers.stats import Stats\n",
+    "from janus_core.processing import post_process"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `data_tutorials` to get the data required for this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
+    "    filename=[\"precomputed_NaCl-traj.xyz\"],\n",
+    "    folder=\"data\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cooling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Build NaCl structure and attach the MACE calculator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
+    "NaCl = NaCl * (2, 2, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view(NaCl, viewer=\"x3d\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prepare a simulation, cooling the structure from 300K to 200K in stepx of 20K, with 5fs at each temperature:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cooling = NVT(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    temp_start=300.0,\n",
+    "    temp_end=200.0,\n",
+    "    temp_step=20,\n",
+    "    temp_time=5,\n",
+    "    stats_every=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run cooling:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cooling.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The final structures at each temperature are saved in `Cl32Na32-nvt-T300.0-final.xyz`, `Cl32Na32-nvt-T280.0-final.xyz`, ..., `Cl32Na32-nvt-T200.0-final.xyz`.\n",
+    "\n",
+    "The statiscs from the simulation are also saved every 20 steps in `Cl32Na32-nvt-T300.0-T200.0-stats.dat`. This can then be analysed using the `Stats` module:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = Stats(\"Cl32Na32-nvt-T300.0-T200.0-stats.dat\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(data[0], data[5], label=\"Actual\")\n",
+    "plt.plot(data[0], data[16], label=\"Target\")\n",
+    "plt.legend()\n",
+    "plt.xlabel(\"Steps\")\n",
+    "plt.ylabel(\"Temperature / K\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Heating, followed by MD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will prepare an NVT MD simulation, initially increasing the temperature from 0K to 300K in 20K steps, with 1fs at each temperature, before a further 10 steps (10fs) at 300K.\n",
+    "\n",
+    "The final structure at each temperature will be saved, e.g. `Cl32Na32-nvt-T0-final.xyz`, `Cl32Na32-nvt-T0-final.xyz`, ..., `Cl32Na32-nvt-T300-final.xyz.`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "heating = NVT(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    temp_start=0,  # Start of temperature ramp\n",
+    "    temp_end=300.0,  # End of temperature ramp\n",
+    "    temp_step=20,  # Temperature ramp increments\n",
+    "    temp_time=1,  # Time at each temperature in ramp\n",
+    "    temp=300,  # MD temperature\n",
+    "    steps=10,  # MD steps at 300K\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "heating.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same structure can then be used to run an additional NVE MD similation for 50 steps (50fs), with post-processing performed to compute the RDF by setting `post_process_kwargs = {\"rdf_compute\": True}`, with the results saved to `Cl32Na32-nve-rdf.dat`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md = NVE(\n",
+    "    struct=heating.struct,\n",
+    "    temp=300,\n",
+    "    stats_every=5,\n",
+    "    steps=50,\n",
+    "    post_process_kwargs={\"rdf_compute\": True, \"rdf_rmax\": 5, \"rdf_bins\": 200},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "md.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rdf = np.loadtxt(\"Cl32Na32-nve-T300-rdf.dat\")\n",
+    "bins, counts = zip(*rdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(bins, counts)\n",
+    "plt.ylabel(\"RDF\")\n",
+    "plt.xlabel(\"Distance / Å\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same post-processing can also be performed separately after completing the simulation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = read(\"data/precomputed_NaCl-traj.xyz\", index=\":\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rdf = post_process.compute_rdf(data, rmax=5.0, nbins=200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(rdf[0], rdf[1])\n",
+    "plt.ylabel(\"RDF\")\n",
+    "plt.xlabel(\"Distance / Å\")\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "authorship_tag": "ABX9TyNvtIsPHVgkt0NvUv51T6ZG",
+   "gpuType": "T4",
+   "include_colab_link": true,
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/source/tutorials/md.ipynb
+++ b/docs/source/tutorials/md.ipynb
@@ -7,7 +7,7 @@
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb)"
    ]
   },
   {

--- a/docs/source/tutorials/phonons.ipynb
+++ b/docs/source/tutorials/phonons.ipynb
@@ -1,0 +1,490 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4vcbRxmIhHLL"
+   },
+   "source": [
+    "# Phonons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment (optional)\n",
+    "\n",
+    "These steps are required for Google Colab, but may work on other systems too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TF-EiWxyuMc7"
+   },
+   "outputs": [],
+   "source": [
+    "# import locale\n",
+    "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "# !python3 -m pip install janus-core[all]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "857K7R9Cenca"
+   },
+   "source": [
+    "## Phonons (periodic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.build import bulk\n",
+    "\n",
+    "from janus_core.calculations.phonons import Phonons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prepare for phonon calculations on salt "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Set `filter_func = None` for geometry optimization via `minimize_kwargs`, so cell is fixed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace = Phonons(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    supercell=[2, 2, 2],\n",
+    "    displacement=0.01,\n",
+    "    temp_step=10.0,\n",
+    "    temp_min=0.0,\n",
+    "    temp_max=1000.0,\n",
+    "    minimize=False,\n",
+    "    force_consts_to_hdf5=True,\n",
+    "    plot_to_file=True,\n",
+    "    symmetrize=False,\n",
+    "    write_full=True,\n",
+    "    minimize_kwargs={\"filter_func\": None},\n",
+    "    write_results=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Optimize structure and calculate force constants using phonopy.\n",
+    "\n",
+    "This will save phonopy to `Cl4Na4-phonopy.yml`, and additionally save force constants to `Cl4Na4-force_constants.hdf5`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace.calc_force_constants()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check cell parameters have not been changed by optimization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(phonons_mace.struct.cell.cellpar())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate and plot band structure, writing results to `Cl4Na4-auto_bands.yml`, and saving the figure as `Cl4Na4-auto_bands.svg`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace.calc_bands(write_bands=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculate thermal properties, saving the heat capacity, enthalpy, and entropy, to `Cl4Na4-thermal.dat`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace.calc_thermal_props(write_thermal=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Phonon calcualtions with optimization of cell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same calculations can be run with cell lengths, but not angles, optimized.\n",
+    "\n",
+    "Note: Set `\"filter_kwargs\" = {\"hydrostatic_strain\": True}` for geometry optimization via `minimize_kwargs`, so cell angles are fixed, but lengths can change"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace_lengths_only = Phonons(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    supercell=[2, 2, 2],\n",
+    "    displacement=0.01,\n",
+    "    temp_step=10.0,\n",
+    "    temp_min=0.0,\n",
+    "    temp_max=1000.0,\n",
+    "    minimize=True,\n",
+    "    force_consts_to_hdf5=True,\n",
+    "    plot_to_file=True,\n",
+    "    symmetrize=False,\n",
+    "    write_full=True,\n",
+    "    minimize_kwargs={\"filter_kwargs\": {\"hydrostatic_strain\": True}},\n",
+    "    write_results=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace_lengths_only.calc_bands(write_bands=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Confirm changes to cell lengths:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(phonons_mace_lengths_only.struct.cell.cellpar())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Phonon calculations with pressure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calculations can also be run at a fixed pressure, as well as optmising both the cell lengths and angles.\n",
+    "\n",
+    "Note: Set `\"filter_kwargs\" = {\"scalar_pressure\": x}` for geometry optimization via `minimize_kwargs` to set the pressure. Without setting `hydrostatic_strain =  True`, both the cell lengths and angles will be optimized "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace_pressure = Phonons(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=\"cpu\",\n",
+    "    model_path=\"small\",\n",
+    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
+    "    supercell=[2, 2, 2],\n",
+    "    displacement=0.01,\n",
+    "    temp_step=10.0,\n",
+    "    temp_min=0.0,\n",
+    "    temp_max=1000.0,\n",
+    "    minimize=True,\n",
+    "    force_consts_to_hdf5=True,\n",
+    "    plot_to_file=True,\n",
+    "    symmetrize=False,\n",
+    "    write_full=True,\n",
+    "    minimize_kwargs={\"filter_kwargs\": {\"scalar_pressure\": 0.1}},\n",
+    "    write_results=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace_pressure.calc_bands(write_bands=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Confirm changes to cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(phonons_mace_pressure.struct.cell.cellpar())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare band structures for different optimization options and save to files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace.write_bands(plot_file=\"NaCl_mace.svg\")\n",
+    "phonons_mace_lengths_only.write_bands(plot_file=\"NaCl_lengths_only.svg\")\n",
+    "phonons_mace_pressure.write_bands(plot_file=\"NaCl_pressure.svg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing the band structure from MACE to CHGNet and M3GNet:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate band structure using CHGNET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_chgnet = Phonons(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"chgnet\",\n",
+    "    device=\"cpu\",\n",
+    "    supercell=[2, 2, 2],\n",
+    "    displacement=0.01,\n",
+    "    temp_step=10.0,\n",
+    "    temp_min=0.0,\n",
+    "    temp_max=1000.0,\n",
+    "    minimize=True,\n",
+    "    force_consts_to_hdf5=True,\n",
+    "    plot_to_file=True,\n",
+    "    symmetrize=False,\n",
+    "    write_full=True,\n",
+    "    minimize_kwargs={\"filter_func\": None},\n",
+    "    write_results=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_chgnet.calc_bands(write_bands=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calculate band structure using M3GNET"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_m3gnet = Phonons(\n",
+    "    struct=NaCl.copy(),\n",
+    "    arch=\"m3gnet\",\n",
+    "    device=\"cpu\",\n",
+    "    supercell=[2, 2, 2],\n",
+    "    displacement=0.01,\n",
+    "    temp_step=10.0,\n",
+    "    temp_min=0.0,\n",
+    "    temp_max=1000.0,\n",
+    "    minimize=True,\n",
+    "    force_consts_to_hdf5=True,\n",
+    "    plot_to_file=True,\n",
+    "    symmetrize=False,\n",
+    "    write_full=True,\n",
+    "    minimize_kwargs={\"filter_func\": None},\n",
+    "    write_results=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_m3gnet.calc_bands(write_bands=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compare and save plots for each MLIP:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phonons_mace.write_bands(plot_file=\"MACE.svg\")\n",
+    "phonons_chgnet.write_bands(plot_file=\"chgnet.svg\")\n",
+    "phonons_m3gnet.write_bands(plot_file=\"m3gnet.svg\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: It may be necessary to reset the default PyTorch dtype if different calculators have been set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "torch.set_default_dtype(torch.float64)\n",
+    "\n",
+    "phonons_mace.calc_force_constants()"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "authorship_tag": "ABX9TyNvtIsPHVgkt0NvUv51T6ZG",
+   "gpuType": "T4",
+   "include_colab_link": true,
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/source/tutorials/phonons.ipynb
+++ b/docs/source/tutorials/phonons.ipynb
@@ -7,7 +7,7 @@
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb)"
    ]
   },
   {

--- a/docs/source/tutorials/single_point.ipynb
+++ b/docs/source/tutorials/single_point.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Single Point"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4vcbRxmIhHLL"
+   },
+   "source": [
+    "`janus-core` contains various machine learnt interatomic potentials (MLIPs), including MACE based models (MACE-MP, MACE-OFF), CHGNet, and matgl based M3GNet.\n",
+    "\n",
+    "Other will be added as their utility is proven beyond a specific material."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment (optional)\n",
+    "\n",
+    "These steps are required for Google Colab, but may work on other systems too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TF-EiWxyuMc7"
+   },
+   "outputs": [],
+   "source": [
+    "# import locale\n",
+    "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "# !python3 -m pip install janus-core[all]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `data_tutorials` to get the data required for this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_tutorials.data import get_data\n",
+    "\n",
+    "get_data(\n",
+    "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
+    "    filename=[\"sucrose.xyz\", \"NaCl-set.xyz\"],\n",
+    "    folder=\"data\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "857K7R9Cenca"
+   },
+   "source": [
+    "## Single point calculations for periodic system"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cgch8VQ--AES"
+   },
+   "outputs": [],
+   "source": [
+    "from ase.build import bulk\n",
+    "\n",
+    "from janus_core.calculations.single_point import SinglePoint\n",
+    "\n",
+    "# Change to cuda if you have a gpu or mps for apple silicon\n",
+    "device = \"cpu\"\n",
+    "\n",
+    "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
+    "sp = SinglePoint(\n",
+    "    struct=NaCl,\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=device,\n",
+    "    calc_kwargs={\"model_paths\": \"small\", \"default_dtype\": \"float64\"},\n",
+    ")\n",
+    "\n",
+    "res_mace = sp.run()\n",
+    "\n",
+    "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
+    "sp = SinglePoint(\n",
+    "    struct=NaCl,\n",
+    "    arch=\"m3gnet\",\n",
+    "    device=device,\n",
+    ")\n",
+    "\n",
+    "res_chgnet = sp.run()\n",
+    "\n",
+    "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
+    "sp = SinglePoint(\n",
+    "    struct=NaCl,\n",
+    "    arch=\"chgnet\",\n",
+    "    device=device,\n",
+    ")\n",
+    "\n",
+    "res_m3gnet = sp.run()\n",
+    "\n",
+    "print(f\"  MACE[eV]: {res_mace['energy']}\")\n",
+    "print(f\"M3GNET[eV]: {res_m3gnet['energy']}\")\n",
+    "print(f\"CHGNET[eV]: {res_chgnet['energy']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "fDt01muwC5fl"
+   },
+   "source": [
+    "## Simple Molecules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "cbvNchA4_dEq"
+   },
+   "outputs": [],
+   "source": [
+    "from ase.build import molecule\n",
+    "from ase.visualize import view\n",
+    "\n",
+    "from janus_core.calculations.single_point import SinglePoint\n",
+    "\n",
+    "sp = SinglePoint(\n",
+    "    struct=molecule(\"H2O\"),\n",
+    "    arch=\"mace_off\",\n",
+    "    device=device,\n",
+    "    calc_kwargs={\"model_paths\": \"medium\"},\n",
+    ")\n",
+    "res = sp.run()\n",
+    "print(res)\n",
+    "view(NaCl, viewer=\"x3d\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "lazs3WCKC3fY"
+   },
+   "source": [
+    "## Sugar on salt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "WHHUSn7gCz-l"
+   },
+   "outputs": [],
+   "source": [
+    "from ase.build import add_adsorbate, bulk\n",
+    "from ase.io import read, write\n",
+    "from ase.visualize import view\n",
+    "\n",
+    "a = 5.63\n",
+    "NaCl = bulk(\n",
+    "    \"NaCl\", crystalstructure=\"rocksalt\", cubic=True, orthorhombic=True, a=5.63\n",
+    ") * (6, 6, 3)\n",
+    "\n",
+    "NaCl.center(vacuum=20.0, axis=2)\n",
+    "sugar = read(\"data/sucrose.xyz\")\n",
+    "add_adsorbate(slab=NaCl, adsorbate=sugar, height=4.5, position=(10, 10))\n",
+    "write(\"slab.xyz\", NaCl)\n",
+    "\n",
+    "sp = SinglePoint(\n",
+    "    struct_path=\"slab.xyz\",\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=device,\n",
+    "    calc_kwargs={\"model_paths\": \"small\"},\n",
+    ")\n",
+    "res = sp.run()\n",
+    "print(res)\n",
+    "view(NaCl, viewer=\"x3d\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "7BDbwfmDE-BO"
+   },
+   "source": [
+    "## Calculate an entire collection of data frames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "frames = read(\"data/NaCl-set.xyz\", format=\"extxyz\", index=\":\")\n",
+    "dft_energy = np.array([s.info[\"dft_energy\"] / len(s) for s in frames])\n",
+    "\n",
+    "sp = SinglePoint(\n",
+    "    struct_path=\"data/NaCl-set.xyz\",\n",
+    "    arch=\"mace_mp\",\n",
+    "    device=device,\n",
+    "    calc_kwargs={\"model_paths\": \"small\"},\n",
+    ")\n",
+    "sp.run()\n",
+    "\n",
+    "mace_mp_energy = np.array([s.info[\"mace_mp_energy\"] / len(s) for s in sp.struct])\n",
+    "rmse_mace = np.linalg.norm(mace_mp_energy - dft_energy) / np.sqrt(len(dft_energy))\n",
+    "\n",
+    "sp = SinglePoint(struct_path=\"data/NaCl-set.xyz\", arch=\"chgnet\", device=device)\n",
+    "sp.run()\n",
+    "\n",
+    "chgnet_energy = np.array([s.info[\"chgnet_energy\"] / len(s) for s in sp.struct])\n",
+    "rmse_chgnet = np.linalg.norm(chgnet_energy - dft_energy) / np.sqrt(len(dft_energy))\n",
+    "\n",
+    "sp = SinglePoint(struct_path=\"data/NaCl-set.xyz\", arch=\"m3gnet\", device=device)\n",
+    "sp.run()\n",
+    "\n",
+    "m3gnet_energy = np.array([s.info[\"m3gnet_energy\"] / len(s) for s in sp.struct])\n",
+    "rmse_m3gnet = np.linalg.norm(m3gnet_energy - dft_energy) / np.sqrt(len(dft_energy))\n",
+    "\n",
+    "print(\n",
+    "    f\"rmse: mace_mp = {rmse_mace}, chgnet = {rmse_chgnet}, \"\n",
+    "    f\"m3gnet = {rmse_m3gnet} eV/atom\"\n",
+    ")\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "ax.scatter(dft_energy, mace_mp_energy, marker=\"o\", label=\"mace-mp-0\")\n",
+    "ax.scatter(dft_energy, m3gnet_energy, marker=\"x\", label=\"m3gnet\")\n",
+    "ax.scatter(dft_energy, chgnet_energy, marker=\"+\", label=\"chgnet\")\n",
+    "ax.legend()\n",
+    "plt.xlabel(\"MLIP [eV/atom]\")\n",
+    "plt.ylabel(\"DFT [eV/atom]\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "authorship_tag": "ABX9TyNvtIsPHVgkt0NvUv51T6ZG",
+   "gpuType": "T4",
+   "include_colab_link": true,
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/tutorials/single_point.ipynb
+++ b/docs/source/tutorials/single_point.ipynb
@@ -7,7 +7,7 @@
     "id": "view-in-github"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb)"
    ]
   },
   {

--- a/docs/source/user_guide/python.rst
+++ b/docs/source/user_guide/python.rst
@@ -4,11 +4,11 @@ Python interface
 
 Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the `janus-tutorials <https://github.com/stfc/janus-tutorials>`_ repository. This currently includes examples for:
 
-- `Single Point <https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/single_point.ipynb>`_
-- `Geometry Optimization <https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/geom_opt.ipynb>`_
-- `Molecular Dynamics <https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/md.ipynb>`_
-- `Equation of State <https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/eos.ipynb>`_
-- `Phonons <https://colab.research.google.com/github/stfc/janus-tutorials/blob/main/phonons.ipynb>`_
+- `Single Point <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb>`_
+- `Geometry Optimization <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb>`_
+- `Molecular Dynamics <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb>`_
+- `Equation of State <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb>`_
+- `Phonons <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb>`_
 
 
 Calculation outputs

--- a/docs/source/user_guide/python.rst
+++ b/docs/source/user_guide/python.rst
@@ -2,13 +2,33 @@
 Python interface
 ================
 
-Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the `janus-tutorials <https://github.com/stfc/janus-tutorials>`_ repository. This currently includes examples for:
+Jupyter Notebook tutorials illustrating the use of currently available calculations can be found in the `tutorials <https://github.com/stfc/janus-core/tree/main/docs/source/tutorials>`_ documentation directory. This currently includes examples for:
 
-- `Single Point <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb>`_
-- `Geometry Optimization <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb>`_
-- `Molecular Dynamics <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb>`_
-- `Equation of State <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb>`_
-- `Phonons <https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb>`_
+.. |single_point| image:: https://colab.research.google.com/assets/colab-badge.svg
+    :target: https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/single_point.ipynb
+    :alt: Launch single point Colab
+
+.. |geom_opt| image:: https://colab.research.google.com/assets/colab-badge.svg
+    :target: https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/geom_opt.ipynb
+    :alt: Launch geometry optimisation Colab
+
+.. |md| image:: https://colab.research.google.com/assets/colab-badge.svg
+    :target: https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/md.ipynb
+    :alt: Launch molecular dynamics Colab
+
+.. |eos| image:: https://colab.research.google.com/assets/colab-badge.svg
+    :target: https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/eos.ipynb
+    :alt: Launch equation of state Colab
+
+.. |phonons| image:: https://colab.research.google.com/assets/colab-badge.svg
+    :target: https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/phonons.ipynb
+    :alt: Launch phonons Colab
+
+- :doc:`Single Point </tutorials/single_point>` |single_point|
+- :doc:`Geometry Optimization </tutorials/geom_opt>` |geom_opt|
+- :doc:`Molecular Dynamics </tutorials/md>` |md|
+- :doc:`Equation of State </tutorials/eos>` |eos|
+- :doc:`Phonons </tutorials/phonons>` |phonons|
 
 
 Calculation outputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "data-tutorials>=0.3.1",
     "ipykernel>=6.29.5",
     "jupyter>=1.1.1",
+    "nbsphinx>=0.9.6",
     "pgtest<2.0.0,>=1.3.2",
     "pytest<9.0,>=8.0",
     "pytest-cov<5.0.0,>=4.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ pythonpath = ["."]
 source=["janus_core"]
 
 [tool.ruff]
-exclude = ["conf.py"]
+exclude = ["conf.py", "*ipynb"]
 target-version = "py310"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,6 @@ dev = [
     "coverage[toml]<8.0.0,>=7.4.1",
     "data-tutorials>=0.3.1",
     "ipykernel>=6.29.5",
-    "jupyter>=1.1.1",
-    "nbsphinx>=0.9.6",
     "pgtest<2.0.0,>=1.3.2",
     "pytest<9.0,>=8.0",
     "pytest-cov<5.0.0,>=4.1.0",
@@ -84,7 +82,9 @@ dev = [
 
 docs = [
     "furo<2025.0.0,>=2024.1.29",
+    "jupyter>=1.1.1",
     "markupsafe<2.1",
+    "nbsphinx>=0.9.6",
     "numpydoc<2.0.0,>=1.6.0",
     "sphinx<9.0.0,>=8.0.2",
     "sphinxcontrib-contentui<1.0.0,>=0.2.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,9 @@ Documentation = "https://stfc.github.io/janus-core/"
 [dependency-groups]
 dev = [
     "coverage[toml]<8.0.0,>=7.4.1",
+    "data-tutorials>=0.3.1",
     "ipykernel>=6.29.5",
+    "jupyter>=1.1.1",
     "pgtest<2.0.0,>=1.3.2",
     "pytest<9.0,>=8.0",
     "pytest-cov<5.0.0,>=4.1.0",


### PR DESCRIPTION
Resolves #386

Adds basic tutorials from https://github.com/stfc/janus-tutorials, with minor formatting changes.

These are built as part of the publishing workflow, so must run successfully before janus-core is published to PyPI.

An example: https://elliottkasoar.github.io/janus-core/tutorials/single_point.html

To do:

- [x] Add note in dev docs for building/running, including need to install pandoc on system