### PR TITLE
Show all MD progress bars during ramp

### DIFF
--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -15,7 +15,7 @@ from warnings import warn
 
 # Only needed for type hints
 if TYPE_CHECKING:
-    from rich.progress import Progress, TaskID
+    from rich.progress import TaskID
 
 from ase import Atoms
 from ase.geometry.analysis import Analysis
@@ -1074,19 +1074,88 @@ class MolecularDynamics(BaseCalculation):
         else:
             raise ValueError("Temperature set for ensemble with no thermostat.")
 
-    def _update_progress_bar(self, progress_bar: Progress, task_id: TaskID):
+    def _init_progress_bar(self) -> ProgressBar:
+        """
+        Initialise MD progress bar.
+
+        Returns
+        -------
+        progress_bar
+            Object used for managing progress bars.
+        """
+        if not self.enable_progress_bar:
+            self._progress_bar = ProgressBar(disable=True)
+            return self._progress_bar
+        self._progress_bar = ProgressBar()
+        total_steps = self.steps
+
+        # Set total expected MD steps.
+        if self.ramp_temp:
+            total_steps += self.heating_n_temps * self.heating_steps_per_temp
+            # Heating steps at 0 are skipped.
+            if np.isclose(self.temp_start, 0.0):
+                total_steps -= self.heating_steps_per_temp
+
+        total_task_id = self._progress_bar.add_task(
+            "Performing MD simulation...",
+            total=total_steps,
+            completed=self.offset,
+        )
+        ramp_task_id = None
+        if self.ramp_temp:
+            ramp_task_id = self._progress_bar.add_task(
+                "",
+                visible=False,
+            )
+
+        update_func = partial(self._update_progress_bar, total_task_id, ramp_task_id)
+        self.dyn.attach(update_func, interval=self.progress_bar_update_every)
+        # Also ensure progress is updated at the end
+        self.dyn.attach(update_func, interval=-total_steps)
+        return self._progress_bar
+
+    def _update_progress_bar(
+        self, total_task_id: TaskID, ramp_task_id: TaskID | None = None
+    ):
         """
         Update the progress bar for MD run.
 
         Parameters
         ----------
-        progress_bar
-            The progress bar to be updated.
-        task_id
-            The task ID of the task created by `ProgressBar.add_task()`.
+        total_task_id
+            Task ID tracking overall simulation progress.
+        ramp_task_id
+            Task ID tracking progress of individual temperature ramp steps (Optional).
         """
-        progress_bar.update(task_id, completed=self.dyn.nsteps + self.offset)
-        progress_bar.refresh()
+        current_step = self.dyn.nsteps + self.offset
+
+        self._progress_bar.update(total_task_id, completed=current_step)
+
+        if ramp_task_id:
+            current_ramp_step = current_step // self.heating_steps_per_temp
+
+            # Account for MD temperature steps at T=0 K being skipped.
+            heating_n_temps = self.heating_n_temps
+            if np.isclose(self.temp_start, 0.0):
+                heating_n_temps -= 1
+
+            if current_ramp_step < heating_n_temps:
+                description = f"Temperature ramp ({self.temp} K)..."
+                completed = current_step % self.heating_steps_per_temp
+                total = self.heating_steps_per_temp
+            else:
+                description = f"Constant temperature ({self.temp} K)..."
+                completed = current_step - heating_n_temps * self.heating_steps_per_temp
+                total = self.steps
+            self._progress_bar.update(
+                ramp_task_id,
+                description=description,
+                completed=completed,
+                total=total,
+                visible=True,
+            )
+
+        self._progress_bar.refresh()
 
     def run(self) -> None:
         """Run molecular dynamics simulation and/or temperature ramp."""
@@ -1124,19 +1193,7 @@ class MolecularDynamics(BaseCalculation):
         if self.minimize and self.minimize_every > 0:
             self.dyn.attach(self._optimize_structure, interval=self.minimize_every)
 
