### PR TITLE
Add default output directory

### DIFF
--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -53,36 +53,38 @@ prints the following:
 
     Usage: janus singlepoint [OPTIONS]
 
-      Perform single point calculations and save to file.
+    Perform single point calculations and save to file.
 
-    Options:
-      --struct PATH        Path of structure to simulate.  [required]
-      --arch TEXT          MLIP architecture to use for calculations.  [default:
-                           mace_mp]
-      --device TEXT        Device to run calculations on.  [default: cpu]
-      --model-path TEXT    Path to MLIP model.  [default: None]
-      --properties TEXT    Properties to calculate. If not specified, 'energy',
-                       'forces' and 'stress' will be returned.
-      --out PATH           Path to save structure with calculated results. Default
-                           is inferred from name of structure file.
-      --read-kwargs DICT   Keyword arguments to pass to ase.io.read. Must be
-                           passed as a dictionary wrapped in quotes, e.g. "{'key'
-                           : value}".  [default: "{}"]
-      --calc-kwargs DICT   Keyword arguments to pass to selected calculator. Must
-                           be passed as a dictionary wrapped in quotes, e.g.
-                           "{'key' : value}". For the default architecture
-                           ('mace_mp'), "{'model':'small'}" is set unless
-                           overwritten.
-      --write-kwargs DICT  Keyword arguments to pass to ase.io.write when saving
-                           results. Must be passed as a dictionary wrapped in
-                           quotes, e.g. "{'key' : value}".  [default: "{}"]
-      --log PATH           Path to save logs to. Default is inferred from the name
-                           of the structure file.
-      --summary PATH       Path to save summary of inputs, start/end time, and
-                           carbon emissions. Default is inferred from the name of
-                           the structure file.
-      --config TEXT        Configuration file.
-      --help               Show this message and exit.
+       Options:
+      *  --struct                          PATH  Path of structure to simulate. [default: None] [required]
+         --arch                            TEXT  MLIP architecture to use for calculations. [default: mace_mp]
+         --device                          TEXT  Device to run calculations on. [default:]
+         --model-path                      TEXT  Path to MLIP model. [default: None]
+         --properties                      TEXT  Properties to calculate. If not specified, 'energy', 'forces' and
+                                                 'stress' will be returned. [default: None]
+         --file-prefix                     PATH  Prefix for output files, including directories. Default directory is
+                                                 ./janus_results, and default filename prefix is inferred from the
+                                                 input stucture filename.
+         --out                             PATH  Path to save structure with calculated results. Default is inferred
+                                                 from name of structure file. [default: None]
+         --read-kwargs                     DICT  Keyword arguments to pass to ase.io.read. Must be passed as a
+                                                 dictionary wrapped in quotes, e.g. "{'key': value}".
+                                                 By default, read_kwargs['index'] = ':', so all structures are read.
+                                                 [default: None]
+         --calc-kwargs                     DICT  Keyword arguments to pass to selected calculator. Must be passed as a
+                                                 dictionary wrapped in quotes, e.g. "{'key': value}".
+                                                 For the default architecture ('mace_mp'), "{'model': 'small'}" is set
+                                                 unless overwritten. [default: None]
+         --write-kwargs                    DICT  Keyword arguments to pass to ase.io.write when saving results. Must be
+                                                 passed as a dictionary wrapped in quotes, e.g. "{'key': value}".
+                                                 [default: None]
+         --log                             PATH  Path to save logs to. Default is inferred from the name of the
+                                                 structure file. [default: None]
+         --tracker         --no-tracker          Whether to save carbon emissions of calculation [default: tracker]
+         --summary                         PATH  Path to save summary of inputs, start/end time, and carbon emissions.
+                                                 Default is inferred from the name of the structure file. [default: None]
+         --config                          TEXT  Configuration file.
+         --help                                  Show this message and exit.
 
 
 Using configuration files
@@ -121,6 +123,30 @@ Example configurations for all commands can be found in `janus-tutorials <https:
 
 Output files
 ------------
+
+Filenames
++++++++++
+
+The names and locations of output files from calculations are controlled by ``--file-prefix``.
+By default, files will be saved to the ``./janus_results`` directory, creating it if is does not already exist.
+
+The prefix for files saved within this directory defaults to the name of the input structure file.
+For example, an input structure from ``NaCl.cif`` will lead to results being saved in ``./janus_results/NaCl-[suffix]``,
+where suffix depends on the output file.
+
+If both ``--file-prefix`` and a specific output file are specified, the latter will take precedence. For example:
+
+.. code-block:: bash
+
+    janus singlepoint --struct tests/data/NaCl.cif --arch mace_mp --out results/NaCl.extxyz --file-prefix other_results/NaCl
+
+
+will save the main output file to ``./results/NaCl.extxyz``, but the summary and log files to
+``./other_results/NaCl-singlepoint-log.yml`` and ``./other_results/NaCl-singlepoint-summary.yml``.
+
+
+Data saved
+++++++++++
 
 By default, calculations performed will modify the underlying `ase.Atoms <https://wiki.fysik.dtu.dk/ase/ase/atoms.html>`_ object
 to store information in the ``Atoms.info`` and ``Atoms.arrays`` dictionaries about the MLIP used.

--- a/janus_core/calculations/descriptors.py
+++ b/janus_core/calculations/descriptors.py
@@ -36,6 +36,8 @@ class Descriptors(BaseCalculation):
         Device to run MLIP model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
+    file_prefix
+        Prefix for output filenames. Default is inferred from structure.
     read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
         read_kwargs["index"] is -1.
@@ -75,6 +77,7 @@ class Descriptors(BaseCalculation):
         arch: Architectures = "mace_mp",
         device: Devices = "cpu",
         model_path: PathLike | None = None,
+        file_prefix: PathLike | None = None,
         read_kwargs: ASEReadArgs | None = None,
         calc_kwargs: dict[str, Any] | None = None,
         set_calc: bool | None = None,
@@ -102,6 +105,8 @@ class Descriptors(BaseCalculation):
             Device to run MLIP model on. Default is "cpu".
         model_path
             Path to MLIP model. Default is `None`.
+        file_prefix
+            Prefix for output filenames. Default is inferred from structure.
         read_kwargs
             Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is -1.
@@ -161,6 +166,7 @@ class Descriptors(BaseCalculation):
             log_kwargs=log_kwargs,
             track_carbon=track_carbon,
             tracker_kwargs=tracker_kwargs,
+            file_prefix=file_prefix,
         )
 
         if isinstance(self.struct, Atoms) and not self.struct.calc:

--- a/janus_core/calculations/eos.py
+++ b/janus_core/calculations/eos.py
@@ -22,7 +22,7 @@ from janus_core.helpers.janus_types import (
     PathLike,
 )
 from janus_core.helpers.struct_io import output_structs
-from janus_core.helpers.utils import none_to_dict, set_minimize_logging
+from janus_core.helpers.utils import build_file_dir, none_to_dict, set_minimize_logging
 
 
 class EoS(BaseCalculation):
@@ -302,7 +302,9 @@ class EoS(BaseCalculation):
         self._calc_volumes_energies()
 
         if self.write_results:
-            with open(f"{self.file_prefix}-eos-raw.dat", "w", encoding="utf8") as out:
+            eos_raw_file = f"{self.file_prefix}-eos-raw.dat"
+            build_file_dir(eos_raw_file)
+            with open(eos_raw_file, "w", encoding="utf8") as out:
                 print("#Lattice Scalar | Energy [eV] | Volume [Å^3] ", file=out)
                 for eos_data in zip(
                     self.lattice_scalars, self.energies, self.volumes, strict=True
@@ -328,7 +330,9 @@ class EoS(BaseCalculation):
             self.tracker.stop()
 
         if self.write_results:
-            with open(f"{self.file_prefix}-eos-fit.dat", "w", encoding="utf8") as out:
+            eos_fit_file = f"{self.file_prefix}-eos-fit.dat"
+            build_file_dir(eos_fit_file)
+            with open(eos_fit_file, "w", encoding="utf8") as out:
                 print("#Bulk modulus [GPa] | Energy [eV] | Volume [Å^3] ", file=out)
                 print(bulk_modulus, e_0, v_0, file=out)
 
@@ -340,6 +344,7 @@ class EoS(BaseCalculation):
         }
 
         if self.plot_to_file:
+            build_file_dir(self.plot_kwargs["filename"])
             eos.plot(**self.plot_kwargs)
 
         return self.results

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -43,7 +43,12 @@ from janus_core.helpers.janus_types import (
     PostProcessKwargs,
 )
 from janus_core.helpers.struct_io import input_structs, output_structs
-from janus_core.helpers.utils import none_to_dict, set_minimize_logging, write_table
+from janus_core.helpers.utils import (
+    build_file_dir,
+    none_to_dict,
+    set_minimize_logging,
+    write_table,
+)
 from janus_core.processing.correlator import Correlation
 from janus_core.processing.post_process import compute_rdf, compute_vaf
 
@@ -716,11 +721,9 @@ class MolecularDynamics(BaseCalculation):
     def _write_correlations(self) -> None:
         """Write out the correlations."""
         if self._correlations:
-            with open(
-                self._build_filename("cor.dat", self.param_prefix),
-                "w",
-                encoding="utf-8",
-            ) as out_file:
+            corr_file = self._build_filename("cor.dat", self.param_prefix)
+            build_file_dir(corr_file)
+            with open(corr_file, "w", encoding="utf-8") as out_file:
                 data = {}
                 for cor in self._correlations:
                     value, lags = cor.get()
@@ -843,6 +846,7 @@ class MolecularDynamics(BaseCalculation):
 
     def _write_header(self) -> None:
         """Write header for stats file."""
+        build_file_dir(self.stats_file)
         with open(self.stats_file, "w", encoding="utf-8") as stats_file:
             write_table(
                 "ascii",

--- a/janus_core/calculations/neb.py
+++ b/janus_core/calculations/neb.py
@@ -26,7 +26,7 @@ from janus_core.helpers.janus_types import (
     PathLike,
 )
 from janus_core.helpers.struct_io import input_structs, output_structs
-from janus_core.helpers.utils import none_to_dict, set_minimize_logging
+from janus_core.helpers.utils import build_file_dir, none_to_dict, set_minimize_logging
 
 
 class NEB(BaseCalculation):
@@ -404,6 +404,7 @@ class NEB(BaseCalculation):
             self.run_nebtools()
 
         if self.plot_band:
+            build_file_dir(self.plot_file)
             fig = self.nebtools.plot_band()
             fig.savefig(self.plot_file)
         else:
@@ -489,6 +490,7 @@ class NEB(BaseCalculation):
         }
 
         if self.write_results:
+            build_file_dir(self.results_file)
             with open(self.results_file, "w", encoding="utf8") as out:
                 print("#Barrier [eV] | delta E [eV] | Max force [eV/Å] ", file=out)
                 print(*self.results.values(), file=out)

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -596,8 +596,8 @@ class Phonons(BaseCalculation):
 
         bplt = self.results["phonon"].plot_band_structure()
         if save_plots:
-            build_file_dir(plot_file)
             plot_file = self._build_filename("bands.svg", filename=plot_file)
