### PR TITLE
Update mace

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tools for machine learnt interatomic potentials
 
 - Python >= 3.10
 - ASE >= 3.24
-- mace-torch = 0.3.9
+- mace-torch = 0.3.10
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
 - sevenn = 0.10.3 (optional)

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -9,7 +9,7 @@ Dependencies
 
 - Python >= 3.10
 - ASE >= 3.24
-- mace-torch = 0.3.9
+- mace-torch = 0.3.10
 - chgnet = 0.3.8 (optional)
 - matgl = 1.1.3 (optional)
 - sevenn = 0.10.3 (optional)

--- a/janus_core/training/preprocess.py
+++ b/janus_core/training/preprocess.py
@@ -67,17 +67,7 @@ def preprocess(
     if logger and "foundation_model" in options:
         logger.info("Fine tuning model: %s", options["foundation_model"])
 
-    # Parse options from config, as MACE cannot read config file yet
-    args = []
-    for key, value in options.items():
-        if isinstance(value, bool):
-            if value is True:
-                args.append(f"--{key}")
-        else:
-            args.append(f"--{key}")
-            args.append(f"{value}")
-
-    mlip_args = mace_parser().parse_args(args)
+    mlip_args = mace_parser().parse_args(["--config", str(mlip_config)])
 
     if logger:
         logger.info("Starting preprocessing")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ readme = "README.md"
 dependencies = [
     "ase<4.0,>=3.24",
     "codecarbon<3.0.0,>=2.5.0",
-    "mace-torch==0.3.9",
+    "mace-torch==0.3.10",
     "numpy<2.0.0,>=1.26.4",
     "phonopy<3.0.0,>=2.23.1",
     "pyyaml<7.0.0,>=6.0.1",


### PR DESCRIPTION
Updates mace to 3.10, which also allows us to pass the configuration file directly to `preprocess`.

3.10 includes strings for newer foundational models, and other improvements: https://github.com/ACEsuit/mace/releases/tag/v0.3.10