### PR TITLE
Add CI test against development versions

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@v5
       with:
         version: "latest"
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -1,0 +1,42 @@
+name: ci-dev
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test-dev-versions:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        version: "latest"
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: uv sync --all-extras
+
+    # Full reinstall in case the version number is the same as the last release
+    - name: Uninstall release versions
+      run: uv pip uninstall ase mace-torch
+
+    - name: Install dev versions
+      run: |
+        uv pip install \
+            https://gitlab.com/ase/ase.git \
+            https://github.com/ACEsuit/mace.git
+
+    - name: Run test suite
+      env:
+        # show timings of tests
+        PYTEST_ADDOPTS: "--durations=0"
+      run: uv run pytest .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,38 +37,6 @@ jobs:
           file: coverage.xml
           base-path: janus_core
 
-  test-dev-versions:
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "0.5.7"
-          python-version: ${{ matrix.python-version }}
-
-      - name: Target dev versions
-        run: |
-          uv add \
-              https://gitlab.com/ase/ase.git \
-              https://github.com/ACEsuit/mace.git
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Run test suite
-        env:
-          # show timings of tests
-          PYTEST_ADDOPTS: "--durations=0"
-        run: uv run pytest .
-
   coverage:
     needs: tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,38 @@ jobs:
           file: coverage.xml
           base-path: janus_core
 
+  test-dev-versions:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.7"
+          python-version: ${{ matrix.python-version }}
+
+      - name: Target dev versions
+        run: |
+          uv add \
+              https://gitlab.com/ase/ase.git \
+              https://github.com/ACEsuit/mace.git
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run test suite
+        env:
+          # show timings of tests
+          PYTEST_ADDOPTS: "--durations=0"
+        run: uv run pytest .
+
   coverage:
     needs: tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should test against up-to-date development versions of ASE and MACE during CI.

It shouldn't fail the CI if the tests fail, so that we can have a warning about upcoming breaking changes.