### PR TITLE
Add file prefix options to singlepoint and geomopt

### DIFF
--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -197,7 +197,7 @@ Additional options may be specified. This shares most options with ``singlepoint
 
 .. code-block:: bash
 
-    janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --opt-cell-lengths --traj 'NaCl-traj.extxyz'
+    janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --opt-cell-lengths --write-traj --traj-kwargs "{'filename':'NaCl-traj.extxyz'}"
 
 
 This allows the cell vectors to be optimised, allowing only hydrostatic deformation, and saves the optimization trajectory in addition to the final structure and log.

--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -197,7 +197,7 @@ Additional options may be specified. This shares most options with ``singlepoint
 
 .. code-block:: bash
 
-    janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --opt-cell-lengths --write-traj --traj-kwargs "{'filename':'NaCl-traj.extxyz'}"
+    janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --opt-cell-lengths --write-traj --minimize-kwargs "{'traj_kwargs':{'filename':'NaCl-traj.extxyz'}}"
 
 
 This allows the cell vectors to be optimised, allowing only hydrostatic deformation, and saves the optimization trajectory in addition to the final structure and log.

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -58,6 +58,8 @@ class GeomOpt(BaseCalculation):
         Default is True if attach_logger is True, else False.
     tracker_kwargs
         Keyword arguments to pass to `config_tracker`. Default is {}.
+    file_prefix
+        Prefix for output filenames. Default is inferred from structure.
     fmax
         Set force convergence criteria for optimizer in units eV/Å. Default is 0.1.
     steps
@@ -85,6 +87,8 @@ class GeomOpt(BaseCalculation):
     write_kwargs
         Keyword arguments to pass to ase.io.write to save optimized structure.
         Default is {}.
+    write_trajectory
+        Whether to save a trajectory file of optimization frames.
     traj_kwargs
         Keyword arguments to pass to ase.io.write to save optimization trajectory.
         Must include "filename" keyword. Default is {}.
@@ -103,6 +107,7 @@ class GeomOpt(BaseCalculation):
         log_kwargs: dict[str, Any] | None = None,
         track_carbon: bool | None = None,
         tracker_kwargs: dict[str, Any] | None = None,
+        file_prefix: PathLike | None = None,
         fmax: float = 0.1,
         steps: int = 1000,
         symmetrize: bool = False,
@@ -114,6 +119,7 @@ class GeomOpt(BaseCalculation):
         opt_kwargs: ASEOptArgs | None = None,
         write_results: bool = False,
         write_kwargs: OutputKwargs | None = None,
+        write_trajectory: bool = False,
         traj_kwargs: OutputKwargs | None = None,
     ) -> None:
         """
@@ -146,6 +152,8 @@ class GeomOpt(BaseCalculation):
             Default is True if attach_logger is True, else False.
         tracker_kwargs
             Keyword arguments to pass to `config_tracker`. Default is {}.
+        file_prefix
+            Prefix for output filenames. Default is inferred from structure.
         fmax
             Set force convergence criteria for optimizer in units eV/Å. Default is 0.1.
         steps
@@ -173,9 +181,11 @@ class GeomOpt(BaseCalculation):
         write_kwargs
             Keyword arguments to pass to ase.io.write to save optimized structure.
             Default is {}.
+        write_trajectory
+            Whether to save a trajectory file of optimization frames.
         traj_kwargs
             Keyword arguments to pass to ase.io.write to save optimization trajectory.
-            Must include "filename" keyword. Default is {}.
+            "filename" keyword is inferred from file_prefix if not given. Default is {}.
         """
         read_kwargs, filter_kwargs, opt_kwargs, write_kwargs, traj_kwargs = (
             none_to_dict(
@@ -194,16 +204,8 @@ class GeomOpt(BaseCalculation):
         self.opt_kwargs = opt_kwargs
         self.write_results = write_results
         self.write_kwargs = write_kwargs
+        self.write_trajectory = write_trajectory
         self.traj_kwargs = traj_kwargs
-
-        # Validate parameters
-        if self.traj_kwargs and "filename" not in self.traj_kwargs:
-            raise ValueError("'filename' must be included in `traj_kwargs`")
-
-        if self.traj_kwargs and "trajectory" not in self.opt_kwargs:
-            raise ValueError(
-                "'trajectory' must be a key in `opt_kwargs` to save the trajectory."
-            )
 
         # Read last image by default
         read_kwargs.setdefault("index", -1)
@@ -223,16 +225,29 @@ class GeomOpt(BaseCalculation):
             log_kwargs=log_kwargs,
             track_carbon=track_carbon,
             tracker_kwargs=tracker_kwargs,
+            file_prefix=file_prefix,
         )
 
         if not self.struct.calc:
             raise ValueError("Please attach a calculator to `struct`.")
 
-        # Set output file
+        # Set output files
         self.write_kwargs.setdefault("filename", None)
         self.write_kwargs["filename"] = self._build_filename(
             "opt.extxyz", filename=self.write_kwargs["filename"]
         ).absolute()
+
+        if self.write_trajectory and "filename" not in self.traj_kwargs:
+            self.traj_kwargs["filename"] = self._build_filename(
+                "traj.extxyz"
+            ).absolute()
+
+        if self.write_trajectory and "trajectory" not in self.opt_kwargs:
+            # Overwrite .traj binary with .extxyz by default.
+            self.opt_kwargs["trajectory"] = str(self.traj_kwargs["filename"])
+
+        if self.traj_kwargs and not self.write_trajectory:
+            raise ValueError("traj_kwargs given, but trajectory writing not enabled.")
 
         # Configure optimizer dynamics
         self.set_optimizer()
@@ -342,7 +357,7 @@ class GeomOpt(BaseCalculation):
         )
 
         # Reformat trajectory file from binary