-        with ProgressBar(disable=not self.enable_progress_bar) as progress_bar:
-            if self.enable_progress_bar:
-                total_steps = self.steps
-                if self.ramp_temp:
-                    total_steps += self.heating_n_temps * self.heating_steps_per_temp
-                task_id = progress_bar.add_task(
-                    "Performing MD simulation...",
-                    total=total_steps,
-                    completed=self.offset,
-                )
-                update_func = partial(self._update_progress_bar, progress_bar, task_id)
-                self.dyn.attach(update_func, interval=self.progress_bar_update_every)
-
+        with self._init_progress_bar():
             # Note current time
             self.struct.info["real_time"] = datetime.datetime.now()
             self._run_dynamics()
@@ -1159,7 +1216,9 @@ class MolecularDynamics(BaseCalculation):
         # Run temperature ramp
         if self.ramp_temp:
             if self.logger and not np.isclose(self.temp_time % self.timestep, 0.0):
-                rounded_temp_step = self.heating_n_steps * self.timestep / units.fs
+                rounded_temp_step = (
+                    self.heating_steps_per_temp * self.timestep / units.fs
+                )
                 self.logger.info(
                     "Temperature ramp step time rounded to nearest timestep "
                     f"({rounded_temp_step:.5} fs)"

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -168,8 +168,9 @@ class MolecularDynamics(BaseCalculation):
         Default is None.
     enable_progress_bar
         Whether to show a progress bar. Default is False.
-    progress_bar_update_every
-        How many timesteps between progress bar updates. Default is 1.
+    update_progress_every
+        How many timesteps between progress bar updates.
+        Default is steps/100, rounded up.
 
     Attributes
     ----------
@@ -232,7 +233,7 @@ class MolecularDynamics(BaseCalculation):
         correlation_kwargs: list[CorrelationKwargs] | None = None,
         seed: int | None = None,
         enable_progress_bar: bool = False,
-        progress_bar_update_every: int = 1,
+        update_progress_every: int | None = None,
     ) -> None:
         """
         Initialise molecular dynamics simulation configuration.
@@ -342,8 +343,9 @@ class MolecularDynamics(BaseCalculation):
             Default is None.
         enable_progress_bar
             Whether to show a progress bar. Default is False.
-        progress_bar_update_every
-            How many timesteps between progress bar updates. Default is 1.
+        update_progress_every
+            How many timesteps between progress bar updates.
+            Default is steps/100, rounded up.
         """
         (
             read_kwargs,
@@ -392,7 +394,7 @@ class MolecularDynamics(BaseCalculation):
         self.correlation_kwargs = correlation_kwargs
         self.seed = seed
         self.enable_progress_bar = enable_progress_bar
-        self.progress_bar_update_every = progress_bar_update_every
+        self.update_progress_every = update_progress_every
 
         if "append" in self.write_kwargs:
             raise ValueError("`append` cannot be specified when writing files")
@@ -459,6 +461,9 @@ class MolecularDynamics(BaseCalculation):
                 raise ValueError(
                     "Temperature ramp step time cannot be less than 1 timestep"
                 )
+
+        if self.update_progress_every is None:
+            self.update_progress_every = np.ceil(self.steps / 100)
 
         # Read last image by default
         read_kwargs.setdefault("index", -1)
@@ -1080,7 +1085,7 @@ class MolecularDynamics(BaseCalculation):
 
         Returns
         -------
-        progress_bar
+        ProgressBar
             Object used for managing progress bars.
         """
         if not self.enable_progress_bar:
@@ -1109,7 +1114,7 @@ class MolecularDynamics(BaseCalculation):
             )
 
         update_func = partial(self._update_progress_bar, total_task_id, ramp_task_id)
-        self.dyn.attach(update_func, interval=self.progress_bar_update_every)
+        self.dyn.attach(update_func, interval=self.update_progress_every)
         # Also ensure progress is updated at the end
         self.dyn.attach(update_func, interval=-total_steps)
         return self._progress_bar

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -445,14 +445,6 @@ class MolecularDynamics(BaseCalculation):
                 )
 
         if self.ramp_temp:
-            self.heating_steps_per_temp = int(self.temp_time // self.timestep)
-
-            # Always include start temperature in ramp, and include end temperature
-            # if separated by an integer number of temperature steps
-            self.heating_n_temps = int(
-                1 + abs(self.temp_end - self.temp_start) // self.temp_step
-            )
-
             # Validate start and end temperatures
             if self.temp_start < 0 or self.temp_end < 0:
                 raise ValueError("Start and end temperatures must be positive")
@@ -461,6 +453,21 @@ class MolecularDynamics(BaseCalculation):
                 raise ValueError(
                     "Temperature ramp step time cannot be less than 1 timestep"
                 )
+
+            self.heating_steps_per_temp = int(self.temp_time // self.timestep)
+
+            # Always include start temperature in ramp, and include end temperature
+            # if separated by an integer number of temperature steps
+            self.heating_n_temps = int(
+                1 + abs(self.temp_end - self.temp_start) // self.temp_step
+            )
+
+            # Add or subtract temperatures
+            ramp_sign = 1 if (self.temp_end - self.temp_start) > 0 else -1
+            self.ramp_temps = [
+                self.temp_start + ramp_sign * i * self.temp_step
+                for i in range(self.heating_n_temps)
+            ]
 
         if self.update_progress_every is None:
             self.update_progress_every = np.ceil(self.steps / 100)
@@ -1089,9 +1096,8 @@ class MolecularDynamics(BaseCalculation):
             Object used for managing progress bars.
         """
         if not self.enable_progress_bar:
-            self._progress_bar = ProgressBar(disable=True)
-            return self._progress_bar
-        self._progress_bar = ProgressBar()
+            return ProgressBar(disable=True)
+        progress_bar = ProgressBar()
         total_steps = self.steps
 
         # Set total expected MD steps.
@@ -1101,66 +1107,85 @@ class MolecularDynamics(BaseCalculation):
             if np.isclose(self.temp_start, 0.0):
                 total_steps -= self.heating_steps_per_temp
 
-        total_task_id = self._progress_bar.add_task(
+        total_task_id = progress_bar.add_task(
             "Performing MD simulation...",
             total=total_steps,
             completed=self.offset,
         )
-        ramp_task_id = None
+        ramp_task_ids = []
         if self.ramp_temp:
-            ramp_task_id = self._progress_bar.add_task(
-                "",
-                visible=False,
+            for temp in self.ramp_temps:
+                total = 0 if isclose(0.0, temp) else self.heating_steps_per_temp
+                ramp_task_ids.append(
+                    progress_bar.add_task(
+                        f"Temperature ramp ({temp} K)...",
+                        total=total,
+                    )
+                )
+            ramp_task_ids.append(
+                progress_bar.add_task(
+                    f"Constant temperature ({self.temp} K)...",
+                    total=self.steps,
+                )
             )
 
-        update_func = partial(self._update_progress_bar, total_task_id, ramp_task_id)
+        update_func = partial(
+            self._update_progress_bar, progress_bar, total_task_id, ramp_task_ids
+        )
         self.dyn.attach(update_func, interval=self.update_progress_every)
         # Also ensure progress is updated at the end
         self.dyn.attach(update_func, interval=-total_steps)
-        return self._progress_bar
+        return progress_bar
 
     def _update_progress_bar(
-        self, total_task_id: TaskID, ramp_task_id: TaskID | None = None
+        self,
+        progress_bar: ProgressBar,
+        total_task_id: TaskID,
+        ramp_task_ids: Sequence[TaskID] | None = None,
     ):
         """
         Update the progress bar for MD run.
 
         Parameters
         ----------
+        progress_bar
+            Progress bar object tracking all tasks.
         total_task_id
             Task ID tracking overall simulation progress.
-        ramp_task_id
-            Task ID tracking progress of individual temperature ramp steps (Optional).
+        ramp_task_ids
+            Task IDs tracking progress of individual temperature ramp steps
+            and final MD step (Optional).
         """
+        if ramp_task_ids is None:
+            ramp_task_ids = []
         current_step = self.dyn.nsteps + self.offset
 
-        self._progress_bar.update(total_task_id, completed=current_step)
+        # 0th step, no progress yet.
+        if current_step == 0:
+            return
 
-        if ramp_task_id:
-            current_ramp_step = current_step // self.heating_steps_per_temp
+        progress_bar.update(total_task_id, completed=current_step)
 
-            # Account for MD temperature steps at T=0 K being skipped.
-            heating_n_temps = self.heating_n_temps
-            if np.isclose(self.temp_start, 0.0):
-                heating_n_temps -= 1
+        if ramp_task_ids:
+            if isclose(0, self.temp_start):
+                current_step += self.heating_steps_per_temp
 
-            if current_ramp_step < heating_n_temps:
-                description = f"Temperature ramp ({self.temp} K)..."
-                completed = current_step % self.heating_steps_per_temp
-                total = self.heating_steps_per_temp
+            current_ramp_step = (current_step - 1) // self.heating_steps_per_temp
+            # Clamp current_ramp_step between 0 and n_temps
+            current_ramp_step = min(self.heating_n_temps, current_ramp_step)
+
+            if current_ramp_step < self.heating_n_temps:
+                completed = (current_step - 1) % self.heating_steps_per_temp + 1
             else:
-                description = f"Constant temperature ({self.temp} K)..."
-                completed = current_step - heating_n_temps * self.heating_steps_per_temp
-                total = self.steps
-            self._progress_bar.update(
-                ramp_task_id,
-                description=description,
+                total_heating_steps = self.heating_n_temps * self.heating_steps_per_temp
+                completed = current_step - total_heating_steps
+            progress_bar.update(
+                ramp_task_ids[current_ramp_step],
                 completed=completed,
-                total=total,
                 visible=True,
             )
 
-        self._progress_bar.refresh()
+        progress_bar.refresh()
 
     def run(self) -> None:
         """Run molecular dynamics simulation and/or temperature ramp."""
@@ -1229,19 +1254,14 @@ class MolecularDynamics(BaseCalculation):
                     f"({rounded_temp_step:.5} fs)"
                 )
 
-            # Add or subtract temperatures
-            ramp_sign = 1 if (self.temp_end - self.temp_start) > 0 else -1
-            temps = [
-                self.temp_start + ramp_sign * i * self.temp_step
-                for i in range(self.heating_n_temps)
-            ]
-
             if self.logger:
-                self.logger.info("Beginning temperature ramp at %sK", temps[0])
+                self.logger.info(
+                    "Beginning temperature ramp at %sK", self.ramp_temps[0]
+                )
             if self.tracker:
                 self.tracker.start_task("Temperature ramp")
 
-            for temp in temps:
+            for temp in self.ramp_temps:
                 self.temp = temp
                 self._set_velocity_distribution()
                 if isclose(temp, 0.0):
@@ -1257,7 +1277,9 @@ class MolecularDynamics(BaseCalculation):
                 self.created_final_file = True
 
             if self.logger:
-                self.logger.info("Temperature ramp complete at %sK", temps[-1])
+                self.logger.info(
+                    "Temperature ramp complete at %sK", self.ramp_temps[-1]
+                )
             if self.tracker:
                 emissions = self.tracker.stop_task().emissions
                 self.struct.info["emissions"] = emissions

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -27,7 +27,7 @@ from janus_core.helpers.janus_types import (
     PathLike,
     PhononCalcs,
 )
-from janus_core.helpers.utils import none_to_dict, set_minimize_logging, track_progress
+from janus_core.helpers.utils import ProgressBar, none_to_dict, set_minimize_logging
 
 
 class Phonons(BaseCalculation):
@@ -426,8 +426,8 @@ class Phonons(BaseCalculation):
         disp_supercells = phonon.supercells_with_displacements
 
         if self.enable_progress_bar:
-            disp_supercells = track_progress(
-                disp_supercells, "Computing displacements..."
+            disp_supercells = ProgressBar().track(
+                disp_supercells, description="Computing displacements..."
             )
 
         phonon.forces = [

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -22,7 +22,7 @@ from janus_core.helpers.janus_types import (
 )
 from janus_core.helpers.mlip_calculators import check_calculator
 from janus_core.helpers.struct_io import output_structs
-from janus_core.helpers.utils import none_to_dict, track_progress
+from janus_core.helpers.utils import ProgressBar, none_to_dict
 
 
 class SinglePoint(BaseCalculation):
@@ -233,8 +233,8 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(
-                    struct_sequence, "Computing potential energies..."
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing potential energies..."
                 )
             return [struct.get_potential_energy() for struct in struct_sequence]
 
@@ -252,7 +252,9 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(struct_sequence, "Computing forces...")
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing forces..."
+                )
             return [struct.get_forces() for struct in struct_sequence]
 
         return self.struct.get_forces()
@@ -269,8 +271,8 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(
-                    struct_sequence, "Computing stresses..."
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing stresses..."
                 )
             return [struct.get_stress() for struct in struct_sequence]
 
@@ -313,8 +315,9 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(
-                    struct_sequence, "Computing Hessian..."
+                print("There should be a progress bar...")
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing Hessian..."
                 )
             return [self._calc_hessian(struct) for struct in struct_sequence]
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -222,10 +222,13 @@ def md(
             help="Whether to show progress bar.",
         ),
     ] = True,
-    progress_bar_update_every: Annotated[
+    update_progress_every: Annotated[
         int,
-        Option(help="How many timesteps between progress bar updates. Default is 1."),
-    ] = 1,
+        Option(
+            help="How many timesteps between progress bar updates. "
+            "Default is steps/100, rounded up."
+        ),
+    ] = None,
     summary: Summary = None,
 ) -> None:
     """
@@ -356,8 +359,9 @@ def md(
         Default is True.
     enable_progress_bar
         Whether to show progress bar.
-    progress_bar_update_every
-        How many timesteps between progress bar updates. Default is 1.
+    update_progress_every
+        How many timesteps between progress bar updates.
+        Default is steps/100, rounded up.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
@@ -472,7 +476,7 @@ def md(
         "post_process_kwargs": post_process_kwargs,
         "seed": seed,
         "enable_progress_bar": enable_progress_bar,
-        "progress_bar_update_every": progress_bar_update_every,
+        "update_progress_every": update_progress_every,
     }
 
     # Instantiate MD ensemble

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -215,6 +215,17 @@ def md(
     tracker: Annotated[
         bool, Option(help="Whether to save carbon emissions of calculation")
     ] = True,
+    enable_progress_bar: Annotated[
+        bool,
+        Option(
+            "--enable-progress-bar/--disable-progress-bar",
+            help="Whether to show progress bar.",
+        ),
+    ] = True,
+    progress_bar_update_every: Annotated[
+        int,
+        Option(help="How many timesteps between progress bar updates. Default is 1."),
+    ] = 1,
     summary: Summary = None,
 ) -> None:
     """
@@ -343,6 +354,10 @@ def md(
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
+    enable_progress_bar
+        Whether to show progress bar.
+    progress_bar_update_every
+        How many timesteps between progress bar updates. Default is 1.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from the name of the structure file.
@@ -456,6 +471,8 @@ def md(
         "write_kwargs": write_kwargs,
         "post_process_kwargs": post_process_kwargs,
         "seed": seed,
+        "enable_progress_bar": enable_progress_bar,
+        "progress_bar_update_every": progress_bar_update_every,
     }
 
     # Instantiate MD ensemble

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -368,45 +368,44 @@ def _dump_csv(
         print(",".join(map(format, cols, formats)), file=file)
 
 
-def track_progress(sequence: Sequence | Iterable, description: str) -> Iterable:
+class ProgressBar(Progress):
     """
-    Track the progress of iterating over a sequence.
+    Progress bar with preset formatting.
 
-    This is done by displaying a progress bar in the console using the rich library.
-    The function is an iterator over the sequence, updating the progress bar each
-    iteration.
+    Inherits from `rich.progress.Progress`, providing preset formatting.
 
     Parameters
     ----------
-    sequence
-        The sequence to iterate over. Must support "len".
-    description
-        The text to display to the left of the progress bar.
-
-    Yields
-    ------
-    Iterable
-        An iterable of the values in the sequence.
+        **kwargs
+            Keyword arguments passed on to `rich.progress.Progress`.
     """
-    text_column = TextColumn("{task.description}")
-    bar_column = BarColumn(
-        bar_width=None,
-        complete_style=Style(color="#FBBB10"),
-        finished_style=Style(color="#E38408"),
-    )
-    completion_column = MofNCompleteColumn()
-    time_column = TimeRemainingColumn()
-    progress = Progress(
-        text_column,
-        bar_column,
-        completion_column,
-        time_column,
-        expand=True,
-        auto_refresh=False,
-    )
 
-    with progress:
-        yield from progress.track(sequence, description=description)
+    def __init__(self, **kwargs):
+        """
+        Initialise a `rich` progress bar with preset formatting.
+
+        Parameters
+        ----------
+        **kwargs
+            Keyword arguments passed on to `rich.progress.Progress`.
+        """
+        text_column = TextColumn("{task.description}")
+        bar_column = BarColumn(
+            bar_width=None,
+            complete_style=Style(color="#FBBB10"),
+            finished_style=Style(color="#E38408"),
+        )
+        completion_column = MofNCompleteColumn()
+        time_column = TimeRemainingColumn()
+        super().__init__(
+            text_column,
+            bar_column,
+            completion_column,
+            time_column,
+            expand=True,
+            auto_refresh=False,
+            **kwargs,
+        )
 
 
 def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1334,7 +1334,7 @@ def test_progress_bar_complete(tmp_path, capsys, ensemble, tag):
     file_prefix = tmp_path / f"Cl4Na4-{tag}-T300.0"
 
     single_point = SinglePoint(
-        struct_path=DATA_PATH / "NaCl.cif",
+        struct=DATA_PATH / "NaCl.cif",
         arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -717,7 +717,7 @@ def test_stats(tmp_path, ensemble, tag):
 
 
 @pytest.mark.parametrize("ensemble", ensembles_with_thermostat)
-def test_heating(tmp_path, ensemble):
+def test_heating(tmp_path, capsys, ensemble):
     """Test heating with no MD."""
     file_prefix = tmp_path / "NaCl-heating"
     final_file = tmp_path / "NaCl-heating-final.extxyz"
@@ -741,6 +741,7 @@ def test_heating(tmp_path, ensemble):
         temp_step=20,
         temp_time=2,
         log_kwargs={"filename": log_file},
+        enable_progress_bar=True,
     )
     md.run()
     assert_log_contains(
@@ -753,6 +754,9 @@ def test_heating(tmp_path, ensemble):
     )
 
     assert final_file.exists()
+
+    # Check progress bar has completed.
+    assert "━━ 2/2" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize("ensemble", ensembles_without_thermostat)
@@ -807,7 +811,7 @@ def test_noramp_heating(tmp_path, ensemble):
 
 
 @pytest.mark.parametrize("ensemble", ensembles_with_thermostat)
-def test_heating_md(tmp_path, ensemble):
+def test_heating_md(tmp_path, capsys, ensemble):
     """Test heating followed by MD."""
     file_prefix = tmp_path / "NaCl-heating"
     stats_path = tmp_path / "NaCl-heating-stats.dat"
@@ -830,6 +834,7 @@ def test_heating_md(tmp_path, ensemble):
         temp_step=10,
         temp_time=2,
         log_kwargs={"filename": log_file},
+        enable_progress_bar=True,
     )
     md.run()
     assert_log_contains(
@@ -859,6 +864,11 @@ def test_heating_md(tmp_path, ensemble):
     assert stat_data.labels[0] == "# Step"
     assert stat_data.units[0] == ""
     assert stat_data.units[target_t_col] == "K"
+
+    # Check progress bar has completed.
+    out = capsys.readouterr().out
+    assert "━━ 9/9" in out  # Total progress
+    assert "━━ 5/5" in out  # Const T progress
 
 
 def test_heating_files():

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1124,7 +1124,7 @@ def test_logging(tmp_path):
     assert single_point.struct.info["emissions"] > 0
 
 
-def test_auto_restart(tmp_path):
+def test_auto_restart(tmp_path, capsys):
     """Test auto restarting simulation."""
     # tmp_path for all files other than restart
     # Include T300.0 to test Path.stem vs Path.name
@@ -1183,6 +1183,7 @@ def test_auto_restart(tmp_path):
             traj_every=1,
             final_file=final_path,
             log_kwargs={"filename": log_file},
+            enable_progress_bar=True,
         )
 
         assert_log_contains(log_file, includes="Auto restart successful")
@@ -1210,6 +1211,9 @@ def test_auto_restart(tmp_path):
 
         final_traj = read(traj_path, index=":")
         assert len(final_traj) == 8
+
+        # Check progress bar has completed.
+        assert "━━ 7/7" in capsys.readouterr().out
 
     finally:
         restart_path.unlink(missing_ok=True)
@@ -1322,3 +1326,26 @@ def test_set_info(tmp_path):
     final_struct = read(traj_path, index="-1")
     assert npt.struct.info["density"] == pytest.approx(2.120952627887493)
     assert final_struct.info["density"] == pytest.approx(2.120952627887493)
+
+
+@pytest.mark.parametrize("ensemble, tag", test_data)
+def test_progress_bar_complete(tmp_path, capsys, ensemble, tag):
+    """Test progress bar completes in all ensembles."""
+    file_prefix = tmp_path / f"Cl4Na4-{tag}-T300.0"
+
+    single_point = SinglePoint(
+        struct_path=DATA_PATH / "NaCl.cif",
+        arch="mace",
+        calc_kwargs={"model": MODEL_PATH},
+    )
+    md = ensemble(
+        struct=single_point.struct,
+        steps=2,
+        file_prefix=file_prefix,
+        enable_progress_bar=True,
+    )
+
+    md.run()
+
+    # Check progress bar has completed.
+    assert "━━ 2/2" in capsys.readouterr().out

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -140,6 +140,8 @@ def test_md(ensemble):
         for prop, units in expected_units.items():
             assert atoms.info["units"][prop] == units
 
+        assert "━━ 2/2" in result.output
+
     finally:
         final_path.unlink(missing_ok=True)
         restart_path.unlink(missing_ok=True)
@@ -785,6 +787,9 @@ def test_auto_restart(tmp_path):
     # Includes header and steps 0, 3, and steps 5, 6, 7
     assert len(lines) == 6
     assert int(lines[-1].split()[0]) == 7
+
+    # Check progress bar counted restart steps correctly
+    assert "7/7" in result.stdout
 
 
 def test_no_carbon(tmp_path):


### PR DESCRIPTION
This fundamentally works:

![image](https://github.com/user-attachments/assets/bee750ed-133d-4924-9111-b476b6b71d24)

but still has some holes:
- Progress bar update frequencies that aren't a multiple of the task total won't complete the bars.
- Restarts have not been checked and definitely don't behave properly.

I'll leave it here as a draft so someone else can polish it if they want to.