### PR TITLE
Remove cancel-in-progress for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,6 @@ permissions:
 # Allow one concurrent deployment
 concurrency:
   group: "pages"
-  cancel-in-progress: true
 
 jobs:
   docs-deploy:

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -19,7 +19,6 @@ jobs:
       id-token: write
     concurrency:
       group: "pages"
-      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Resolves #419

There may be better solutions, but given that the docs only take a couple of minutes to run, I think for now just allowing them to run sequentially (which I think is what should happen with these changes) is fine.