### PR TITLE
Tidy neb

### DIFF
--- a/janus_core/calculations/neb.py
+++ b/janus_core/calculations/neb.py
@@ -486,7 +486,10 @@ class NEB(BaseCalculation):
                 raise ValueError("Invalid interpolator selected")
 
     def optimize(self):
-        """Run optimization."""
+        """Run NEB optimization."""
+        if not hasattr(self, "neb"):
+            self.interpolate()
+
         optimizer = self.optimizer(self.neb, **self.optimizer_kwargs)
         optimizer.run(fmax=self.fmax, steps=self.steps)
         if self.logger:

--- a/janus_core/calculations/neb.py
+++ b/janus_core/calculations/neb.py
@@ -437,7 +437,7 @@ class NEB(BaseCalculation):
 
         return fig
 
-    def set_interpolator(self) -> None:
+    def interpolate(self) -> None:
         """Interpolate images to create initial band."""
         match self.interpolator:
             case "ase":
@@ -541,7 +541,7 @@ class NEB(BaseCalculation):
             )
             GeomOpt(self.final_struct, **self.minimize_kwargs).run()
 
-        self.set_interpolator()
+        self.interpolate()
         self.optimize()
         self.run_nebtools()
         self.plot()

--- a/janus_core/calculations/neb.py
+++ b/janus_core/calculations/neb.py
@@ -276,7 +276,7 @@ class NEB(BaseCalculation):
 
         # Identify whether interpolating
         if band_structs or band_path:
-            self.inerpolator = None
+            self.interpolator = None
             if init_struct or init_struct_path or final_struct or final_struct_path:
                 raise ValueError(
                     "Band cannot be specified in combination with an initial or final "
@@ -293,7 +293,7 @@ class NEB(BaseCalculation):
             # Read all image by default for band
             read_kwargs.setdefault("index", ":")
         else:
-            if interpolator is None:
+            if self.interpolator is None:
                 raise ValueError(
                     "An interpolator must be specified when using an initial and final "
                     "structure"
@@ -320,7 +320,7 @@ class NEB(BaseCalculation):
             file_prefix=file_prefix,
         )
 
-        if interpolator:
+        if self.interpolator:
             if not isinstance(self.struct, Atoms):
                 raise ValueError("`init_struct` must be a single structure.")
             if not self.struct.calc:

--- a/tests/test_neb.py
+++ b/tests/test_neb.py
@@ -117,3 +117,48 @@ def test_set_calc(tmp_path, LFPO_start_b, LFPO_end_b):
     assert neb.results["barrier"] == pytest.approx(7817.150960456944)
     assert neb.results["delta_E"] == pytest.approx(78.34034136421758)
     assert neb.results["max_force"] == pytest.approx(148695.846153840771)
+
+
+def test_neb_functions(tmp_path, LFPO_start_b, LFPO_end_b):
+    """Test individual NEB functions."""
+    file_prefix = tmp_path / "LFPO"
+
+    neb = NEB(
+        init_struct=LFPO_start_b,
+        final_struct=LFPO_end_b,
+        arch="mace",
+        model_path=MODEL_PATH,
+        n_images=5,
+        interpolator="ase",
+        file_prefix=file_prefix,
+    )
+    neb.interpolate()
+    neb.optimize()
+    neb.run_nebtools()
+
+    assert len(neb.images) == 7
+    assert all(key in neb.results for key in ("barrier", "delta_E", "max_force"))
+    assert neb.results["barrier"] == pytest.approx(7817.150960456944)
+    assert neb.results["delta_E"] == pytest.approx(78.34034136421758)
+    assert neb.results["max_force"] == pytest.approx(148695.846153840771)
+
+
+def test_neb_plot(tmp_path):
+    """Test plotting NEB before running NEBTools."""
+    file_prefix = tmp_path / "LFPO"
+
+    neb = NEB(
+        band_path=DATA_PATH / "LiFePO4-neb-band.xyz",
+        arch="mace",
+        model_path=MODEL_PATH,
+        steps=2,
+        file_prefix=file_prefix,
+    )
+    neb.optimize()
+    neb.plot()
+
+    assert len(neb.images) == 7
+    assert all(key in neb.results for key in ("barrier", "delta_E", "max_force"))
+    assert neb.results["barrier"] == pytest.approx(0.67567742247752)
+    assert neb.results["delta_E"] == pytest.approx(5.002693796996027e-07)
+    assert neb.results["max_force"] == pytest.approx(1.5425684122118983)


### PR DESCRIPTION
Fixes and tidies a few things in NEB:

- Fixes setting the interpolator to `None` when specifying the band
- Separates out functions that make up `NEB.run`, e.g. to allow repeated optimisation with different `fmax`