-        if self.traj_kwargs:
+        if self.write_trajectory:
             traj = read(self.opt_kwargs["trajectory"], index=":")
             output_structs(
                 traj,

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -246,17 +246,12 @@ class GeomOpt(BaseCalculation):
             if "trajectory" not in self.opt_kwargs:
                 # Overwrite .traj binary with .extxyz by default.
                 self.opt_kwargs["trajectory"] = str(self.traj_kwargs["filename"])
-        else:
-            if self.traj_kwargs:
-                raise ValueError(
-                    "traj_kwargs given, but trajectory writing not enabled."
-                )
-            if "trajectory" in self.opt_kwargs:
-                raise ValueError(
-                    '"trajectory" given in opt_kwargs,'
-                    "but trajectory writing not enabled."
-                )
-
+        elif self.traj_kwargs:
+            raise ValueError("traj_kwargs given, but trajectory writing not enabled.")
+        elif "trajectory" in self.opt_kwargs:
+            raise ValueError(
+                '"trajectory" given in opt_kwargs,but trajectory writing not enabled.'
+            )
         # Configure optimizer dynamics
         self.set_optimizer()
 

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -87,7 +87,7 @@ class GeomOpt(BaseCalculation):
     write_kwargs
         Keyword arguments to pass to ase.io.write to save optimized structure.
         Default is {}.
-    write_trajectory
+    write_traj
         Whether to save a trajectory file of optimization frames.
     traj_kwargs
         Keyword arguments to pass to ase.io.write to save optimization trajectory.
@@ -119,7 +119,7 @@ class GeomOpt(BaseCalculation):
         opt_kwargs: ASEOptArgs | None = None,
         write_results: bool = False,
         write_kwargs: OutputKwargs | None = None,
-        write_trajectory: bool = False,
+        write_traj: bool = False,
         traj_kwargs: OutputKwargs | None = None,
     ) -> None:
         """
@@ -181,7 +181,7 @@ class GeomOpt(BaseCalculation):
         write_kwargs
             Keyword arguments to pass to ase.io.write to save optimized structure.
             Default is {}.
-        write_trajectory
+        write_traj
             Whether to save a trajectory file of optimization frames.
         traj_kwargs
             Keyword arguments to pass to ase.io.write to save optimization trajectory.
@@ -204,7 +204,7 @@ class GeomOpt(BaseCalculation):
         self.opt_kwargs = opt_kwargs
         self.write_results = write_results
         self.write_kwargs = write_kwargs
-        self.write_trajectory = write_trajectory
+        self.write_traj = write_traj
         self.traj_kwargs = traj_kwargs
 
         # Read last image by default
@@ -237,7 +237,7 @@ class GeomOpt(BaseCalculation):
             "opt.extxyz", filename=self.write_kwargs["filename"]
         ).absolute()
 
-        if self.write_trajectory:
+        if self.write_traj:
             if "filename" not in self.traj_kwargs:
                 self.traj_kwargs["filename"] = self._build_filename(
                     "traj.extxyz"
@@ -364,7 +364,7 @@ class GeomOpt(BaseCalculation):
         )
 
         # Reformat trajectory file from binary
-        if self.write_trajectory:
+        if self.write_traj:
             traj = read(self.opt_kwargs["trajectory"], index=":")
             output_structs(
                 traj,

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -91,7 +91,7 @@ class GeomOpt(BaseCalculation):
         Whether to save a trajectory file of optimization frames.
     traj_kwargs
         Keyword arguments to pass to ase.io.write to save optimization trajectory.
-        Must include "filename" keyword. Default is {}.
+        "filename" keyword is inferred from `file_prefix` if not given. Default is {}.
     """
 
     def __init__(
@@ -185,7 +185,8 @@ class GeomOpt(BaseCalculation):
             Whether to save a trajectory file of optimization frames.
         traj_kwargs
             Keyword arguments to pass to ase.io.write to save optimization trajectory.
-            "filename" keyword is inferred from file_prefix if not given. Default is {}.
+            "filename" keyword is inferred from `file_prefix` if not given.
+            Default is {}.
         """
         read_kwargs, filter_kwargs, opt_kwargs, write_kwargs, traj_kwargs = (
             none_to_dict(

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -239,13 +239,10 @@ class GeomOpt(BaseCalculation):
         ).absolute()
 
         if self.write_traj:
-            if "filename" not in self.traj_kwargs:
-                self.traj_kwargs["filename"] = self._build_filename(
-                    "traj.extxyz"
-                ).absolute()
-            if "trajectory" not in self.opt_kwargs:
-                # Overwrite .traj binary with .extxyz by default.
-                self.opt_kwargs["trajectory"] = str(self.traj_kwargs["filename"])
+            self.traj_kwargs.setdefault(
+                "filename", self._build_filename("traj.extxyz").absolute()
+            )
+            self.opt_kwargs.setdefault("trajectory", str(self.traj_kwargs["filename"]))
         elif self.traj_kwargs:
             raise ValueError("traj_kwargs given, but trajectory writing not enabled.")
         elif "trajectory" in self.opt_kwargs:

--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -237,17 +237,24 @@ class GeomOpt(BaseCalculation):
             "opt.extxyz", filename=self.write_kwargs["filename"]
         ).absolute()
 
-        if self.write_trajectory and "filename" not in self.traj_kwargs:
-            self.traj_kwargs["filename"] = self._build_filename(
-                "traj.extxyz"
-            ).absolute()
-
-        if self.write_trajectory and "trajectory" not in self.opt_kwargs:
-            # Overwrite .traj binary with .extxyz by default.
-            self.opt_kwargs["trajectory"] = str(self.traj_kwargs["filename"])
-
-        if self.traj_kwargs and not self.write_trajectory:
-            raise ValueError("traj_kwargs given, but trajectory writing not enabled.")
+        if self.write_trajectory:
+            if "filename" not in self.traj_kwargs:
+                self.traj_kwargs["filename"] = self._build_filename(
+                    "traj.extxyz"
+                ).absolute()
+            if "trajectory" not in self.opt_kwargs:
+                # Overwrite .traj binary with .extxyz by default.
+                self.opt_kwargs["trajectory"] = str(self.traj_kwargs["filename"])
+        else:
+            if self.traj_kwargs:
+                raise ValueError(
+                    "traj_kwargs given, but trajectory writing not enabled."
+                )
+            if "trajectory" in self.opt_kwargs:
+                raise ValueError(
+                    '"trajectory" given in opt_kwargs,'
+                    "but trajectory writing not enabled."
+                )
 
         # Configure optimizer dynamics
         self.set_optimizer()

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -40,6 +40,8 @@ class SinglePoint(BaseCalculation):
         Device to run model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
+    file_prefix
+        Prefix for output filenames. Default is inferred from structure.
     read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is ":".
@@ -82,6 +84,7 @@ class SinglePoint(BaseCalculation):
         arch: Architectures = "mace_mp",
         device: Devices = "cpu",
         model_path: PathLike | None = None,
+        file_prefix: PathLike | None = None,
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
@@ -108,6 +111,8 @@ class SinglePoint(BaseCalculation):
             Device to run MLIP model on. Default is "cpu".
         model_path
             Path to MLIP model. Default is `None`.
+        file_prefix
+            Prefix for output filenames. Default is inferred from structure.
         read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is ":".
@@ -162,6 +167,7 @@ class SinglePoint(BaseCalculation):
             log_kwargs=log_kwargs,
             track_carbon=track_carbon,
             tracker_kwargs=tracker_kwargs,
+            file_prefix=file_prefix,
         )
 
         # Properties validated using calculator

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -193,7 +193,7 @@ def geomopt(
         Whether to save a trajectory file of optimization frames.
     traj_kwargs
         Keyword arguments to pass to ase.io.write when saving trajectory.
-        If "filename" is not included, it is inferred from --file-prefix.
+        If "filename" is not included, it is inferred from `file_prefix`.
     read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -229,8 +229,10 @@ def geomopt(
     # Check options from configuration file are all valid
     check_config(ctx)
 
-    [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs] = parse_typer_dicts(
-        [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs]
+    [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs, traj_kwargs] = (
+        parse_typer_dicts(
+            [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs, traj_kwargs]
+        )
     )
 
     # Read only first structure by default and ensure only one image is read

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -18,7 +18,6 @@ from janus_core.cli.types import (
     ReadKwargsLast,
     StructPath,
     Summary,
-    TrajKwargs,
     WriteKwargs,
 )
 from janus_core.cli.utils import yaml_converter_callback
@@ -47,6 +46,9 @@ def _set_minimize_kwargs(
     """
     if "opt_kwargs" not in minimize_kwargs:
         minimize_kwargs["opt_kwargs"] = {}
+
+    if "traj_kwargs" not in minimize_kwargs:
+        minimize_kwargs["traj_kwargs"] = {}
 
     # Check hydrostatic_strain and scalar pressure not duplicated
     if "filter_kwargs" in minimize_kwargs:
@@ -130,9 +132,15 @@ def geomopt(
         ),
     ] = None,
     write_traj: Annotated[
-        bool, Option(help="Whether to save a trajectory file of optimization frames.")
+        bool,
+        Option(
+            help=(
+                "Whether to save a trajectory file of optimization frames. "
+                'If traj_kwargs["filename"] is not specified, it is inferred '
+                "from `file_prefix`."
+            ),
+        ),
     ] = False,
