### PR TITLE
Add progress bars to single point calculations

### DIFF
--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -139,6 +139,7 @@ def singlepoint(
         "attach_logger": True,
         "log_kwargs": log_kwargs,
         "track_carbon": tracker,
+        "enable_progress_bar": True,
     }
 
     # Initialise singlepoint structure and calculator


### PR DESCRIPTION
Closes #403

Adds progress bars identical to #319 to single point calculations when applied to multiple frames:

![Loading bars](https://github.com/user-attachments/assets/a6feffe7-a570-454e-ba3a-d5fdd28db583)


Because each property is calculated in a separate loop, there is one progress bar per property for now. I'm happy to try to make it one overall progress bar if that's preferred.