### PR TITLE
Specify Python version in dev docs

### DIFF
--- a/docs/source/developer_guide/get_started.rst
+++ b/docs/source/developer_guide/get_started.rst
@@ -21,17 +21,17 @@ This provides a number of useful features, including:
 
 Dependencies useful for development can then be installed by running::
 
-    uv sync
+    uv sync -p 3.12
     source .venv/bin/activate
 
 
 Extras, such as optional MLIPs, can also be installed by running::
 
-    uv sync --extra alignn --extra sevennet
+    uv sync -p 3.12 --extra alignn --extra sevennet
 
 or to install all supported MLIPs::
 
-    uv sync --all-extras
+    uv sync -p 3.12 --all-extras
 
 
 Using uv


### PR DESCRIPTION
By default, uv will try to install Python 3.13 on a system with no existing Python 3 (e.g. scarf, before modules have been loaded).

Specifying different Python versions with `-p` is discussed in the section below, but since people may copy and paste these to get started, it's probably safest to specify this here explicitly.