-    traj_kwargs: TrajKwargs = None,
     read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
     minimize_kwargs: MinimizeKwargs = None,
@@ -191,9 +199,7 @@ def geomopt(
         converge. Default is inferred from name of structure file.
     write_traj
         Whether to save a trajectory file of optimization frames.
-    traj_kwargs
-        Keyword arguments to pass to ase.io.write when saving trajectory.
-        If "filename" is not included, it is inferred from `file_prefix`.
+        If traj_kwargs["filename"] is not specified, it is inferred from `file_prefix`.
     read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
@@ -229,10 +235,8 @@ def geomopt(
     # Check options from configuration file are all valid
     check_config(ctx)
 
-    [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs, traj_kwargs] = (
-        parse_typer_dicts(
-            [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs, traj_kwargs]
-        )
+    [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs] = parse_typer_dicts(
+        [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs]
     )
 
     # Read only first structure by default and ensure only one image is read
@@ -284,7 +288,6 @@ def geomopt(
         "write_results": True,
         "write_kwargs": write_kwargs,
         "write_traj": write_traj,
-        "traj_kwargs": traj_kwargs,
     }
 
     # Set up geometry optimization

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -44,11 +44,8 @@ def _set_minimize_kwargs(
         Scalar pressure when optimizing cell geometry, in GPa. Passed to the filter
         function if either `opt_cell_lengths` or `opt_cell_fully` is True.
     """
-    if "opt_kwargs" not in minimize_kwargs:
-        minimize_kwargs["opt_kwargs"] = {}
-
-    if "traj_kwargs" not in minimize_kwargs:
-        minimize_kwargs["traj_kwargs"] = {}
+    minimize_kwargs.setdefault("opt_kwargs", {})
+    minimize_kwargs.setdefault("traj_kwargs", {})
 
     # Check hydrostatic_strain and scalar pressure not duplicated
     if "filter_kwargs" in minimize_kwargs:

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -129,7 +129,7 @@ def geomopt(
             ),
         ),
     ] = None,
-    write_trajectory: Annotated[
+    write_traj: Annotated[
         bool, Option(help="Whether to save a trajectory file of optimization frames.")
     ] = False,
     traj_kwargs: TrajKwargs = None,
@@ -189,7 +189,7 @@ def geomopt(
     out
         Path to save optimized structure, or last structure if optimization did not
         converge. Default is inferred from name of structure file.
-    write_trajectory
+    write_traj
         Whether to save a trajectory file of optimization frames.
     traj_kwargs
         Keyword arguments to pass to ase.io.write when saving trajectory.
@@ -283,7 +283,7 @@ def geomopt(
         **minimize_kwargs,
         "write_results": True,
         "write_kwargs": write_kwargs,
-        "write_trajectory": write_trajectory,
+        "write_traj": write_traj,
         "traj_kwargs": traj_kwargs,
     }
 

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -42,6 +42,12 @@ def singlepoint(
             ),
         ),
     ] = None,
+    file_prefix: Annotated[
+        Path | None,
+        Option(
+            help=("Prefix for output filenames. Default is inferred from structure.")
+        ),
+    ] = None,
     out: Annotated[
         Path | None,
         Option(
@@ -78,6 +84,8 @@ def singlepoint(
         Path to MLIP model. Default is `None`.
     properties
         Physical properties to calculate. Default is ("energy", "forces", "stress").
+    file_prefix
+        Prefix for output filenames. Default is inferred from structure.
     out
         Path to save structure with calculated results. Default is inferred from name
         of the structure file.
@@ -133,6 +141,7 @@ def singlepoint(
         "write_results": True,
         "arch": arch,
         "device": device,
+        "file_prefix": file_prefix,
         "model_path": model_path,
         "read_kwargs": read_kwargs,
         "calc_kwargs": calc_kwargs,

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -279,7 +279,7 @@ TrajKwargs = Annotated[
             """
             Keyword arguments to pass to ase.io.write when saving trajectory. Must be
             passed as a dictionary wrapped in quotes, e.g. "{'key': value}".
-            If "filename" is not included, it is inferred from --file-prefix.
+            If "filename" is not included, it is inferred from `file_prefix`.
             """
         ),
         metavar="DICT",

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -271,21 +271,6 @@ InterpolationKwargs = Annotated[
     ),
 ]
 
-TrajKwargs = Annotated[
-    TyperDict | None,
-    Option(
-        parser=parse_dict_class,
-        help=(
-            """
-            Keyword arguments to pass to ase.io.write when saving trajectory. Must be
-            passed as a dictionary wrapped in quotes, e.g. "{'key': value}".
-            If "filename" is not included, it is inferred from `file_prefix`.
-            """
-        ),
-        metavar="DICT",
-    ),
-]
-
 PostProcessKwargs = Annotated[
     TyperDict | None,
     Option(

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -271,6 +271,21 @@ InterpolationKwargs = Annotated[
     ),
 ]
 
+TrajKwargs = Annotated[
+    TyperDict | None,
+    Option(
+        parser=parse_dict_class,
+        help=(
+            """
+            Keyword arguments to pass to ase.io.write when saving trajectory. Must be
+            passed as a dictionary wrapped in quotes, e.g. "{'key': value}".
+            If "filename" is not included, it is inferred from --file-prefix.
+            """
+        ),
+        metavar="DICT",
+    ),
+]
+
 PostProcessKwargs = Annotated[
     TyperDict | None,
     Option(

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -84,7 +84,9 @@ def test_saving_traj(tmp_path):
         calc_kwargs={"model": MODEL_PATH},
     )
     optimizer = GeomOpt(
-        single_point.struct, opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")}
+        single_point.struct,
+        write_trajectory=True,
+        opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")},
     )
     optimizer.run()
     traj = read(tmp_path / "NaCl.traj", index=":")
@@ -105,6 +107,7 @@ def test_traj_reformat(tmp_path):
     optimizer = GeomOpt(
         single_point.struct,
         opt_kwargs={"trajectory": str(traj_path_binary)},
+        write_trajectory=True,
         traj_kwargs={"filename": traj_path_xyz, "format": "xyz"},
     )
     optimizer.run()

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -85,7 +85,7 @@ def test_saving_traj(tmp_path):
     )
     optimizer = GeomOpt(
         single_point.struct,
-        write_trajectory=True,
+        write_traj=True,
         opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")},
     )
     optimizer.run()
@@ -107,7 +107,7 @@ def test_traj_reformat(tmp_path):
     optimizer = GeomOpt(
         single_point.struct,
         opt_kwargs={"trajectory": str(traj_path_binary)},
-        write_trajectory=True,
+        write_traj=True,
         traj_kwargs={"filename": traj_path_xyz, "format": "xyz"},
     )
     optimizer.run()

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -115,7 +115,7 @@ def test_traj(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--out",
             results_path,
-            "--write-trajectory",
+            "--write-traj",
             "--traj-kwargs",
             f"{{'filename':'{traj_path}'}}",
             "--log",
@@ -784,7 +784,7 @@ def test_file_prefix(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--file-prefix",
             file_prefix,
-            "--write-trajectory",
+            "--write-traj",
         ],
     )
     assert result.exit_code == 0

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -116,8 +116,8 @@ def test_traj(tmp_path):
             "--out",
             results_path,
             "--write-traj",
-            "--traj-kwargs",
-            f"{{'filename':'{traj_path}'}}",
+            "--minimize-kwargs",
+            f"{{'traj_kwargs':{{'filename':'{traj_path}'}}}}",
             "--log",
             log_path,
             "--summary",
@@ -808,8 +808,8 @@ def test_traj_kwargs_no_write(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--file-prefix",
             tmp_path / "NaCl",
-            "--traj-kwargs",
-            f"{{'filename':'{tmp_path / 'traj.extxyz'}'}}",
+            "--minimize-kwargs",
+            f"{{'traj_kwargs':{{'filename':'{tmp_path / 'traj.extxyz'}'}}}}",
         ],
     )
     assert result.exit_code == 1

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -788,12 +788,14 @@ def test_file_prefix(tmp_path):
         ],
     )
     assert result.exit_code == 0
-    tmp_path_contents = list(tmp_path.glob("*"))
-    assert len(tmp_path_contents) == 1
-    assert tmp_path_contents[0].stem == "test"
-    subdir_contents = list((tmp_path / "test/").glob("*"))
-    assert len(subdir_contents) == 4
-    assert all(file.stem[:4] for file in subdir_contents)
+    test_path = tmp_path / "test"
+    assert list(tmp_path.iterdir()) == [test_path]
+    assert set(test_path.iterdir()) == {
+        test_path / "test-opt.extxyz",
+        test_path / "test-traj.extxyz",
+        test_path / "test-geomopt-summary.yml",
+        test_path / "test-geomopt-log.yml",
+    }
 
 
 def test_traj_kwargs_no_write(tmp_path):

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -60,6 +60,7 @@ def test_geomopt():
     finally:
         # Ensure files deleted if command fails
         read_atoms(results_path)
+        results_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
         clear_log_handlers()
@@ -114,8 +115,9 @@ def test_traj(tmp_path):
             DATA_PATH / "NaCl.cif",
             "--out",
             results_path,
-            "--traj",
-            traj_path,
+            "--write-trajectory",
+            "--traj-kwargs",
+            f"{{'filename':'{traj_path}'}}",
             "--log",
             log_path,
             "--summary",


### PR DESCRIPTION
Adds the option to provide a file prefix that is used for all of the files produced by single point and geometry optimisations. Since this can include a directory, it helps to allow the option to create a results directory for https://github.com/stfc/janus-core/issues/359#issuecomment-2684974380.