### PR TITLE
Update codecarbon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ readme = "README.md"
 
 dependencies = [
     "ase<4.0,>=3.24",
-    "codecarbon<3.0.0,>=2.5.0",
+    "codecarbon<3.0.0,>=2.8.3",
     "mace-torch==0.3.9",
     "numpy<2.0.0,>=1.26.4",
     "phonopy<3.0.0,>=2.23.1",


### PR DESCRIPTION
We require at least 2.7, as of #316, to use the `allow_multiple_runs` option that was added, but our requirements were not updated to match this at the time.

I've bumped it slightly higher, to include other new features, unless this causes any problems.