### PR TITLE
Add MD progress bar

### DIFF
--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -215,6 +215,13 @@ def md(
     tracker: Annotated[
         bool, Option(help="Whether to save carbon emissions of calculation")
     ] = True,
+    enable_progress_bar: Annotated[
+        bool,
+        Option(
+            "--enable-progress-bar/--disable-progress-bar",
+            help="Whether to show progress bar.",
+        ),
+    ] = True,
     summary: Summary = None,
 ) -> None:
     """
@@ -343,6 +350,8 @@ def md(
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
+    enable_progress_bar
+        Whether to show progress bar.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
@@ -456,6 +465,7 @@ def md(
         "write_kwargs": write_kwargs,
         "post_process_kwargs": post_process_kwargs,
         "seed": seed,
+        "enable_progress_bar": enable_progress_bar,
     }
 
     # Instantiate MD ensemble

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1205,3 +1205,28 @@ def test_set_info(tmp_path):
     final_struct = read(traj_path, index="-1")
     assert npt.struct.info["density"] == pytest.approx(2.120952627887493)
     assert final_struct.info["density"] == pytest.approx(2.120952627887493)
+
+
+@pytest.mark.parametrize("ensemble, tag", test_data)
+def test_progress_bar_complete(tmp_path, ensemble, tag):
+    """Test progress bar completes in all ensembles."""
+    file_prefix = tmp_path / f"Cl4Na4-{tag}-T300.0"
+
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="mace",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+    md = ensemble(
+        struct=single_point.struct,
+        steps=2,
+        file_prefix=file_prefix,
+        enable_progress_bar=True,
+    )
+
+    md.run()
+
+    # Force 1 extra call to observer functions than expected.
+    # If progress bar already completed, it will raise StopIteration/RuntimeError.
+    with pytest.raises((RuntimeError, StopIteration)):
+        md.dyn.call_observers()


### PR DESCRIPTION
Resolves #405 

I think there are a few ways that this could be done - this one (attaching the progress bar as an observer function) does not discriminate between heating and production MD steps. I tried using `irun` as had been suggested, but since half of the ASE ensembles don't support `irun` right now, this seemed like the best way.

There's a hack at md.py lines 1060/1061 to get around ASE's `NPT` ensemble calling observers 1 less time than expected. Once the  fix is incorporated (https://gitlab.com/ase/ase/-/merge_requests/3598), those lines will need to be deleted.

There is also a test that should check each ensemble fills the progress bar completely by the end of the run.