### PR TITLE
Prevent temp steps less than timestep

### DIFF
--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -429,7 +429,7 @@ class MolecularDynamics(BaseCalculation):
                     "Temperature ramp requested for ensemble with no thermostat"
                 )
 
-            # Check validate start and end temperatures
+            # Validate start and end temperatures
             if self.temp_start < 0 or self.temp_end < 0:
                 raise ValueError("Start and end temperatures must be positive")
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -423,14 +423,20 @@ class MolecularDynamics(BaseCalculation):
                 "heating to run",
                 stacklevel=2,
             )
-        if self.ramp_temp and self.ensemble in ("nve", "nph"):
-            raise ValueError(
-                "Temperature ramp requested for ensemble with no thermostat."
-            )
+        if self.ramp_temp:
+            if self.ensemble in ("nve", "nph"):
+                raise ValueError(
+                    "Temperature ramp requested for ensemble with no thermostat"
+                )
 
-        # Check validate start and end temperatures
-        if self.ramp_temp and (self.temp_start < 0 or self.temp_end < 0):
-            raise ValueError("Start and end temperatures must be positive")
+            # Check validate start and end temperatures
+            if self.temp_start < 0 or self.temp_end < 0:
+                raise ValueError("Start and end temperatures must be positive")
+
+            if self.temp_time < self.timestep:
+                raise ValueError(
+                    "Temperature ramp step time cannot be less than 1 timestep"
+                )
 
         # Read last image by default
         read_kwargs.setdefault("index", -1)
@@ -1105,6 +1111,13 @@ class MolecularDynamics(BaseCalculation):
         # Run temperature ramp
         if self.ramp_temp:
             heating_steps = int(self.temp_time // self.timestep)
+
+            if self.logger and not np.isclose(self.temp_time % self.timestep, 0.0):
+                rounded_temp_step = heating_steps * self.timestep / units.fs
+                self.logger.info(
+                    "Temperature ramp step time rounded to nearest timestep "
+                    f"({rounded_temp_step:.5} fs)"
+                )
 
             # Always include start temperature in ramp, and include end temperature
             # if separated by an integer number of temperature steps

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -739,7 +739,7 @@ def test_heating(tmp_path, ensemble):
         temp_start=0.0,
         temp_end=20.0,
         temp_step=20,
-        temp_time=0.5,
+        temp_time=2,
         log_kwargs={"filename": log_file},
     )
     md.run()
@@ -1010,7 +1010,7 @@ def test_cooling(tmp_path):
         temp_start=20.0,
         temp_end=0.0,
         temp_step=10,
-        temp_time=0.5,
+        temp_time=1,
         log_kwargs={"filename": log_file},
     )
     nvt.run()
@@ -1028,9 +1028,35 @@ def test_cooling(tmp_path):
     assert len(final_atoms) == 3
 
     stats = Stats(source=stats_cooling_path)
-    assert stats.rows == 2
+    assert stats.rows == 3
     assert stats.data[0, 16] == 20.0
-    assert stats.data[1, 16] == 10.0
+    assert stats.data[2, 16] == 10.0
+
+
+def test_heating_too_short(tmp_path):
+    """Test that heating with steps shorter than 1 timestep fails."""
+    file_prefix = tmp_path / "NaCl-heating"
+
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="mace",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+
+    with pytest.raises(ValueError, match="Temperature ramp step time rounded"):
+        nvt = NVT(
+            struct=single_point.struct,
+            temp=300.0,
+            steps=0,
+            traj_every=10,
+            stats_every=10,
+            file_prefix=file_prefix,
+            temp_start=0.0,
+            temp_end=20.0,
+            temp_step=20,
+            temp_time=0.5,
+        )
+        nvt.run()
 
 
 def test_ensemble_kwargs(tmp_path):

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1043,7 +1043,7 @@ def test_heating_too_short(tmp_path):
         calc_kwargs={"model": MODEL_PATH},
     )
 
-    with pytest.raises(ValueError, match="Temperature ramp step time rounded"):
+    with pytest.raises(ValueError, match="Temperature ramp step time"):
         nvt = NVT(
             struct=single_point.struct,
             temp=300.0,

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -376,9 +376,9 @@ def test_heating(tmp_path, ensemble):
             "--temp-end",
             20,
             "--temp-step",
-            50,
+            10,
             "--temp-time",
-            0.05,
+            2,
         ],
     )
     if ensemble in ("nve", "nph"):


### PR DESCRIPTION
Fixes #436 

Adds a check to raise an error if the temperature step time is shorter than 1 timestep. Also prints a debug message if the temperature step time is rounded significantly.

Tests have been added to verify the error is raised correctly, and existing tests using temperature step times shorter than 1 timestep have been updated.