+            build_file_dir(plot_file)
             bplt.savefig(plot_file)
 
     def calc_thermal_props(
@@ -764,17 +764,17 @@ class Phonons(BaseCalculation):
 
         bplt = self.results["phonon"].plot_total_dos()
         if plot_to_file:
-            build_file_dir(plot_file)
             plot_file = self._build_filename("dos.svg", filename=plot_file)
+            build_file_dir(plot_file)
             bplt.savefig(plot_file)
 
         if plot_bands:
             bplt = self.results["phonon"].plot_band_structure_and_dos()
             if plot_to_file:
-                build_file_dir(plot_bands_file)
                 plot_bands_file = self._build_filename(
                     "bs-dos.svg", filename=plot_bands_file
                 )
+                build_file_dir(plot_bands_file)
                 bplt.savefig(plot_bands_file)
 
     def calc_pdos(
@@ -863,8 +863,8 @@ class Phonons(BaseCalculation):
 
         bplt = self.results["phonon"].plot_projected_dos()
         if plot_to_file:
-            build_file_dir(plot_file)
             plot_file = self._build_filename("pdos.svg", filename=plot_file)
+            build_file_dir(plot_file)
             bplt.savefig(plot_file)
 
     # No magnetic moments considered

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -27,7 +27,12 @@ from janus_core.helpers.janus_types import (
     PathLike,
     PhononCalcs,
 )
-from janus_core.helpers.utils import none_to_dict, set_minimize_logging, track_progress
+from janus_core.helpers.utils import (
+    build_file_dir,
+    none_to_dict,
+    set_minimize_logging,
+    track_progress,
+)
 
 
 class Phonons(BaseCalculation):
@@ -491,9 +496,11 @@ class Phonons(BaseCalculation):
         phonon = self.results["phonon"]
 
         save_force_consts = not force_consts_to_hdf5
+        build_file_dir(phonopy_file)
         phonon.save(phonopy_file, settings={"force_constants": save_force_consts})
 
         if force_consts_to_hdf5:
+            build_file_dir(force_consts_file)
             write_force_constants_to_hdf5(
                 phonon.force_constants, filename=force_consts_file
             )
@@ -580,6 +587,8 @@ class Phonons(BaseCalculation):
             with_eigenvectors=self.write_full,
             with_group_velocities=self.write_full,
         )
+
+        build_file_dir(bands_file)
         self.results["phonon"].write_yaml_band_structure(
             filename=bands_file,
             compression="lzma",
@@ -587,6 +596,7 @@ class Phonons(BaseCalculation):
 
         bplt = self.results["phonon"].plot_band_structure()
         if save_plots:
+            build_file_dir(plot_file)
             plot_file = self._build_filename("bands.svg", filename=plot_file)
             bplt.savefig(plot_file)
 
@@ -654,6 +664,7 @@ class Phonons(BaseCalculation):
             `file_prefix`.
         """
         thermal_file = self._build_filename("thermal.yml", filename=thermal_file)
+        build_file_dir(thermal_file)
         self.results["phonon"].write_yaml_thermal_properties(filename=thermal_file)
 
     def calc_dos(
@@ -748,16 +759,19 @@ class Phonons(BaseCalculation):
             plot_to_file = self.plot_to_file
 
         dos_file = self._build_filename("dos.dat", filename=dos_file)
+        build_file_dir(dos_file)
         self.results["phonon"].total_dos.write(dos_file)
 
         bplt = self.results["phonon"].plot_total_dos()
         if plot_to_file:
+            build_file_dir(plot_file)
             plot_file = self._build_filename("dos.svg", filename=plot_file)
             bplt.savefig(plot_file)
 
         if plot_bands:
             bplt = self.results["phonon"].plot_band_structure_and_dos()
             if plot_to_file:
+                build_file_dir(plot_bands_file)
                 plot_bands_file = self._build_filename(
                     "bs-dos.svg", filename=plot_bands_file
                 )
@@ -844,10 +858,12 @@ class Phonons(BaseCalculation):
             plot_to_file = self.plot_to_file
 
         pdos_file = self._build_filename("pdos.dat", filename=pdos_file)
+        build_file_dir(pdos_file)
         self.results["phonon"].projected_dos.write(pdos_file)
 
         bplt = self.results["phonon"].plot_projected_dos()
         if plot_to_file:
+            build_file_dir(plot_file)
             plot_file = self._build_filename("pdos.svg", filename=plot_file)
             bplt.savefig(plot_file)
 

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -12,6 +12,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    FilePrefix,
     LogPath,
     ModelPath,
     ReadKwargsAll,
@@ -45,6 +46,7 @@ def descriptors(
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     model_path: ModelPath = None,
+    file_prefix: FilePrefix = None,
     out: Annotated[
         Path | None,
         Option(
@@ -84,9 +86,13 @@ def descriptors(
         Device to run model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
+    file_prefix
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     out
-        Path to save structure with calculated results. Default is inferred from name
-        of the structure file.
+        Path to save structure with calculated results. Default is inferred
+        `file_prefix`.
     read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is ":".
@@ -95,13 +101,13 @@ def descriptors(
     write_kwargs
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log
-        Path to write logs to. Default is inferred from the name of the structure file.
+        Path to write logs to. Default is inferred from `file_prefix`.
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
-        is inferred from the name of the structure file.
+        is inferred from `file_prefix`.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -159,6 +165,7 @@ def descriptors(
         "calc_per_atom": calc_per_atom,
         "write_results": True,
         "write_kwargs": write_kwargs,
+        "file_prefix": file_prefix,
         "enable_progress_bar": True,
     }
 

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Annotated, get_args
 
 from typer import Context, Option, Typer
@@ -12,6 +11,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    FilePrefix,
     LogPath,
     MinimizeKwargs,
     ModelPath,
@@ -62,17 +62,7 @@ def eos(
     model_path: ModelPath = None,
     read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
-    file_prefix: Annotated[
-        Path | None,
-        Option(
-            help=(
-                """
-                Prefix for output filenames. Default is inferred from structure name,
-                or chemical formula.
-                """
-            ),
-        ),
-    ] = None,
+    file_prefix: FilePrefix = None,
     log: LogPath = None,
     tracker: Annotated[
         bool, Option(help="Whether to save carbon emissions of calculation")
@@ -125,16 +115,17 @@ def eos(
     calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
     file_prefix
-        Prefix for output filenames. Default is inferred from structure name, or
-        chemical formula.
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     log
-        Path to write logs to. Default is inferred from the name of the structure file.
+        Path to write logs to. Default is inferred from `file_prefix`.
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
-        is inferred from the name of the structure file.
+        is inferred from `file_prefix`.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -12,6 +12,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    FilePrefix,
     LogPath,
     MinimizeKwargs,
     ModelPath,
@@ -115,16 +116,12 @@ def geomopt(
             help="Atom displacement tolerance for spglib symmetry determination, in Å."
         ),
     ] = 0.001,
-    file_prefix: Annotated[
-        Path | None,
-        Option(help="Prefix for output filenames. Default is inferred from structure."),
-    ] = None,
+    file_prefix: FilePrefix = None,
     out: Annotated[
         Path | None,
         Option(
             help=(
-                "Path to save optimized structure. Default is inferred from name "
-                "of structure file."
+                "Path to save optimized structure. Default is inferred `file_prefix`."
             ),
         ),
     ] = None,
@@ -190,10 +187,12 @@ def geomopt(
         Atom displacement tolerance for spglib symmetry determination, in Å.
         Default is 0.001.
     file_prefix
-        Prefix for output filenames. Default is inferred from structure.
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     out
         Path to save optimized structure, or last structure if optimization did not
-        converge. Default is inferred from name of structure file.
+        converge. Default is inferred from `file_prefix`.
     write_traj
         Whether to save a trajectory file of optimization frames.
         If traj_kwargs["filename"] is not specified, it is inferred from `file_prefix`.
@@ -208,13 +207,13 @@ def geomopt(
         Keyword arguments to pass to ase.io.write when saving optimized structure.
         Default is {}.
     log
-        Path to write logs to. Default is inferred from the name of the structure file.
+        Path to write logs to. Default is inferred from `file_prefix`.
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
-        is inferred from the name of the structure file.
+        is inferred from `file_prefix`.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -13,6 +13,7 @@ from janus_core.cli.types import (
     CalcKwargs,
     Device,
     EnsembleKwargs,
+    FilePrefix,
     LogPath,
     MinimizeKwargs,
     ModelPath,
@@ -131,17 +132,7 @@ def md(
     rescale_every: Annotated[
         int, Option(help="Frequency to rescale velocities during equilibration.")
     ] = 10,
-    file_prefix: Annotated[
-        Path | None,
-        Option(
-            help=(
-                """
-                Prefix for output filenames. Default is inferred from structure,
-                ensemble, and temperature.
-                """
-            ),
-        ),
-    ] = None,
+    file_prefix: FilePrefix = None,
     restart: Annotated[bool, Option(help="Whether restarting dynamics.")] = False,
     restart_auto: Annotated[
         bool, Option(help="Whether to infer restart file if restarting dynamics.")
@@ -289,8 +280,9 @@ def md(
     rescale_every
         Frequency to rescale velocities. Default is 10.
     file_prefix
-        Prefix for output filenames. Default is inferred from structure, ensemble,
-        and temperature.
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     restart
         Whether restarting dynamics. Default is False.
     restart_auto
@@ -339,13 +331,13 @@ def md(
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.
     log
-        Path to write logs to. Default is inferred from the name of the structure file.
+        Path to write logs to. Default is inferred from `file_prefix`.
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
-        is inferred from the name of the structure file.
+        is inferred from `file_prefix`.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """

--- a/janus_core/cli/neb.py
+++ b/janus_core/cli/neb.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Annotated, get_args
 
 from click import Choice
@@ -13,6 +12,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    FilePrefix,
     InterpolationKwargs,
     LogPath,
     MinimizeKwargs,
@@ -78,17 +78,7 @@ def neb(
     model_path: ModelPath = None,
     read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
-    file_prefix: Annotated[
-        Path | None,
-        Option(
-            help=(
-                """
-                Prefix for output filenames. Default is inferred from structure name,
-                or chemical formula.
-                """
-            ),
-        ),
-    ] = None,
+    file_prefix: FilePrefix = None,
     log: LogPath = None,
     tracker: Annotated[
         bool, Option(help="Whether to save carbon emissions of calculation")
@@ -157,16 +147,17 @@ def neb(
     calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
     file_prefix
-        Prefix for output filenames. Default is inferred from the intial structure
-        name, or chemical formula of the intial structure.
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     log
-        Path to write logs to. Default is inferred from the name of the structure file.
+        Path to write logs to. Default is inferred from `file_prefix`.
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
-        is inferred from the name of the structure file.
+        is inferred from `file_prefix`.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -14,6 +14,7 @@ from janus_core.cli.types import (
     Device,
     DisplacementKwargs,
     DoSKwargs,
+    FilePrefix,
     LogPath,
     MinimizeKwargs,
     ModelPath,
@@ -121,17 +122,7 @@ def phonons(
     model_path: ModelPath = None,
     read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
-    file_prefix: Annotated[
-        Path | None,
-        Option(
-            help=(
-                """
-                Prefix for output filenames. Default is inferred from structure name,
-                or chemical formula.
-                """
-            ),
-        ),
-    ] = None,
+    file_prefix: FilePrefix = None,
     log: LogPath = None,
     tracker: Annotated[
         bool, Option(help="Whether to save carbon emissions of calculation")
@@ -215,16 +206,17 @@ def phonons(
     calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
     file_prefix
-        Prefix for output filenames. Default is inferred from structure name, or
-        chemical formula.
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     log
-        Path to write logs to. Default is inferred from the name of the structure file.
+        Path to write logs to. Default is inferred from `file_prefix`.
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
-        is inferred from the name of the structure file.
+        is inferred from `file_prefix`.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """

--- a/janus_core/cli/preprocess.py
+++ b/janus_core/cli/preprocess.py
@@ -16,7 +16,7 @@ def preprocess(
         Path, Option(help="Configuration file to pass to MLIP CLI.")
     ],
     log: Annotated[Path, Option(help="Path to save logs to.")] = Path(
-        "preprocess-log.yml"
+        "./janus_results/preprocess-log.yml"
     ),
     tracker: Annotated[
         bool, Option(help="Whether to save carbon emissions of calculation")
@@ -28,7 +28,7 @@ def preprocess(
                 "Path to save summary of inputs, start/end time, and carbon emissions."
             )
         ),
-    ] = Path("preprocess-summary.yml"),
+    ] = Path("./janus_results/preprocess-summary.yml"),
 ):
     """
     Convert training data to hdf5 by passing a configuration file to the MLIP's CLI.

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -12,6 +12,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    FilePrefix,
     LogPath,
     ModelPath,
     ReadKwargsAll,
@@ -42,18 +43,13 @@ def singlepoint(
             ),
         ),
     ] = None,
-    file_prefix: Annotated[
-        Path | None,
-        Option(
-            help=("Prefix for output filenames. Default is inferred from structure.")
-        ),
-    ] = None,
+    file_prefix: FilePrefix = None,
     out: Annotated[
         Path | None,
         Option(
             help=(
                 "Path to save structure with calculated results. Default is inferred "
-                "from name of structure file."
+                "from `file_prefix`."
             ),
         ),
     ] = None,
@@ -85,10 +81,12 @@ def singlepoint(
     properties
         Physical properties to calculate. Default is ("energy", "forces", "stress").
     file_prefix
-        Prefix for output filenames. Default is inferred from structure.
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     out
-        Path to save structure with calculated results. Default is inferred from name
-        of the structure file.
+        Path to save structure with calculated results. Default is inferred from
+        `file_prefix`.
     read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is ":".
@@ -97,13 +95,13 @@ def singlepoint(
     write_kwargs
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log
-        Path to write logs to. Default is inferred from the name of the structure file.
+        Path to write logs to. Default is inferred from `file_prefix`.
     tracker
         Whether to save carbon emissions of calculation in log file and summary.
         Default is True.
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
-        is inferred from the name of the structure file.
+        is inferred from `file_prefix`.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -19,7 +19,9 @@ def train(
     fine_tune: Annotated[
         bool, Option(help="Whether to fine-tune a foundational model.")
     ] = False,
-    log: Annotated[Path, Option(help="Path to save logs to.")] = Path("train-log.yml"),
+    log: Annotated[Path, Option(help="Path to save logs to.")] = Path(
+        "./janus_results/train-log.yml"
+    ),
     tracker: Annotated[
         bool, Option(help="Whether to save carbon emissions of calculation")
     ] = True,
@@ -30,7 +32,7 @@ def train(
                 "Path to save summary of inputs, start/end time, and carbon emissions."
             )
         ),
-    ] = Path("train-summary.yml"),
+    ] = Path("./janus_results/train-summary.yml"),
 ) -> None:
     """
     Run training for MLIP by passing a configuration file to the MLIP's CLI.

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -72,6 +72,19 @@ Architecture = Annotated[
 Device = Annotated[str | None, Option(help="Device to run calculations on.")]
 ModelPath = Annotated[str | None, Option(help="Path to MLIP model.")]
 
+FilePrefix = Annotated[
+    Path | None,
+    Option(
+        help=(
+            """
+                Prefix for output files, including directories. Default directory is
+                ./janus_results, and default filename prefix is inferred from the
+                input stucture filename.
+                """
+        )
+    ),
+]
+
 ReadKwargsAll = Annotated[
     TyperDict | None,
     Option(
@@ -287,12 +300,7 @@ PostProcessKwargs = Annotated[
 
 LogPath = Annotated[
     Path | None,
-    Option(
-        help=(
-            "Path to save logs to. Default is inferred from the name of the structure "
-            "file."
-        )
-    ),
+    Option(help=("Path to save logs to. Default is inferred from `file_prefix`")),
 ]
 
 Summary = Annotated[
@@ -300,7 +308,7 @@ Summary = Annotated[
     Option(
         help=(
             "Path to save summary of inputs, start/end time, and carbon emissions. "
-            "Default is inferred from the name of the structure file."
+            "Default is inferred from `file_prefix`."
         )
     ),
 ]

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 from typer_config import conf_callback_factory, yaml_loader
 import yaml
 
+from janus_core.helpers.utils import build_file_dir
+
 if TYPE_CHECKING:
     from ase import Atoms
     from typer import Context
@@ -177,6 +179,7 @@ def start_summary(
     dict_paths_to_strs(summary_contents)
     dict_tuples_to_lists(summary_contents)
 
+    build_file_dir(summary)
     with open(summary, "w", encoding="utf8") as outfile:
         yaml.dump(summary_contents, outfile, default_flow_style=False)
 

--- a/janus_core/helpers/log.py
+++ b/janus_core/helpers/log.py
@@ -10,6 +10,7 @@ from codecarbon import OfflineEmissionsTracker
 from codecarbon.output import LoggerOutput
 
 from janus_core.helpers.janus_types import LogLevel
+from janus_core.helpers.utils import build_file_dir
 
 
 class YamlFormatter(logging.Formatter):  # numpydoc ignore=PR02
@@ -127,6 +128,7 @@ def config_logger(
         Configured logger if `filename` has been specified.
     """
     if filename:
+        build_file_dir(filename)
         logger = logging.getLogger(name)
 
         handler = logging.FileHandler(

--- a/janus_core/helpers/struct_io.py
+++ b/janus_core/helpers/struct_io.py
@@ -22,7 +22,7 @@ from janus_core.helpers.janus_types import (
     Properties,
 )
 from janus_core.helpers.mlip_calculators import choose_calculator
-from janus_core.helpers.utils import none_to_dict
+from janus_core.helpers.utils import build_file_dir, none_to_dict
 
 
 def results_to_info(
@@ -284,4 +284,6 @@ def output_structs(
             write_kwargs.setdefault("write_results", not invalidate_calc)
         else:
             write_kwargs.pop("write_results", None)
+
+        build_file_dir(write_kwargs["filename"])
         write(images=images, **write_kwargs)

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -83,7 +83,8 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
         Parameters
         ----------
         file_prefix
-            File prefix.
+            Name to be given to any result files. May also include path to file
+            directory.
         struct
             Structure(s) from which to derive the default name. If `struct` is a
             sequence, the first structure will be used.

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -148,8 +148,6 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
             )
             built_filename = Path("-".join((prefix, *filter(None, additional), suffix)))
 
-        # Make directory if it does not exist
-        built_filename.parent.mkdir(parents=True, exist_ok=True)
         return built_filename
 
 
@@ -578,3 +576,15 @@ def set_minimize_logging(
             "filemode": "a",
         }
         minimize_kwargs["track_carbon"] = track_carbon
+
+
+def build_file_dir(filepath: PathLike) -> None:
+    """
+    Make any missing parent directories of a file.
+
+    Parameters
+    ----------
+    filepath
+        Path to file being written.
+    """
+    Path(filepath).parent.mkdir(parents=True, exist_ok=True)

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -109,7 +109,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
             struct_name = struct.get_chemical_formula()
 
         # Set default output directory
-        prefix = Path("./results") / struct_name
+        prefix = Path("./janus_results") / struct_name
 
         return "-".join((str(prefix), *filter(None, additional)))
 

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -67,7 +67,7 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
             Components to add to default file_prefix (joined by hyphens).
         """
         self.file_prefix = Path(
-            self._get_default_prefix(file_prefix, struct, struct_path, *additional)
+            self._get_default_prefix(file_prefix, struct, struct_path, *additional),
         )
 
     @staticmethod
@@ -78,12 +78,12 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
         *additional,
     ) -> str:
         """
-        Determine the default prefix from the structure  or provided file_prefix.
+        Determine the default prefix from the structure or provided file_prefix.
 
         Parameters
         ----------
         file_prefix
-            Given file_prefix.
+            File prefix.
         struct
             Structure(s) from which to derive the default name. If `struct` is a
             sequence, the first structure will be used.
@@ -108,7 +108,10 @@ class FileNameMixin(ABC):  # noqa: B024 (abstract-base-class-without-abstract-me
         else:
             struct_name = struct.get_chemical_formula()
 
-        return "-".join((struct_name, *filter(None, additional)))
+        # Set default output directory
+        prefix = Path("./results") / struct_name
+
+        return "-".join((str(prefix), *filter(None, additional)))
 
     def _build_filename(
         self,

--- a/janus_core/processing/post_process.py
+++ b/janus_core/processing/post_process.py
@@ -16,7 +16,7 @@ from janus_core.helpers.janus_types import (
     PathLike,
     SliceLike,
 )
-from janus_core.helpers.utils import slicelike_to_startstopstep
+from janus_core.helpers.utils import build_file_dir, slicelike_to_startstopstep
 
 
 def compute_rdf(
@@ -123,6 +123,7 @@ def compute_rdf(
                 )
 
             for (dists, rdfs), out_path in zip(rdf.values(), filenames, strict=True):
+                build_file_dir(out_path)
                 with open(out_path, "w", encoding="utf-8") as out_file:
                     for dist, rdf_i in zip(dists, rdfs, strict=True):
                         print(dist, rdf_i, file=out_file)
@@ -151,6 +152,7 @@ def compute_rdf(
                     )
                 filenames = filenames[0]
 
+            build_file_dir(filenames)
             with open(filenames, "w", encoding="utf-8") as out_file:
                 for dist, rdf_i in zip(*rdf, strict=True):
                     print(dist, rdf_i, file=out_file)
@@ -308,6 +310,7 @@ def compute_vaf(
     )
     if filenames:
         for vaf, filename in zip(vafs[1], filenames, strict=True):
+            build_file_dir(filename)
             with open(filename, "w", encoding="utf-8") as out_file:
                 for lag, dat in zip(lags, vaf, strict=True):
                     print(lag, dat, file=out_file)

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -33,9 +33,6 @@ def test_descriptors():
     summary_path = results_dir / "NaCl-descriptors-summary.yml"
 
     assert not results_dir.exists()
-    assert not out_path.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     try:
         result = runner.invoke(
@@ -88,9 +85,6 @@ def test_descriptors():
         assert descriptors_summary["emissions"] > 0
 
     finally:
-        out_path.unlink(missing_ok=True)
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -271,3 +271,26 @@ def test_no_carbon(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         descriptors_summary = yaml.safe_load(file)
     assert "emissions" not in descriptors_summary
+
+
+def test_file_prefix(tmp_path):
+    """Test file prefix creates directories and affects all files."""
+    file_prefix = tmp_path / "test/test"
+    result = runner.invoke(
+        app,
+        [
+            "descriptors",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--file-prefix",
+            file_prefix,
+        ],
+    )
+    assert result.exit_code == 0
+    test_path = tmp_path / "test"
+    assert list(tmp_path.iterdir()) == [test_path]
+    assert set(test_path.iterdir()) == {
+        test_path / "test-descriptors.extxyz",
+        test_path / "test-descriptors-summary.yml",
+        test_path / "test-descriptors-log.yml",
+    }

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from ase.io import read
 import pytest
@@ -26,10 +27,12 @@ def test_help():
 
 def test_descriptors():
     """Test calculating MLIP descriptors."""
-    out_path = Path("./janus_results/NaCl-descriptors.extxyz")
-    log_path = Path("./janus_results/NaCl-descriptors-log.yml")
-    summary_path = Path("./janus_results/NaCl-descriptors-summary.yml")
+    results_dir = Path("./janus_results")
+    out_path = results_dir / "NaCl-descriptors.extxyz"
+    log_path = results_dir / "NaCl-descriptors-log.yml"
+    summary_path = results_dir / "NaCl-descriptors-summary.yml"
 
+    assert not results_dir.exists()
     assert not out_path.exists()
     assert not log_path.exists()
     assert not summary_path.exists()
@@ -88,6 +91,7 @@ def test_descriptors():
         out_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 
 

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -26,9 +26,9 @@ def test_help():
 
 def test_descriptors():
     """Test calculating MLIP descriptors."""
-    out_path = Path("./NaCl-descriptors.extxyz").absolute()
-    log_path = Path("./NaCl-descriptors-log.yml").absolute()
-    summary_path = Path("./NaCl-descriptors-summary.yml").absolute()
+    out_path = Path("./results/NaCl-descriptors.extxyz").absolute()
+    log_path = Path("./results/NaCl-descriptors-log.yml").absolute()
+    summary_path = Path("./results/NaCl-descriptors-summary.yml").absolute()
 
     assert not out_path.exists()
     assert not log_path.exists()

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -26,9 +26,9 @@ def test_help():
 
 def test_descriptors():
     """Test calculating MLIP descriptors."""
-    out_path = Path("./results/NaCl-descriptors.extxyz").absolute()
-    log_path = Path("./results/NaCl-descriptors-log.yml").absolute()
-    summary_path = Path("./results/NaCl-descriptors-summary.yml").absolute()
+    out_path = Path("./janus_results/NaCl-descriptors.extxyz")
+    log_path = Path("./janus_results/NaCl-descriptors-log.yml")
+    summary_path = Path("./janus_results/NaCl-descriptors-summary.yml")
 
     assert not out_path.exists()
     assert not log_path.exists()

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -34,10 +34,6 @@ def test_eos():
     summary_path = results_dir / "NaCl-eos-summary.yml"
 
     assert not results_dir.exists()
-    assert not eos_raw_path.exists()
-    assert not eos_fit_path.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     try:
         result = runner.invoke(
@@ -97,10 +93,6 @@ def test_eos():
         assert eos_summary["emissions"] > 0
 
     finally:
-        eos_raw_path.unlink(missing_ok=True)
-        eos_fit_path.unlink(missing_ok=True)
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from ase.io import read
 import pytest
@@ -26,11 +27,13 @@ def test_help():
 
 def test_eos():
     """Test calculating the equation of state."""
-    eos_raw_path = Path("./janus_results/NaCl-eos-raw.dat")
-    eos_fit_path = Path("./janus_results/NaCl-eos-fit.dat")
-    log_path = Path("./janus_results/NaCl-eos-log.yml")
-    summary_path = Path("./janus_results/NaCl-eos-summary.yml")
+    results_dir = Path("./janus_results")
+    eos_raw_path = results_dir / "NaCl-eos-raw.dat"
+    eos_fit_path = results_dir / "NaCl-eos-fit.dat"
+    log_path = results_dir / "NaCl-eos-log.yml"
+    summary_path = results_dir / "NaCl-eos-summary.yml"
 
+    assert not results_dir.exists()
     assert not eos_raw_path.exists()
     assert not eos_fit_path.exists()
     assert not log_path.exists()
@@ -98,6 +101,7 @@ def test_eos():
         eos_fit_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 
 

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -26,10 +26,10 @@ def test_help():
 
 def test_eos():
     """Test calculating the equation of state."""
-    eos_raw_path = Path("./results/NaCl-eos-raw.dat").absolute()
-    eos_fit_path = Path("./results/NaCl-eos-fit.dat").absolute()
-    log_path = Path("./results/NaCl-eos-log.yml").absolute()
-    summary_path = Path("./results/NaCl-eos-summary.yml").absolute()
+    eos_raw_path = Path("./janus_results/NaCl-eos-raw.dat")
+    eos_fit_path = Path("./janus_results/NaCl-eos-fit.dat")
+    log_path = Path("./janus_results/NaCl-eos-log.yml")
+    summary_path = Path("./janus_results/NaCl-eos-summary.yml")
 
     assert not eos_raw_path.exists()
     assert not eos_fit_path.exists()

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -26,10 +26,10 @@ def test_help():
 
 def test_eos():
     """Test calculating the equation of state."""
-    eos_raw_path = Path("./NaCl-eos-raw.dat").absolute()
-    eos_fit_path = Path("./NaCl-eos-fit.dat").absolute()
-    log_path = Path("./NaCl-eos-log.yml").absolute()
-    summary_path = Path("./NaCl-eos-summary.yml").absolute()
+    eos_raw_path = Path("./results/NaCl-eos-raw.dat").absolute()
+    eos_fit_path = Path("./results/NaCl-eos-fit.dat").absolute()
+    log_path = Path("./results/NaCl-eos-log.yml").absolute()
+    summary_path = Path("./results/NaCl-eos-summary.yml").absolute()
 
     assert not eos_raw_path.exists()
     assert not eos_fit_path.exists()

--- a/tests/test_filenamemixin.py
+++ b/tests/test_filenamemixin.py
@@ -25,17 +25,17 @@ class DummyFileHandler(FileNameMixin):
     "params,file_prefix",
     (
         # Defaults to structure atoms from ASE
-        ((STRUCT, None, None), "C6H6"),
+        ((STRUCT, None, None), "janus_results/C6H6"),
         # Defaults to stem over ASE structure
-        ((STRUCT, "mybenzene", None), "mybenzene"),
+        ((STRUCT, "mybenzene", None), "janus_results/mybenzene"),
         # file_prefix just sets itself
         ((STRUCT, "mybenzene", "benzene"), "benzene"),
         # file_prefix ignores additional
         ((STRUCT, None, "benzene", "wowzers"), "benzene"),
         # Additional only applies where no file_prefix
-        ((STRUCT, None, None, "wowzers"), "C6H6-wowzers"),
+        ((STRUCT, None, None, "wowzers"), "janus_results/C6H6-wowzers"),
         # Additional only applies where no file_prefix
-        ((STRUCT, "mybenzene", None, "wowzers"), "mybenzene-wowzers"),
+        ((STRUCT, "mybenzene", None, "wowzers"), "janus_results/mybenzene-wowzers"),
     ),
 )
 def test_file_name_mixin_init(params, file_prefix):
@@ -48,22 +48,27 @@ def test_file_name_mixin_init(params, file_prefix):
 @pytest.mark.parametrize(
     "mixin_params,file_args,file_kwargs,file_name",
     (
-        ((STRUCT, None, None), ("data.xyz",), {}, "C6H6-data.xyz"),
+        ((STRUCT, None, None), ("data.xyz",), {}, "janus_results/C6H6-data.xyz"),
         ((STRUCT, None, "benzene"), ("data.xyz",), {}, "benzene-data.xyz"),
         ((STRUCT, None, "benzene", "wowzers"), ("data.xyz",), {}, "benzene-data.xyz"),
-        ((STRUCT, None, None, "wowzers"), ("data.xyz",), {}, "C6H6-wowzers-data.xyz"),
+        (
+            (STRUCT, None, None, "wowzers"),
+            ("data.xyz",),
+            {},
+            "janus_results/C6H6-wowzers-data.xyz",
+        ),
         # Additional stacks with base
         (
             (STRUCT, None, None, "wowzers"),
             ("data.xyz", "beef"),
             {},
-            "C6H6-wowzers-beef-data.xyz",
+            "janus_results/C6H6-wowzers-beef-data.xyz",
         ),
         (
             (STRUCT, "mybenzene", None, "wowzers"),
             ("data.xyz", "beef"),
             {},
-            "mybenzene-wowzers-beef-data.xyz",
+            "janus_results/mybenzene-wowzers-beef-data.xyz",
         ),
         # but not file_prefix
         (

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -87,6 +87,7 @@ def test_saving_traj(tmp_path):
         single_point.struct,
         write_traj=True,
         opt_kwargs={"trajectory": str(tmp_path / "NaCl.traj")},
+        traj_kwargs={"filename": str(tmp_path / "NaCl.extxyz")},
     )
     optimizer.run()
     traj = read(tmp_path / "NaCl.traj", index=":")

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from ase import Atoms
 from ase.io import read
@@ -32,10 +33,12 @@ def test_help():
 
 def test_geomopt():
     """Test geomopt calculation."""
-    results_path = Path("./janus_results/NaCl-opt.extxyz")
-    log_path = Path("./janus_results/NaCl-geomopt-log.yml")
-    summary_path = Path("./janus_results/NaCl-geomopt-summary.yml")
+    results_dir = Path("./janus_results")
+    results_path = results_dir / "NaCl-opt.extxyz"
+    log_path = results_dir / "NaCl-geomopt-log.yml"
+    summary_path = results_dir / "NaCl-geomopt-summary.yml"
 
+    assert not results_dir.exists()
     assert not results_path.exists()
     assert not log_path.exists()
     assert not summary_path.exists()
@@ -56,13 +59,14 @@ def test_geomopt():
         assert results_path.exists()
         assert log_path.exists()
         assert summary_path.exists()
+        read_atoms(results_path)
 
     finally:
         # Ensure files deleted if command fails
-        read_atoms(results_path)
         results_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 
 

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -39,9 +39,6 @@ def test_geomopt():
     summary_path = results_dir / "NaCl-geomopt-summary.yml"
 
     assert not results_dir.exists()
-    assert not results_path.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     try:
         result = runner.invoke(
@@ -63,9 +60,6 @@ def test_geomopt():
 
     finally:
         # Ensure files deleted if command fails
-        results_path.unlink(missing_ok=True)
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -32,9 +32,9 @@ def test_help():
 
 def test_geomopt():
     """Test geomopt calculation."""
-    results_path = Path("./results/NaCl-opt.extxyz").absolute()
-    log_path = Path("./results/NaCl-geomopt-log.yml").absolute()
-    summary_path = Path("./results/NaCl-geomopt-summary.yml").absolute()
+    results_path = Path("./janus_results/NaCl-opt.extxyz")
+    log_path = Path("./janus_results/NaCl-geomopt-log.yml")
+    summary_path = Path("./janus_results/NaCl-geomopt-summary.yml")
 
     assert not results_path.exists()
     assert not log_path.exists()

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -32,9 +32,9 @@ def test_help():
 
 def test_geomopt():
     """Test geomopt calculation."""
-    results_path = Path("./NaCl-opt.extxyz").absolute()
-    log_path = Path("./NaCl-geomopt-log.yml").absolute()
-    summary_path = Path("./NaCl-geomopt-summary.yml").absolute()
+    results_path = Path("./results/NaCl-opt.extxyz").absolute()
+    log_path = Path("./results/NaCl-geomopt-log.yml").absolute()
+    summary_path = Path("./results/NaCl-geomopt-summary.yml").absolute()
 
     assert not results_path.exists()
     assert not log_path.exists()

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -84,11 +84,6 @@ def test_npt():
     stats_path = results_dir / "Cl4Na4-npt-T300.0-p1.0-stats.dat"
 
     assert not results_dir.exists()
-    assert not restart_path_1.exists()
-    assert not restart_path_2.exists()
-    assert not restart_final.exists()
-    assert not traj_path.exists()
-    assert not stats_path.exists()
 
     single_point = SinglePoint(
         struct=DATA_PATH / "NaCl.cif",
@@ -122,11 +117,6 @@ def test_npt():
             assert "Target_P [GPa]" in lines[0] and "Target_T [K]" in lines[0]
             assert len(lines) == 5
     finally:
-        restart_path_1.unlink(missing_ok=True)
-        restart_path_2.unlink(missing_ok=True)
-        restart_final.unlink(missing_ok=True)
-        traj_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 
@@ -139,10 +129,6 @@ def test_nvt_nh():
     stats_path = results_dir / "Cl4Na4-nvt-nh-T300.0-stats.dat"
 
     assert not results_dir.exists()
-    assert not restart_path.exists()
-    assert not restart_final_path.exists()
-    assert not traj_path.exists()
-    assert not stats_path.exists()
 
     single_point = SinglePoint(
         struct=DATA_PATH / "NaCl.cif",
@@ -176,10 +162,6 @@ def test_nvt_nh():
             assert " | T [K]" in lines[0]
             assert len(lines) == 4
     finally:
-        restart_path.unlink(missing_ok=True)
-        restart_final_path.unlink(missing_ok=True)
-        traj_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 
@@ -224,10 +206,6 @@ def test_nph():
     stats_path = results_dir / "Cl4Na4-nph-T300.0-p0.0-stats.dat"
 
     assert not results_dir.exists()
-    assert not restart_path.exists()
-    assert not restart_final_path.exists()
-    assert not traj_path.exists()
-    assert not stats_path.exists()
 
     single_point = SinglePoint(
         struct=DATA_PATH / "NaCl.cif",
@@ -261,10 +239,6 @@ def test_nph():
             assert " | Epot/N [eV]" in lines[0]
             assert len(lines) == 2
     finally:
-        restart_path.unlink(missing_ok=True)
-        restart_final_path.unlink(missing_ok=True)
-        traj_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 
@@ -278,11 +252,6 @@ def test_nvt_csvr():
     stats_path = results_dir / "NaCl-nvt-csvr-T300.0-stats.dat"
 
     assert not results_dir.exists()
-    assert not restart_path_1.exists()
-    assert not restart_path_2.exists()
-    assert not restart_final.exists()
-    assert not traj_path.exists()
-    assert not stats_path.exists()
 
     csvr = NVT_CSVR(
         struct=DATA_PATH / "NaCl.cif",
@@ -313,11 +282,6 @@ def test_nvt_csvr():
             assert "Target_T [K]" in lines[0]
             assert len(lines) == 6
     finally:
-        restart_path_1.unlink(missing_ok=True)
-        restart_path_2.unlink(missing_ok=True)
-        restart_final.unlink(missing_ok=True)
-        traj_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 
@@ -332,11 +296,6 @@ def test_npt_mtk():
     stats_path = results_dir / "NaCl-npt-mtk-T300.0-p0.0001-stats.dat"
 
     assert not results_dir.exists()
-    assert not restart_path_1.exists()
-    assert not restart_path_2.exists()
-    assert not restart_final.exists()
-    assert not traj_path.exists()
-    assert not stats_path.exists()
 
     npt_mtk = NPT_MTK(
         struct=DATA_PATH / "NaCl.cif",
@@ -374,11 +333,6 @@ def test_npt_mtk():
             assert len(lines) == 6
 
     finally:
-        restart_path_1.unlink(missing_ok=True)
-        restart_path_2.unlink(missing_ok=True)
-        restart_final.unlink(missing_ok=True)
-        traj_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 
@@ -925,9 +879,6 @@ def test_heating_files():
     final_path = results_dir / "Cl4Na4-nvt-T10-T20-final.extxyz"
 
     assert not results_dir.exists()
-    assert not traj_heating_path.exists()
-    assert not stats_heating_path.exists()
-    assert not final_path.exists()
 
     single_point = SinglePoint(
         struct=DATA_PATH / "NaCl.cif",
@@ -962,9 +913,6 @@ def test_heating_files():
         assert stats.data[2, 16] == 20.0
 
     finally:
-        traj_heating_path.unlink(missing_ok=True)
-        stats_heating_path.unlink(missing_ok=True)
-        final_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 
@@ -976,9 +924,6 @@ def test_heating_md_files():
     final_path = results_dir / "Cl4Na4-nvt-T10-T20-T25.0-final.extxyz"
 
     assert not results_dir.exists()
-    assert not traj_heating_path.exists()
-    assert not stats_heating_path.exists()
-    assert not final_path.exists()
 
     single_point = SinglePoint(
         struct=DATA_PATH / "NaCl.cif",
@@ -1013,9 +958,6 @@ def test_heating_md_files():
         assert stats.data[3, 16] == 25
 
     finally:
-        traj_heating_path.unlink(missing_ok=True)
-        stats_heating_path.unlink(missing_ok=True)
-        final_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 
@@ -1200,7 +1142,6 @@ def test_auto_restart(tmp_path):
     restart_path = results_dir / "NaCl-nvt-T300.0-res-4.extxyz"
 
     assert not results_dir.exists()
-    assert not restart_path.exists()
 
     try:
         nvt = NVT(
@@ -1277,7 +1218,6 @@ def test_auto_restart(tmp_path):
         assert len(final_traj) == 8
 
     finally:
-        restart_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -75,11 +75,11 @@ def test_init(ensemble, expected):
 
 def test_npt():
     """Test NPT molecular dynamics."""
-    restart_path_1 = Path("results/Cl4Na4-npt-T300.0-p1.0-res-2.extxyz")
-    restart_path_2 = Path("results/Cl4Na4-npt-T300.0-p1.0-res-4.extxyz")
-    restart_final = Path("results/Cl4Na4-npt-T300.0-p1.0-final.extxyz")
-    traj_path = Path("results/Cl4Na4-npt-T300.0-p1.0-traj.extxyz")
-    stats_path = Path("results/Cl4Na4-npt-T300.0-p1.0-stats.dat")
+    restart_path_1 = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-res-2.extxyz")
+    restart_path_2 = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-res-4.extxyz")
+    restart_final = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-final.extxyz")
+    traj_path = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-traj.extxyz")
+    stats_path = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -128,10 +128,10 @@ def test_npt():
 
 def test_nvt_nh():
     """Test NVT-Nosé–Hoover  molecular dynamics."""
-    restart_path = Path("results/Cl4Na4-nvt-nh-T300.0-res-3.extxyz")
-    restart_final_path = Path("results/Cl4Na4-nvt-nh-T300.0-final.extxyz")
-    traj_path = Path("results/Cl4Na4-nvt-nh-T300.0-traj.extxyz")
-    stats_path = Path("results/Cl4Na4-nvt-nh-T300.0-stats.dat")
+    restart_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-res-3.extxyz")
+    restart_final_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-final.extxyz")
+    traj_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-traj.extxyz")
+    stats_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-stats.dat")
 
     assert not restart_path.exists()
     assert not restart_final_path.exists()
@@ -210,10 +210,10 @@ def test_nve(tmp_path):
 
 def test_nph():
     """Test NPH molecular dynamics."""
-    restart_path = Path("results/Cl4Na4-nph-T300.0-p0.0-res-2.extxyz")
-    restart_final_path = Path("results/Cl4Na4-nph-T300.0-p0.0-final.extxyz")
-    traj_path = Path("results/Cl4Na4-nph-T300.0-p0.0-traj.extxyz")
-    stats_path = Path("results/Cl4Na4-nph-T300.0-p0.0-stats.dat")
+    restart_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-res-2.extxyz")
+    restart_final_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-final.extxyz")
+    traj_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-traj.extxyz")
+    stats_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-stats.dat")
 
     assert not restart_path.exists()
     assert not restart_final_path.exists()
@@ -260,11 +260,11 @@ def test_nph():
 
 def test_nvt_csvr():
     """Test NVT CSVR molecular dynamics."""
-    restart_path_1 = Path("results/NaCl-nvt-csvr-T300.0-res-2.extxyz")
-    restart_path_2 = Path("results/NaCl-nvt-csvr-T300.0-res-4.extxyz")
-    restart_final = Path("results/NaCl-nvt-csvr-T300.0-final.extxyz")
-    traj_path = Path("results/NaCl-nvt-csvr-T300.0-traj.extxyz")
-    stats_path = Path("results/NaCl-nvt-csvr-T300.0-stats.dat")
+    restart_path_1 = Path("./janus_results/NaCl-nvt-csvr-T300.0-res-2.extxyz")
+    restart_path_2 = Path("./janus_results/NaCl-nvt-csvr-T300.0-res-4.extxyz")
+    restart_final = Path("./janus_results/NaCl-nvt-csvr-T300.0-final.extxyz")
+    traj_path = Path("./janus_results/NaCl-nvt-csvr-T300.0-traj.extxyz")
+    stats_path = Path("./janus_results/NaCl-nvt-csvr-T300.0-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -311,11 +311,11 @@ def test_nvt_csvr():
 @pytest.mark.skipif(MTK_IMPORT_FAILED, reason="Requires updated version of ASE")
 def test_npt_mtk():
     """Test NPT MTK molecular dynamics."""
-    restart_path_1 = Path("results/NaCl-npt-mtk-T300.0-p0.0001-res-2.extxyz")
-    restart_path_2 = Path("results/NaCl-npt-mtk-T300.0-p0.0001-res-4.extxyz")
-    restart_final = Path("results/NaCl-npt-mtk-T300.0-p0.0001-final.extxyz")
-    traj_path = Path("results/NaCl-npt-mtk-T300.0-p0.0001-traj.extxyz")
-    stats_path = Path("results/NaCl-npt-mtk-T300.0-p0.0001-stats.dat")
+    restart_path_1 = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-res-2.extxyz")
+    restart_path_2 = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-res-4.extxyz")
+    restart_final = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-final.extxyz")
+    traj_path = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-traj.extxyz")
+    stats_path = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -903,9 +903,9 @@ def test_heating_restart(tmp_path):
 
 def test_heating_files():
     """Test default heating file names."""
-    traj_heating_path = Path("results/Cl4Na4-nvt-T10-T20-traj.extxyz")
-    stats_heating_path = Path("results/Cl4Na4-nvt-T10-T20-stats.dat")
-    final_path = Path("results/Cl4Na4-nvt-T10-T20-final.extxyz")
+    traj_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-traj.extxyz")
+    stats_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-stats.dat")
+    final_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-final.extxyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
@@ -951,9 +951,9 @@ def test_heating_files():
 
 def test_heating_md_files():
     """Test default heating files when also running md."""
-    traj_heating_path = Path("results/Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz")
-    stats_heating_path = Path("results/Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
-    final_path = Path("results/Cl4Na4-nvt-T10-T20-T25.0-final.extxyz")
+    traj_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz")
+    stats_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
+    final_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-T25.0-final.extxyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
@@ -1174,7 +1174,7 @@ def test_auto_restart(tmp_path):
     log_file = tmp_path / "md.log"
 
     # Predicted restart file, from defaults
-    restart_path = Path("./results").absolute() / "NaCl-nvt-T300.0-res-4.extxyz"
+    restart_path = Path("./janus_results") / "NaCl-nvt-T300.0-res-4.extxyz"
     assert not restart_path.exists()
 
     try:

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -75,11 +75,11 @@ def test_init(ensemble, expected):
 
 def test_npt():
     """Test NPT molecular dynamics."""
-    restart_path_1 = Path("Cl4Na4-npt-T300.0-p1.0-res-2.extxyz")
-    restart_path_2 = Path("Cl4Na4-npt-T300.0-p1.0-res-4.extxyz")
-    restart_final = Path("Cl4Na4-npt-T300.0-p1.0-final.extxyz")
-    traj_path = Path("Cl4Na4-npt-T300.0-p1.0-traj.extxyz")
-    stats_path = Path("Cl4Na4-npt-T300.0-p1.0-stats.dat")
+    restart_path_1 = Path("results/Cl4Na4-npt-T300.0-p1.0-res-2.extxyz")
+    restart_path_2 = Path("results/Cl4Na4-npt-T300.0-p1.0-res-4.extxyz")
+    restart_final = Path("results/Cl4Na4-npt-T300.0-p1.0-final.extxyz")
+    traj_path = Path("results/Cl4Na4-npt-T300.0-p1.0-traj.extxyz")
+    stats_path = Path("results/Cl4Na4-npt-T300.0-p1.0-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -128,10 +128,10 @@ def test_npt():
 
 def test_nvt_nh():
     """Test NVT-Nosé–Hoover  molecular dynamics."""
-    restart_path = Path("Cl4Na4-nvt-nh-T300.0-res-3.extxyz")
-    restart_final_path = Path("Cl4Na4-nvt-nh-T300.0-final.extxyz")
-    traj_path = Path("Cl4Na4-nvt-nh-T300.0-traj.extxyz")
-    stats_path = Path("Cl4Na4-nvt-nh-T300.0-stats.dat")
+    restart_path = Path("results/Cl4Na4-nvt-nh-T300.0-res-3.extxyz")
+    restart_final_path = Path("results/Cl4Na4-nvt-nh-T300.0-final.extxyz")
+    traj_path = Path("results/Cl4Na4-nvt-nh-T300.0-traj.extxyz")
+    stats_path = Path("results/Cl4Na4-nvt-nh-T300.0-stats.dat")
 
     assert not restart_path.exists()
     assert not restart_final_path.exists()
@@ -210,10 +210,10 @@ def test_nve(tmp_path):
 
 def test_nph():
     """Test NPH molecular dynamics."""
-    restart_path = Path("Cl4Na4-nph-T300.0-p0.0-res-2.extxyz")
-    restart_final_path = Path("Cl4Na4-nph-T300.0-p0.0-final.extxyz")
-    traj_path = Path("Cl4Na4-nph-T300.0-p0.0-traj.extxyz")
-    stats_path = Path("Cl4Na4-nph-T300.0-p0.0-stats.dat")
+    restart_path = Path("results/Cl4Na4-nph-T300.0-p0.0-res-2.extxyz")
+    restart_final_path = Path("results/Cl4Na4-nph-T300.0-p0.0-final.extxyz")
+    traj_path = Path("results/Cl4Na4-nph-T300.0-p0.0-traj.extxyz")
+    stats_path = Path("results/Cl4Na4-nph-T300.0-p0.0-stats.dat")
 
     assert not restart_path.exists()
     assert not restart_final_path.exists()
@@ -260,11 +260,11 @@ def test_nph():
 
 def test_nvt_csvr():
     """Test NVT CSVR molecular dynamics."""
-    restart_path_1 = Path("NaCl-nvt-csvr-T300.0-res-2.extxyz")
-    restart_path_2 = Path("NaCl-nvt-csvr-T300.0-res-4.extxyz")
-    restart_final = Path("NaCl-nvt-csvr-T300.0-final.extxyz")
-    traj_path = Path("NaCl-nvt-csvr-T300.0-traj.extxyz")
-    stats_path = Path("NaCl-nvt-csvr-T300.0-stats.dat")
+    restart_path_1 = Path("results/NaCl-nvt-csvr-T300.0-res-2.extxyz")
+    restart_path_2 = Path("results/NaCl-nvt-csvr-T300.0-res-4.extxyz")
+    restart_final = Path("results/NaCl-nvt-csvr-T300.0-final.extxyz")
+    traj_path = Path("results/NaCl-nvt-csvr-T300.0-traj.extxyz")
+    stats_path = Path("results/NaCl-nvt-csvr-T300.0-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -311,11 +311,11 @@ def test_nvt_csvr():
 @pytest.mark.skipif(MTK_IMPORT_FAILED, reason="Requires updated version of ASE")
 def test_npt_mtk():
     """Test NPT MTK molecular dynamics."""
-    restart_path_1 = Path("NaCl-npt-mtk-T300.0-p0.0001-res-2.extxyz")
-    restart_path_2 = Path("NaCl-npt-mtk-T300.0-p0.0001-res-4.extxyz")
-    restart_final = Path("NaCl-npt-mtk-T300.0-p0.0001-final.extxyz")
-    traj_path = Path("NaCl-npt-mtk-T300.0-p0.0001-traj.extxyz")
-    stats_path = Path("NaCl-npt-mtk-T300.0-p0.0001-stats.dat")
+    restart_path_1 = Path("results/NaCl-npt-mtk-T300.0-p0.0001-res-2.extxyz")
+    restart_path_2 = Path("results/NaCl-npt-mtk-T300.0-p0.0001-res-4.extxyz")
+    restart_final = Path("results/NaCl-npt-mtk-T300.0-p0.0001-final.extxyz")
+    traj_path = Path("results/NaCl-npt-mtk-T300.0-p0.0001-traj.extxyz")
+    stats_path = Path("results/NaCl-npt-mtk-T300.0-p0.0001-stats.dat")
 
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
@@ -903,9 +903,9 @@ def test_heating_restart(tmp_path):
 
 def test_heating_files():
     """Test default heating file names."""
-    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-traj.extxyz")
-    stats_heating_path = Path("Cl4Na4-nvt-T10-T20-stats.dat")
-    final_path = Path("Cl4Na4-nvt-T10-T20-final.extxyz")
+    traj_heating_path = Path("results/Cl4Na4-nvt-T10-T20-traj.extxyz")
+    stats_heating_path = Path("results/Cl4Na4-nvt-T10-T20-stats.dat")
+    final_path = Path("results/Cl4Na4-nvt-T10-T20-final.extxyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
@@ -951,9 +951,9 @@ def test_heating_files():
 
 def test_heating_md_files():
     """Test default heating files when also running md."""
-    traj_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz")
-    stats_heating_path = Path("Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
-    final_path = Path("Cl4Na4-nvt-T10-T20-T25.0-final.extxyz")
+    traj_heating_path = Path("results/Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz")
+    stats_heating_path = Path("results/Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
+    final_path = Path("results/Cl4Na4-nvt-T10-T20-T25.0-final.extxyz")
 
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
@@ -1174,7 +1174,7 @@ def test_auto_restart(tmp_path):
     log_file = tmp_path / "md.log"
 
     # Predicted restart file, from defaults
-    restart_path = Path(".").absolute() / "NaCl-nvt-T300.0-res-4.extxyz"
+    restart_path = Path("./results").absolute() / "NaCl-nvt-T300.0-res-4.extxyz"
     assert not restart_path.exists()
 
     try:

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from ase import Atoms
 from ase.io import read
@@ -75,12 +76,14 @@ def test_init(ensemble, expected):
 
 def test_npt():
     """Test NPT molecular dynamics."""
-    restart_path_1 = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-res-2.extxyz")
-    restart_path_2 = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-res-4.extxyz")
-    restart_final = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-final.extxyz")
-    traj_path = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-traj.extxyz")
-    stats_path = Path("./janus_results/Cl4Na4-npt-T300.0-p1.0-stats.dat")
+    results_dir = Path("./janus_results")
+    restart_path_1 = results_dir / "Cl4Na4-npt-T300.0-p1.0-res-2.extxyz"
+    restart_path_2 = results_dir / "Cl4Na4-npt-T300.0-p1.0-res-4.extxyz"
+    restart_final = results_dir / "Cl4Na4-npt-T300.0-p1.0-final.extxyz"
+    traj_path = results_dir / "Cl4Na4-npt-T300.0-p1.0-traj.extxyz"
+    stats_path = results_dir / "Cl4Na4-npt-T300.0-p1.0-stats.dat"
 
+    assert not results_dir.exists()
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
     assert not restart_final.exists()
@@ -124,15 +127,18 @@ def test_npt():
         restart_final.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 def test_nvt_nh():
     """Test NVT-Nosé–Hoover  molecular dynamics."""
-    restart_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-res-3.extxyz")
-    restart_final_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-final.extxyz")
-    traj_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-traj.extxyz")
-    stats_path = Path("./janus_results/Cl4Na4-nvt-nh-T300.0-stats.dat")
+    results_dir = Path("./janus_results")
+    restart_path = results_dir / "Cl4Na4-nvt-nh-T300.0-res-3.extxyz"
+    restart_final_path = results_dir / "Cl4Na4-nvt-nh-T300.0-final.extxyz"
+    traj_path = results_dir / "Cl4Na4-nvt-nh-T300.0-traj.extxyz"
+    stats_path = results_dir / "Cl4Na4-nvt-nh-T300.0-stats.dat"
 
+    assert not results_dir.exists()
     assert not restart_path.exists()
     assert not restart_final_path.exists()
     assert not traj_path.exists()
@@ -174,6 +180,7 @@ def test_nvt_nh():
         restart_final_path.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 def test_nve(tmp_path):
@@ -210,11 +217,13 @@ def test_nve(tmp_path):
 
 def test_nph():
     """Test NPH molecular dynamics."""
-    restart_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-res-2.extxyz")
-    restart_final_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-final.extxyz")
-    traj_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-traj.extxyz")
-    stats_path = Path("./janus_results/Cl4Na4-nph-T300.0-p0.0-stats.dat")
+    results_dir = Path("./janus_results")
+    restart_path = results_dir / "Cl4Na4-nph-T300.0-p0.0-res-2.extxyz"
+    restart_final_path = results_dir / "Cl4Na4-nph-T300.0-p0.0-final.extxyz"
+    traj_path = results_dir / "Cl4Na4-nph-T300.0-p0.0-traj.extxyz"
+    stats_path = results_dir / "Cl4Na4-nph-T300.0-p0.0-stats.dat"
 
+    assert not results_dir.exists()
     assert not restart_path.exists()
     assert not restart_final_path.exists()
     assert not traj_path.exists()
@@ -256,16 +265,19 @@ def test_nph():
         restart_final_path.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 def test_nvt_csvr():
     """Test NVT CSVR molecular dynamics."""
-    restart_path_1 = Path("./janus_results/NaCl-nvt-csvr-T300.0-res-2.extxyz")
-    restart_path_2 = Path("./janus_results/NaCl-nvt-csvr-T300.0-res-4.extxyz")
-    restart_final = Path("./janus_results/NaCl-nvt-csvr-T300.0-final.extxyz")
-    traj_path = Path("./janus_results/NaCl-nvt-csvr-T300.0-traj.extxyz")
-    stats_path = Path("./janus_results/NaCl-nvt-csvr-T300.0-stats.dat")
+    results_dir = Path("./janus_results")
+    restart_path_1 = results_dir / "NaCl-nvt-csvr-T300.0-res-2.extxyz"
+    restart_path_2 = results_dir / "NaCl-nvt-csvr-T300.0-res-4.extxyz"
+    restart_final = results_dir / "NaCl-nvt-csvr-T300.0-final.extxyz"
+    traj_path = results_dir / "NaCl-nvt-csvr-T300.0-traj.extxyz"
+    stats_path = results_dir / "NaCl-nvt-csvr-T300.0-stats.dat"
 
+    assert not results_dir.exists()
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
     assert not restart_final.exists()
@@ -306,17 +318,20 @@ def test_nvt_csvr():
         restart_final.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 @pytest.mark.skipif(MTK_IMPORT_FAILED, reason="Requires updated version of ASE")
 def test_npt_mtk():
     """Test NPT MTK molecular dynamics."""
-    restart_path_1 = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-res-2.extxyz")
-    restart_path_2 = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-res-4.extxyz")
-    restart_final = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-final.extxyz")
-    traj_path = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-traj.extxyz")
-    stats_path = Path("./janus_results/NaCl-npt-mtk-T300.0-p0.0001-stats.dat")
+    results_dir = Path("./janus_results")
+    restart_path_1 = results_dir / "NaCl-npt-mtk-T300.0-p0.0001-res-2.extxyz"
+    restart_path_2 = results_dir / "NaCl-npt-mtk-T300.0-p0.0001-res-4.extxyz"
+    restart_final = results_dir / "NaCl-npt-mtk-T300.0-p0.0001-final.extxyz"
+    traj_path = results_dir / "NaCl-npt-mtk-T300.0-p0.0001-traj.extxyz"
+    stats_path = results_dir / "NaCl-npt-mtk-T300.0-p0.0001-stats.dat"
 
+    assert not results_dir.exists()
     assert not restart_path_1.exists()
     assert not restart_path_2.exists()
     assert not restart_final.exists()
@@ -364,6 +379,7 @@ def test_npt_mtk():
         restart_final.unlink(missing_ok=True)
         traj_path.unlink(missing_ok=True)
         stats_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 def test_restart(tmp_path):
@@ -903,10 +919,12 @@ def test_heating_restart(tmp_path):
 
 def test_heating_files():
     """Test default heating file names."""
-    traj_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-traj.extxyz")
-    stats_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-stats.dat")
-    final_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-final.extxyz")
+    results_dir = Path("./janus_results")
+    traj_heating_path = results_dir / "Cl4Na4-nvt-T10-T20-traj.extxyz"
+    stats_heating_path = results_dir / "Cl4Na4-nvt-T10-T20-stats.dat"
+    final_path = results_dir / "Cl4Na4-nvt-T10-T20-final.extxyz"
 
+    assert not results_dir.exists()
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
     assert not final_path.exists()
@@ -947,14 +965,17 @@ def test_heating_files():
         traj_heating_path.unlink(missing_ok=True)
         stats_heating_path.unlink(missing_ok=True)
         final_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 def test_heating_md_files():
     """Test default heating files when also running md."""
-    traj_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz")
-    stats_heating_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-T25.0-stats.dat")
-    final_path = Path("./janus_results/Cl4Na4-nvt-T10-T20-T25.0-final.extxyz")
+    results_dir = Path("./janus_results")
+    traj_heating_path = results_dir / "Cl4Na4-nvt-T10-T20-T25.0-traj.extxyz"
+    stats_heating_path = results_dir / "Cl4Na4-nvt-T10-T20-T25.0-stats.dat"
+    final_path = results_dir / "Cl4Na4-nvt-T10-T20-T25.0-final.extxyz"
 
+    assert not results_dir.exists()
     assert not traj_heating_path.exists()
     assert not stats_heating_path.exists()
     assert not final_path.exists()
@@ -995,6 +1016,7 @@ def test_heating_md_files():
         traj_heating_path.unlink(missing_ok=True)
         stats_heating_path.unlink(missing_ok=True)
         final_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 def test_ramp_negative(tmp_path):
@@ -1174,7 +1196,10 @@ def test_auto_restart(tmp_path):
     log_file = tmp_path / "md.log"
 
     # Predicted restart file, from defaults
-    restart_path = Path("./janus_results") / "NaCl-nvt-T300.0-res-4.extxyz"
+    results_dir = Path("./janus_results")
+    restart_path = results_dir / "NaCl-nvt-T300.0-res-4.extxyz"
+
+    assert not results_dir.exists()
     assert not restart_path.exists()
 
     try:
@@ -1253,6 +1278,7 @@ def test_auto_restart(tmp_path):
 
     finally:
         restart_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
 
 def test_auto_restart_restart_stem(tmp_path):

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -62,14 +62,14 @@ def test_md(ensemble):
         "npt-mtk": "NaCl-npt-mtk-T300.0-p0.0-",
     }
 
-    final_path = Path(f"results/{file_prefix[ensemble]}final.extxyz").absolute()
-    restart_path = Path(f"results/{file_prefix[ensemble]}res-2.extxyz").absolute()
-    stats_path = Path(f"results/{file_prefix[ensemble]}stats.dat").absolute()
-    traj_path = Path(f"results/{file_prefix[ensemble]}traj.extxyz").absolute()
-    rdf_path = Path(f"results/{file_prefix[ensemble]}rdf.dat").absolute()
-    vaf_path = Path(f"results/{file_prefix[ensemble]}vaf.dat").absolute()
-    log_path = Path(f"results/{file_prefix[ensemble]}md-log.yml").absolute()
-    summary_path = Path(f"results/{file_prefix[ensemble]}md-summary.yml").absolute()
+    final_path = Path(f"./janus_results/{file_prefix[ensemble]}final.extxyz")
+    restart_path = Path(f"./janus_results/{file_prefix[ensemble]}res-2.extxyz")
+    stats_path = Path(f"./janus_results/{file_prefix[ensemble]}stats.dat")
+    traj_path = Path(f"./janus_results/{file_prefix[ensemble]}traj.extxyz")
+    rdf_path = Path(f"./janus_results/{file_prefix[ensemble]}rdf.dat")
+    vaf_path = Path(f"./janus_results/{file_prefix[ensemble]}vaf.dat")
+    log_path = Path(f"./janus_results/{file_prefix[ensemble]}md-log.yml")
+    summary_path = Path(f"./janus_results/{file_prefix[ensemble]}md-summary.yml")
 
     assert not final_path.exists()
     assert not restart_path.exists()

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from ase import Atoms
 from ase.io import read
@@ -62,15 +63,17 @@ def test_md(ensemble):
         "npt-mtk": "NaCl-npt-mtk-T300.0-p0.0-",
     }
 
-    final_path = Path(f"./janus_results/{file_prefix[ensemble]}final.extxyz")
-    restart_path = Path(f"./janus_results/{file_prefix[ensemble]}res-2.extxyz")
-    stats_path = Path(f"./janus_results/{file_prefix[ensemble]}stats.dat")
-    traj_path = Path(f"./janus_results/{file_prefix[ensemble]}traj.extxyz")
-    rdf_path = Path(f"./janus_results/{file_prefix[ensemble]}rdf.dat")
-    vaf_path = Path(f"./janus_results/{file_prefix[ensemble]}vaf.dat")
-    log_path = Path(f"./janus_results/{file_prefix[ensemble]}md-log.yml")
-    summary_path = Path(f"./janus_results/{file_prefix[ensemble]}md-summary.yml")
+    results_dir = Path("./janus_results")
+    final_path = results_dir / f"{file_prefix[ensemble]}final.extxyz"
+    restart_path = results_dir / f"{file_prefix[ensemble]}res-2.extxyz"
+    stats_path = results_dir / f"{file_prefix[ensemble]}stats.dat"
+    traj_path = results_dir / f"{file_prefix[ensemble]}traj.extxyz"
+    rdf_path = results_dir / f"{file_prefix[ensemble]}rdf.dat"
+    vaf_path = results_dir / f"{file_prefix[ensemble]}vaf.dat"
+    log_path = results_dir / f"{file_prefix[ensemble]}md-log.yml"
+    summary_path = results_dir / f"{file_prefix[ensemble]}md-summary.yml"
 
+    assert not results_dir.exists()
     assert not final_path.exists()
     assert not restart_path.exists()
     assert not stats_path.exists()
@@ -149,6 +152,7 @@ def test_md(ensemble):
         vaf_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -74,14 +74,6 @@ def test_md(ensemble):
     summary_path = results_dir / f"{file_prefix[ensemble]}md-summary.yml"
 
     assert not results_dir.exists()
-    assert not final_path.exists()
-    assert not restart_path.exists()
-    assert not stats_path.exists()
-    assert not traj_path.exists()
-    assert not rdf_path.exists()
-    assert not vaf_path.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     try:
         result = runner.invoke(
@@ -144,14 +136,6 @@ def test_md(ensemble):
             assert atoms.info["units"][prop] == units
 
     finally:
-        final_path.unlink(missing_ok=True)
-        restart_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
-        traj_path.unlink(missing_ok=True)
-        rdf_path.unlink(missing_ok=True)
-        vaf_path.unlink(missing_ok=True)
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -62,14 +62,14 @@ def test_md(ensemble):
         "npt-mtk": "NaCl-npt-mtk-T300.0-p0.0-",
     }
 
-    final_path = Path(f"{file_prefix[ensemble]}final.extxyz").absolute()
-    restart_path = Path(f"{file_prefix[ensemble]}res-2.extxyz").absolute()
-    stats_path = Path(f"{file_prefix[ensemble]}stats.dat").absolute()
-    traj_path = Path(f"{file_prefix[ensemble]}traj.extxyz").absolute()
-    rdf_path = Path(f"{file_prefix[ensemble]}rdf.dat").absolute()
-    vaf_path = Path(f"{file_prefix[ensemble]}vaf.dat").absolute()
-    log_path = Path(f"{file_prefix[ensemble]}md-log.yml").absolute()
-    summary_path = Path(f"{file_prefix[ensemble]}md-summary.yml").absolute()
+    final_path = Path(f"results/{file_prefix[ensemble]}final.extxyz").absolute()
+    restart_path = Path(f"results/{file_prefix[ensemble]}res-2.extxyz").absolute()
+    stats_path = Path(f"results/{file_prefix[ensemble]}stats.dat").absolute()
+    traj_path = Path(f"results/{file_prefix[ensemble]}traj.extxyz").absolute()
+    rdf_path = Path(f"results/{file_prefix[ensemble]}rdf.dat").absolute()
+    vaf_path = Path(f"results/{file_prefix[ensemble]}vaf.dat").absolute()
+    log_path = Path(f"results/{file_prefix[ensemble]}md-log.yml").absolute()
+    summary_path = Path(f"results/{file_prefix[ensemble]}md-summary.yml").absolute()
 
     assert not final_path.exists()
     assert not restart_path.exists()

--- a/tests/test_neb.py
+++ b/tests/test_neb.py
@@ -51,6 +51,7 @@ def test_neb(tmp_path, LFPO_start_b, LFPO_end_b):
         final_struct=final_struct,
         model_path=MODEL_PATH,
         n_images=5,
+        file_prefix=tmp_path / "LFPO",
     )
     neb.run()
 

--- a/tests/test_neb_cli.py
+++ b/tests/test_neb_cli.py
@@ -36,11 +36,6 @@ def test_neb():
     summary_path = results_dir / "LiFePO4_start-neb-summary.yml"
 
     assert not results_dir.exists()
-    assert not results_path.exists()
-    assert not band_path.exists()
-    assert not plot_path.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     try:
         result = runner.invoke(
@@ -64,6 +59,8 @@ def test_neb():
         assert result.exit_code == 0
 
         assert results_path.exists()
+        assert band_path.exists()
+        assert plot_path.exists()
         assert log_path.exists()
         assert summary_path.exists()
 
@@ -96,11 +93,6 @@ def test_neb():
         assert len(band) == 7
 
     finally:
-        results_path.unlink(missing_ok=True)
-        band_path.unlink(missing_ok=True)
-        plot_path.unlink(missing_ok=True)
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 

--- a/tests/test_neb_cli.py
+++ b/tests/test_neb_cli.py
@@ -27,11 +27,11 @@ def test_help():
 
 def test_neb():
     """Test calculating force constants and band structure."""
-    results_path = Path("./LiFePO4_start-neb-results.dat").absolute()
-    band_path = Path("./LiFePO4_start-neb-band.extxyz").absolute()
-    plot_path = Path("./LiFePO4_start-neb-plot.svg").absolute()
-    log_path = Path("./LiFePO4_start-neb-log.yml").absolute()
-    summary_path = Path("./LiFePO4_start-neb-summary.yml").absolute()
+    results_path = Path("./results/LiFePO4_start-neb-results.dat").absolute()
+    band_path = Path("./results/LiFePO4_start-neb-band.extxyz").absolute()
+    plot_path = Path("./results/LiFePO4_start-neb-plot.svg").absolute()
+    log_path = Path("./results/LiFePO4_start-neb-log.yml").absolute()
+    summary_path = Path("./results/LiFePO4_start-neb-summary.yml").absolute()
 
     assert not results_path.exists()
     assert not band_path.exists()

--- a/tests/test_neb_cli.py
+++ b/tests/test_neb_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from ase import Atoms
 from ase.io import read
@@ -27,12 +28,14 @@ def test_help():
 
 def test_neb():
     """Test calculating force constants and band structure."""
-    results_path = Path("./janus_results/LiFePO4_start-neb-results.dat")
-    band_path = Path("./janus_results/LiFePO4_start-neb-band.extxyz")
-    plot_path = Path("./janus_results/LiFePO4_start-neb-plot.svg")
-    log_path = Path("./janus_results/LiFePO4_start-neb-log.yml")
-    summary_path = Path("./janus_results/LiFePO4_start-neb-summary.yml")
+    results_dir = Path("./janus_results")
+    results_path = results_dir / "LiFePO4_start-neb-results.dat"
+    band_path = results_dir / "LiFePO4_start-neb-band.extxyz"
+    plot_path = results_dir / "LiFePO4_start-neb-plot.svg"
+    log_path = results_dir / "LiFePO4_start-neb-log.yml"
+    summary_path = results_dir / "LiFePO4_start-neb-summary.yml"
 
+    assert not results_dir.exists()
     assert not results_path.exists()
     assert not band_path.exists()
     assert not plot_path.exists()
@@ -98,6 +101,7 @@ def test_neb():
         plot_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 
 

--- a/tests/test_neb_cli.py
+++ b/tests/test_neb_cli.py
@@ -27,11 +27,11 @@ def test_help():
 
 def test_neb():
     """Test calculating force constants and band structure."""
-    results_path = Path("./results/LiFePO4_start-neb-results.dat").absolute()
-    band_path = Path("./results/LiFePO4_start-neb-band.extxyz").absolute()
-    plot_path = Path("./results/LiFePO4_start-neb-plot.svg").absolute()
-    log_path = Path("./results/LiFePO4_start-neb-log.yml").absolute()
-    summary_path = Path("./results/LiFePO4_start-neb-summary.yml").absolute()
+    results_path = Path("./janus_results/LiFePO4_start-neb-results.dat")
+    band_path = Path("./janus_results/LiFePO4_start-neb-band.extxyz")
+    plot_path = Path("./janus_results/LiFePO4_start-neb-plot.svg")
+    log_path = Path("./janus_results/LiFePO4_start-neb-log.yml")
+    summary_path = Path("./janus_results/LiFePO4_start-neb-summary.yml")
 
     assert not results_path.exists()
     assert not band_path.exists()

--- a/tests/test_phonons.py
+++ b/tests/test_phonons.py
@@ -24,7 +24,7 @@ def test_init():
         calc_kwargs={"model": MODEL_PATH},
     )
     phonons = Phonons(struct=single_point.struct)
-    assert str(phonons.file_prefix) == "Cl4Na4"
+    assert str(phonons.file_prefix) == "janus_results/Cl4Na4"
 
 
 def test_calc_phonons():

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -26,10 +26,10 @@ def test_help():
 
 def test_phonons():
     """Test calculating force constants and band structure."""
-    phonopy_path = Path("./NaCl-phonopy.yml").absolute()
-    bands_path = Path("./NaCl-auto_bands.yml.xz").absolute()
-    log_path = Path("./NaCl-phonons-log.yml").absolute()
-    summary_path = Path("./NaCl-phonons-summary.yml").absolute()
+    phonopy_path = Path("./results/NaCl-phonopy.yml").absolute()
+    bands_path = Path("./results/NaCl-auto_bands.yml.xz").absolute()
+    log_path = Path("./results/NaCl-phonons-log.yml").absolute()
+    summary_path = Path("./results/NaCl-phonons-summary.yml").absolute()
 
     assert not phonopy_path.exists()
     assert not bands_path.exists()

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -26,10 +26,10 @@ def test_help():
 
 def test_phonons():
     """Test calculating force constants and band structure."""
-    phonopy_path = Path("./results/NaCl-phonopy.yml").absolute()
-    bands_path = Path("./results/NaCl-auto_bands.yml.xz").absolute()
-    log_path = Path("./results/NaCl-phonons-log.yml").absolute()
-    summary_path = Path("./results/NaCl-phonons-summary.yml").absolute()
+    phonopy_path = Path("./janus_results/NaCl-phonopy.yml")
+    bands_path = Path("./janus_results/NaCl-auto_bands.yml.xz")
+    log_path = Path("./janus_results/NaCl-phonons-log.yml")
+    summary_path = Path("./janus_results/NaCl-phonons-summary.yml")
 
     assert not phonopy_path.exists()
     assert not bands_path.exists()

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import lzma
 from pathlib import Path
+import shutil
 
 import pytest
 from typer.testing import CliRunner
@@ -26,11 +27,13 @@ def test_help():
 
 def test_phonons():
     """Test calculating force constants and band structure."""
-    phonopy_path = Path("./janus_results/NaCl-phonopy.yml")
-    bands_path = Path("./janus_results/NaCl-auto_bands.yml.xz")
-    log_path = Path("./janus_results/NaCl-phonons-log.yml")
-    summary_path = Path("./janus_results/NaCl-phonons-summary.yml")
+    results_dir = Path("./janus_results")
+    phonopy_path = results_dir / "NaCl-phonopy.yml"
+    bands_path = results_dir / "NaCl-auto_bands.yml.xz"
+    log_path = results_dir / "NaCl-phonons-log.yml"
+    summary_path = results_dir / "NaCl-phonons-summary.yml"
 
+    assert not results_dir.exists()
     assert not phonopy_path.exists()
     assert not bands_path.exists()
     assert not log_path.exists()
@@ -85,6 +88,7 @@ def test_phonons():
         bands_path.unlink(missing_ok=True)
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 
 

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -34,10 +34,6 @@ def test_phonons():
     summary_path = results_dir / "NaCl-phonons-summary.yml"
 
     assert not results_dir.exists()
-    assert not phonopy_path.exists()
-    assert not bands_path.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     try:
         result = runner.invoke(
@@ -84,10 +80,6 @@ def test_phonons():
         assert phonon_summary["emissions"] > 0
 
     finally:
-        phonopy_path.unlink(missing_ok=True)
-        bands_path.unlink(missing_ok=True)
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
 

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -75,44 +75,49 @@ def test_md_pp_cli(tmp_path):
     rdf_path = tmp_path / "nve-T300-rdf.dat"
     vaf_na_path = Path("vaf_na.dat")
     vaf_cl_path = Path("vaf_cl.dat")
-    result = runner.invoke(
-        app,
-        [
-            "md",
-            "--ensemble",
-            "nve",
-            "--struct",
-            DATA_PATH / "NaCl.cif",
-            "--file-prefix",
-            file_prefix,
-            "--steps",
-            10,
-            "--traj-every",
-            2,
-            "--log",
-            log_path,
-            "--summary",
-            summary_path,
-            "--post-process-kwargs",
-            """{'vaf_compute': True,
-              'vaf_atoms': (('Na',),('Cl',)),
-              'vaf_output_files': ('vaf_na.dat', 'vaf_cl.dat'),
-              'rdf_compute': True,
-              'rdf_rmax': 2.5}""",
-        ],
-    )
 
-    assert result.exit_code == 0
+    try:
+        result = runner.invoke(
+            app,
+            [
+                "md",
+                "--ensemble",
+                "nve",
+                "--struct",
+                DATA_PATH / "NaCl.cif",
+                "--file-prefix",
+                file_prefix,
+                "--steps",
+                10,
+                "--traj-every",
+                2,
+                "--log",
+                log_path,
+                "--summary",
+                summary_path,
+                "--post-process-kwargs",
+                """{'vaf_compute': True,
+                'vaf_atoms': (('Na',),('Cl',)),
+                'vaf_output_files': ('vaf_na.dat', 'vaf_cl.dat'),
+                'rdf_compute': True,
+                'rdf_rmax': 2.5}""",
+            ],
+        )
 
-    assert rdf_path.exists()
-    rdf = np.loadtxt(rdf_path)
-    assert len(rdf) == 50
+        assert result.exit_code == 0
 
-    # Cell too small to really compute RDF
-    assert np.all(rdf[:, 1] == 0)
+        assert rdf_path.exists()
+        rdf = np.loadtxt(rdf_path)
+        assert len(rdf) == 50
 
-    assert vaf_na_path.exists()
-    assert vaf_cl_path.exists()
+        # Cell too small to really compute RDF
+        assert np.all(rdf[:, 1] == 0)
+
+        assert vaf_na_path.exists()
+        assert vaf_cl_path.exists()
+    finally:
+        vaf_na_path.unlink(missing_ok=True)
+        vaf_cl_path.unlink(missing_ok=True)
 
 
 def test_rdf():

--- a/tests/test_post_process.py
+++ b/tests/test_post_process.py
@@ -23,8 +23,6 @@ runner = CliRunner()
 def test_md_pp(tmp_path):
     """Test post-processing as part of MD cycle."""
     file_prefix = tmp_path / "Cl4Na4-nve-T300.0"
-    traj_path = tmp_path / "Cl4Na4-nve-T300.0-traj.extxyz"
-    stats_path = tmp_path / "Cl4Na4-nve-T300.0-stats.dat"
     rdf_path = tmp_path / "Cl4Na4-nve-T300.0-rdf.dat"
     vaf_path = tmp_path / "Cl4Na4-nve-T300.0-vaf.dat"
 
@@ -48,23 +46,16 @@ def test_md_pp(tmp_path):
         },
     )
 
-    try:
-        nve.run()
+    nve.run()
 
-        assert rdf_path.exists()
-        rdf = np.loadtxt(rdf_path)
-        assert len(rdf) == 50
+    assert rdf_path.exists()
+    rdf = np.loadtxt(rdf_path)
+    assert len(rdf) == 50
 
-        # Cell too small to really compute RDF
-        assert np.all(rdf[:, 1] == 0)
+    # Cell too small to really compute RDF
+    assert np.all(rdf[:, 1] == 0)
 
-        assert vaf_path.exists()
-
-    finally:
-        traj_path.unlink(missing_ok=True)
-        stats_path.unlink(missing_ok=True)
-        rdf_path.unlink(missing_ok=True)
-        vaf_path.unlink(missing_ok=True)
+    assert vaf_path.exists()
 
 
 def test_md_pp_cli(tmp_path):

--- a/tests/test_preprocess_cli.py
+++ b/tests/test_preprocess_cli.py
@@ -71,8 +71,6 @@ def test_preprocess(tmp_path):
     assert not test_path.exists()
     assert not stats_path.exists()
     assert not results_dir.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     config = write_tmp_config(DATA_PATH / "mlip_preprocess.yml", tmp_path)
 
@@ -117,9 +115,6 @@ def test_preprocess(tmp_path):
         shutil.rmtree(val_path, ignore_errors=True)
         shutil.rmtree(test_path, ignore_errors=True)
         shutil.rmtree(results_dir, ignore_errors=True)
-
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
 
         clear_log_handlers()
 

--- a/tests/test_preprocess_cli.py
+++ b/tests/test_preprocess_cli.py
@@ -62,13 +62,15 @@ def test_preprocess(tmp_path):
     val_path = Path("val")
     test_path = Path("test")
     stats_path = Path("./statistics.json")
-    log_path = Path("./janus_results/preprocess-log.yml")
-    summary_path = Path("./janus_results/preprocess-summary.yml")
+    results_dir = Path("./janus_results")
+    log_path = results_dir / "preprocess-log.yml"
+    summary_path = results_dir / "preprocess-summary.yml"
 
     assert not train_path.exists()
     assert not val_path.exists()
     assert not test_path.exists()
     assert not stats_path.exists()
+    assert not results_dir.exists()
     assert not log_path.exists()
     assert not summary_path.exists()
 
@@ -114,6 +116,7 @@ def test_preprocess(tmp_path):
         shutil.rmtree(train_path, ignore_errors=True)
         shutil.rmtree(val_path, ignore_errors=True)
         shutil.rmtree(test_path, ignore_errors=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)

--- a/tests/test_preprocess_cli.py
+++ b/tests/test_preprocess_cli.py
@@ -62,8 +62,8 @@ def test_preprocess(tmp_path):
     val_path = Path("val")
     test_path = Path("test")
     stats_path = Path("./statistics.json")
-    log_path = Path("./preprocess-log.yml").absolute()
-    summary_path = Path("./preprocess-summary.yml").absolute()
+    log_path = Path("./janus_results/preprocess-log.yml")
+    summary_path = Path("./janus_results/preprocess-summary.yml")
 
     assert not train_path.exists()
     assert not val_path.exists()

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -187,7 +187,7 @@ def test_single_point_write():
     skip_extras("mace")
 
     data_path = DATA_PATH / "NaCl.cif"
-    results_path = Path("./results/NaCl-results.extxyz").absolute()
+    results_path = Path("./janus_results/NaCl-results.extxyz")
     assert not results_path.exists()
 
     single_point = SinglePoint(

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -192,7 +192,6 @@ def test_single_point_write():
     results_path = results_dir / "NaCl-results.extxyz"
 
     assert not results_dir.exists()
-    assert not results_path.exists()
 
     try:
         single_point = SinglePoint(

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -187,7 +187,7 @@ def test_single_point_write():
     skip_extras("mace")
 
     data_path = DATA_PATH / "NaCl.cif"
-    results_path = Path("./NaCl-results.extxyz").absolute()
+    results_path = Path("./results/NaCl-results.extxyz").absolute()
     assert not results_path.exists()
 
     single_point = SinglePoint(

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -31,9 +31,9 @@ def test_singlepoint_help():
 
 def test_singlepoint():
     """Test singlepoint calculation."""
-    results_path = Path("./results/NaCl-results.extxyz").absolute()
-    log_path = Path("./results/NaCl-singlepoint-log.yml").absolute()
-    summary_path = Path("./results/NaCl-singlepoint-summary.yml").absolute()
+    results_path = Path("./janus_results/NaCl-results.extxyz")
+    log_path = Path("./janus_results/NaCl-singlepoint-log.yml")
+    summary_path = Path("./janus_results/NaCl-singlepoint-summary.yml")
 
     assert not results_path.exists()
     assert not log_path.exists()

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -31,9 +31,9 @@ def test_singlepoint_help():
 
 def test_singlepoint():
     """Test singlepoint calculation."""
-    results_path = Path("./NaCl-results.extxyz").absolute()
-    log_path = Path("./NaCl-singlepoint-log.yml").absolute()
-    summary_path = Path("./NaCl-singlepoint-summary.yml").absolute()
+    results_path = Path("./results/NaCl-results.extxyz").absolute()
+    log_path = Path("./results/NaCl-singlepoint-log.yml").absolute()
+    summary_path = Path("./results/NaCl-singlepoint-summary.yml").absolute()
 
     assert not results_path.exists()
     assert not log_path.exists()

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -38,9 +38,6 @@ def test_singlepoint():
     summary_path = results_dir / "NaCl-singlepoint-summary.yml"
 
     assert not results_dir.exists()
-    assert not results_path.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     try:
         result = runner.invoke(
@@ -77,9 +74,6 @@ def test_singlepoint():
 
     finally:
         # Ensure files deleted if command fails
-        results_path.unlink(missing_ok=True)
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
         clear_log_handlers()

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 
 from ase import Atoms
 from ase.io import read
@@ -31,10 +32,12 @@ def test_singlepoint_help():
 
 def test_singlepoint():
     """Test singlepoint calculation."""
-    results_path = Path("./janus_results/NaCl-results.extxyz")
-    log_path = Path("./janus_results/NaCl-singlepoint-log.yml")
-    summary_path = Path("./janus_results/NaCl-singlepoint-summary.yml")
+    results_dir = Path("./janus_results")
+    results_path = results_dir / "NaCl-results.extxyz"
+    log_path = results_dir / "NaCl-singlepoint-log.yml"
+    summary_path = results_dir / "NaCl-singlepoint-summary.yml"
 
+    assert not results_dir.exists()
     assert not results_path.exists()
     assert not log_path.exists()
     assert not summary_path.exists()
@@ -54,13 +57,8 @@ def test_singlepoint():
         assert log_path.exists()
         assert summary_path.exists
 
-    finally:
-        # Ensure files deleted if command fails
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
-
-        # Check atoms file can be read, then delete
         atoms = read_atoms(results_path)
+
         assert "mace_mp_energy" in atoms.info
 
         assert "arch" in atoms.info
@@ -76,6 +74,13 @@ def test_singlepoint():
         assert "units" in atoms.info
         for prop, units in expected_units.items():
             assert atoms.info["units"][prop] == units
+
+    finally:
+        # Ensure files deleted if command fails
+        results_path.unlink(missing_ok=True)
+        log_path.unlink(missing_ok=True)
+        summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
         clear_log_handlers()
 

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -437,3 +437,26 @@ def test_no_carbon(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         sp_summary = yaml.safe_load(file)
     assert "emissions" not in sp_summary
+
+
+def test_file_prefix(tmp_path):
+    """Test file prefix creates directories and affects all files."""
+    file_prefix = tmp_path / "test/test"
+    result = runner.invoke(
+        app,
+        [
+            "singlepoint",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--file-prefix",
+            file_prefix,
+        ],
+    )
+    assert result.exit_code == 0
+    test_path = tmp_path / "test"
+    assert list(tmp_path.iterdir()) == [test_path]
+    assert set(test_path.iterdir()) == {
+        test_path / "test-results.extxyz",
+        test_path / "test-singlepoint-summary.yml",
+        test_path / "test-singlepoint-log.yml",
+    }

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -70,8 +70,8 @@ def test_train(tmp_path):
     results_path = Path("results")
     checkpoints_path = Path("checkpoints")
     logs_path = Path("logs")
-    log_path = Path("./train-log.yml").absolute()
-    summary_path = Path("./train-summary.yml").absolute()
+    log_path = Path("./janus_results/train-log.yml")
+    summary_path = Path("./janus_results/train-summary.yml")
 
     assert not model.exists()
     assert not compiled_model.exists()

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -70,14 +70,16 @@ def test_train(tmp_path):
     results_path = Path("results")
     checkpoints_path = Path("checkpoints")
     logs_path = Path("logs")
-    log_path = Path("./janus_results/train-log.yml")
-    summary_path = Path("./janus_results/train-summary.yml")
+    results_dir = Path("./janus_results")
+    log_path = results_dir / "train-log.yml"
+    summary_path = results_dir / "train-summary.yml"
 
     assert not model.exists()
     assert not compiled_model.exists()
     assert not logs_path.exists()
     assert not results_path.exists()
     assert not checkpoints_path.exists()
+    assert not results_dir.exists()
     assert not log_path.exists()
     assert not summary_path.exists()
 
@@ -131,6 +133,7 @@ def test_train(tmp_path):
 
         log_path.unlink(missing_ok=True)
         summary_path.unlink(missing_ok=True)
+        shutil.rmtree(results_dir, ignore_errors=True)
 
         clear_log_handlers()
 

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -80,8 +80,6 @@ def test_train(tmp_path):
     assert not results_path.exists()
     assert not checkpoints_path.exists()
     assert not results_dir.exists()
-    assert not log_path.exists()
-    assert not summary_path.exists()
 
     config = write_tmp_config(DATA_PATH / "mlip_train.yml", tmp_path)
 
@@ -130,9 +128,6 @@ def test_train(tmp_path):
         shutil.rmtree(logs_path, ignore_errors=True)
         shutil.rmtree(results_path, ignore_errors=True)
         shutil.rmtree(checkpoints_path, ignore_errors=True)
-
-        log_path.unlink(missing_ok=True)
-        summary_path.unlink(missing_ok=True)
         shutil.rmtree(results_dir, ignore_errors=True)
 
         clear_log_handlers()


### PR DESCRIPTION
Changes default `file_prefix` to include `./janus_results/` (originally `results`, but this clashes with mace training outputs, meaning that output files will normally all be contained within this directory, as discussed in #359.

I initially thought we may want a dedicated option for the file directory, but since `file_prefix` directories are created anyway, something like `--file-prefix ./alt_dir/prefix`, or `--file-prefix ./just-prefix` (to avoid creating a new directory),  which both already work, is just as effective.

One slight question mark on the dev side of things is currently this will create the `janus_results` directory if it doesn't exist, including when running tests, but I only clean up the files, not the directory itself, so running the tests may leave behind a new empty directory. I thought this was probably preferable to a lot of extra logic figuring out if it starts empty and so is safe to delete/potential test failures if it's not.