### PR TITLE
Save input configuration

### DIFF
--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -143,8 +143,9 @@ def eos(
         carbon_summary,
         check_config,
         end_summary,
+        get_config,
+        get_struct_info,
         parse_typer_dicts,
-        save_struct_calc,
         set_read_kwargs_index,
         start_summary,
     )
@@ -159,6 +160,15 @@ def eos(
 
     if eos_type not in get_args(EoSNames):
         raise ValueError(f"Fit type must be one of: {get_args(EoSNames)}")
+
+    # Set initial config
+    all_kwargs = {
+        "read_kwargs": read_kwargs.copy(),
+        "calc_kwargs": calc_kwargs.copy(),
+        "minimize_kwargs": minimize_kwargs.copy(),
+        "write_kwargs": write_kwargs.copy(),
+    }
+    config = get_config(params=ctx.params, all_kwargs=all_kwargs)
 
     # Read only first structure by default and ensure only one image is read
     set_read_kwargs_index(read_kwargs)
@@ -205,24 +215,14 @@ def eos(
     ).absolute()
     log = equation_of_state.log_kwargs["filename"]
 
-    # Store inputs for yaml summary
-    inputs = eos_kwargs.copy()
-
     # Add structure, MLIP information, and log to inputs
-    save_struct_calc(
-        inputs=inputs,
+    info = get_struct_info(
         struct=equation_of_state.struct,
         struct_path=struct,
-        arch=arch,
-        device=device,
-        model_path=model_path,
-        read_kwargs=read_kwargs,
-        calc_kwargs=calc_kwargs,
-        log=log,
     )
 
-    # Save summary information before calculations begin
-    start_summary(command="eos", summary=summary, inputs=inputs)
+    # Save summary information before calculation begins
+    start_summary(command="eos", summary=summary, config=config, info=info)
 
     # Run equation of state calculations
     equation_of_state.run()

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -223,8 +223,9 @@ def geomopt(
         carbon_summary,
         check_config,
         end_summary,
+        get_config,
+        get_struct_info,
         parse_typer_dicts,
-        save_struct_calc,
         set_read_kwargs_index,
         start_summary,
     )
@@ -235,6 +236,15 @@ def geomopt(
     [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs] = parse_typer_dicts(
         [read_kwargs, calc_kwargs, minimize_kwargs, write_kwargs]
     )
+
+    # Set initial config
+    all_kwargs = {
+        "read_kwargs": read_kwargs.copy(),
+        "calc_kwargs": calc_kwargs.copy(),
+        "minimize_kwargs": minimize_kwargs.copy(),
+        "write_kwargs": write_kwargs.copy(),
+    }
+    config = get_config(params=ctx.params, all_kwargs=all_kwargs)
 
     # Read only first structure by default and ensure only one image is read
     set_read_kwargs_index(read_kwargs)
@@ -296,24 +306,14 @@ def geomopt(
     ).absolute()
     log = optimizer.log_kwargs["filename"]
 
-    # Store inputs for yaml summary
-    inputs = optimize_kwargs.copy()
-
     # Add structure, MLIP information, and log to inputs
-    save_struct_calc(
-        inputs=inputs,
+    info = get_struct_info(
         struct=optimizer.struct,
         struct_path=struct,
-        arch=arch,
-        device=device,
-        model_path=model_path,
-        read_kwargs=read_kwargs,
-        calc_kwargs=calc_kwargs,
-        log=log,
     )
 
-    # Save summary information before optimization begins
-    start_summary(command="geomopt", summary=summary, inputs=inputs)
+    # Save summary information before calculation begins
+    start_summary(command="geomopt", summary=summary, config=config, info=info)
 
     # Run geometry optimization and save output structure
     optimizer.run()

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -354,8 +354,9 @@ def md(
         carbon_summary,
         check_config,
         end_summary,
+        get_config,
+        get_struct_info,
         parse_typer_dicts,
-        save_struct_calc,
         set_read_kwargs_index,
         start_summary,
     )
@@ -384,6 +385,17 @@ def md(
 
     if ensemble not in get_args(Ensembles):
         raise ValueError(f"ensemble must be in {get_args(Ensembles)}")
+
+    # Set initial config
+    all_kwargs = {
+        "read_kwargs": read_kwargs.copy(),
+        "calc_kwargs": calc_kwargs.copy(),
+        "minimize_kwargs": minimize_kwargs.copy(),
+        "ensemble_kwargs": ensemble_kwargs.copy(),
+        "write_kwargs": write_kwargs.copy(),
+        "post_process_kwargs": post_process_kwargs.copy(),
+    }
+    config = get_config(params=ctx.params, all_kwargs=all_kwargs)
 
     # Read only first structure by default and ensure only one image is read
     set_read_kwargs_index(read_kwargs)
@@ -553,23 +565,14 @@ def md(
     log = dyn.log_kwargs["filename"]
 
     # Store inputs for yaml summary
-    inputs = dyn_kwargs | {"ensemble": ensemble}
-
     # Add structure, MLIP information, and log to inputs
-    save_struct_calc(
-        inputs=inputs,
+    info = get_struct_info(
         struct=dyn.struct,
         struct_path=struct,
-        arch=arch,
-        device=device,
-        model_path=model_path,
-        read_kwargs=read_kwargs,
-        calc_kwargs=calc_kwargs,
-        log=log,
     )
 
-    # Save summary information before simulation begins
-    start_summary(command="md", summary=summary, inputs=inputs)
+    # Save summary information before calculation begins
+    start_summary(command="md", summary=summary, config=config, info=info)
 
     # Run molecular dynamics
     dyn.run()

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -232,10 +232,10 @@ def phonons(
     from janus_core.cli.utils import (
         carbon_summary,
         check_config,
-        dict_tuples_to_lists,
         end_summary,
+        get_config,
+        get_struct_info,
         parse_typer_dicts,
-        save_struct_calc,
         set_read_kwargs_index,
         start_summary,
     )
@@ -260,6 +260,17 @@ def phonons(
             pdos_kwargs,
         ]
     )
+
+    # Set initial config
+    all_kwargs = {
+        "displacement_kwargs": displacement_kwargs.copy(),
+        "read_kwargs": read_kwargs.copy(),
+        "calc_kwargs": calc_kwargs.copy(),
+        "minimize_kwargs": minimize_kwargs.copy(),
+        "dos_kwargs": dos_kwargs.copy(),
+        "pdos_kwargs": pdos_kwargs.copy(),
+    }
+    config = get_config(params=ctx.params, all_kwargs=all_kwargs)
 
     # Read only first structure by default and ensure only one image is read
     set_read_kwargs_index(read_kwargs)
@@ -340,27 +351,14 @@ def phonons(
     summary = phonon._build_filename("phonons-summary.yml", filename=summary).absolute()
     log = phonon.log_kwargs["filename"]
 
-    # Store inputs for yaml summary
-    inputs = phonons_kwargs.copy()
-
     # Add structure, MLIP information, and log to inputs
-    save_struct_calc(
-        inputs=inputs,
+    info = get_struct_info(
         struct=phonon.struct,
         struct_path=struct,
-        arch=arch,
-        device=device,
-        model_path=model_path,
-        read_kwargs=read_kwargs,
-        calc_kwargs=calc_kwargs,
-        log=log,
     )
 
-    # Convert all tuples to list in inputs nested dictionary
-    dict_tuples_to_lists(inputs)
-
-    # Save summary information before calculations begin
-    start_summary(command="phonons", summary=summary, inputs=inputs)
+    # Save summary information before calculation begins
+    start_summary(command="phonons", summary=summary, config=config, info=info)
 
     # Run phonon calculations
     phonon.run()

--- a/janus_core/cli/preprocess.py
+++ b/janus_core/cli/preprocess.py
@@ -49,10 +49,15 @@ def preprocess(
     from janus_core.cli.utils import carbon_summary, end_summary, start_summary
     from janus_core.training.preprocess import preprocess as run_preprocess
 
-    inputs = {"mlip_config": str(mlip_config)}
+    config = {
+        "mlip_config": mlip_config,
+        "log": log,
+        "tracker": tracker,
+        "summary": summary,
+    }
 
     # Save summary information before preprocessing begins
-    start_summary(command="preprocess", summary=summary, inputs=inputs)
+    start_summary(command="preprocess", summary=summary, config=config, info={})
 
     log_kwargs = {"filemode": "w"}
     if log:

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -112,8 +112,9 @@ def singlepoint(
         carbon_summary,
         check_config,
         end_summary,
+        get_config,
+        get_struct_info,
         parse_typer_dicts,
-        save_struct_calc,
         start_summary,
     )
 
@@ -127,6 +128,15 @@ def singlepoint(
     # Check filename for results not duplicated
     if "filename" in write_kwargs:
         raise ValueError("'filename' must be passed through the --out option")
+
+    # Set initial config
+    all_kwargs = {
+        "read_kwargs": read_kwargs.copy(),
+        "calc_kwargs": calc_kwargs.copy(),
+        "write_kwargs": write_kwargs.copy(),
+    }
+    config = get_config(params=ctx.params, all_kwargs=all_kwargs)
+
     if out:
         write_kwargs["filename"] = out
 
@@ -160,24 +170,14 @@ def singlepoint(
     ).absolute()
     log = s_point.log_kwargs["filename"]
 
-    # Store inputs for yaml summary
-    inputs = singlepoint_kwargs.copy()
-
     # Add structure, MLIP information, and log to inputs
-    save_struct_calc(
-        inputs=inputs,
+    info = get_struct_info(
         struct=s_point.struct,
         struct_path=struct,
-        arch=arch,
-        device=device,
-        model_path=model_path,
-        read_kwargs=read_kwargs,
-        calc_kwargs=calc_kwargs,
-        log=log,
     )
 
     # Save summary information before singlepoint calculation begins
-    start_summary(command="singlepoint", summary=summary, inputs=inputs)
+    start_summary(command="singlepoint", summary=summary, config=config, info=info)
 
     # Run singlepoint calculation
     s_point.run()

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -176,7 +176,7 @@ def singlepoint(
         struct_path=struct,
     )
 
-    # Save summary information before singlepoint calculation begins
+    # Save summary information before calculation begins
     start_summary(command="singlepoint", summary=summary, config=config, info=info)
 
     # Run singlepoint calculation

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -75,10 +75,16 @@ def train(
     elif "foundation_model" in config:
         raise ValueError("Please include the `--fine-tune` option for fine-tuning")
 
-    inputs = {"mlip_config": str(mlip_config), "fine_tune": fine_tune}
+    config = {
+        "mlip_config": mlip_config,
+        "fine_tune": fine_tune,
+        "log": log,
+        "tracker": tracker,
+        "summary": summary,
+    }
 
     # Save summary information before training begins
-    start_summary(command="train", summary=summary, inputs=inputs)
+    start_summary(command="train", summary=summary, config=config, info={})
 
     log_kwargs = {"filemode": "w"}
     if log:

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -17,9 +17,6 @@ if TYPE_CHECKING:
 
     from janus_core.cli.types import TyperDict
     from janus_core.helpers.janus_types import (
-        Architectures,
-        ASEReadArgs,
-        Devices,
         MaybeSequence,
     )
 
@@ -51,7 +48,7 @@ def dict_tuples_to_lists(dictionary: dict) -> None:
     """
     for key, value in dictionary.items():
         if isinstance(value, dict):
-            dict_paths_to_strs(value)
+            dict_tuples_to_lists(value)
         elif isinstance(value, tuple):
             dictionary[key] = list(value)
 
@@ -150,7 +147,9 @@ def yaml_converter_loader(config_file: str) -> dict[str, Any]:
 yaml_converter_callback = conf_callback_factory(yaml_converter_loader)
 
 
-def start_summary(*, command: str, summary: Path, inputs: dict) -> None:
+def start_summary(
+    *, command: str, summary: Path, config: dict[str, Any], info: dict[str, Any]
+) -> None:
     """
     Write initial summary contents.
 
@@ -160,16 +159,26 @@ def start_summary(*, command: str, summary: Path, inputs: dict) -> None:
         Name of CLI command being used.
     summary
         Path to summary file being saved.
-    inputs
+    config
         Inputs to CLI command to save.
+    info
+        Extra information to save.
     """
-    save_info = {
+    del config["config"]
+
+    summary_contents = {
         "command": f"janus {command}",
         "start_time": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M:%S"),
-        "inputs": inputs,
+        "config": config,
+        "info": info,
     }
+
+    # Convert all paths to strings in inputs nested dictionary
+    dict_paths_to_strs(summary_contents)
+    dict_tuples_to_lists(summary_contents)
+
     with open(summary, "w", encoding="utf8") as outfile:
-        yaml.dump(save_info, outfile, default_flow_style=False)
+        yaml.dump(summary_contents, outfile, default_flow_style=False)
 
 
 def carbon_summary(*, summary: Path, log: Path) -> None:
@@ -214,65 +223,38 @@ def end_summary(summary: Path) -> None:
     logging.shutdown()
 
 
-def save_struct_calc(
+def get_struct_info(
     *,
-    inputs: dict,
     struct: MaybeSequence[Atoms],
     struct_path: Path,
-    arch: Architectures,
-    device: Devices,
-    model_path: str,
-    read_kwargs: ASEReadArgs,
-    calc_kwargs: dict[str, Any],
-    log: Path,
-) -> None:
+) -> dict[str, Any]:
     """
-    Add structure and calculator input information to a dictionary.
+    Add structure information to a dictionary.
 
     Parameters
     ----------
-    inputs
-        Inputs dictionary to add information to.
     struct
         Structure to be simulated.
     struct_path
         Path of structure file.
-    arch
-        MLIP architecture.
-    device
-        Device to run calculations on.
-    model_path
-        Path to MLIP model.
-    read_kwargs
-        Keyword arguments to pass to ase.io.read.
-    calc_kwargs
-        Keyword arguments to pass to the calculator.
-    log
-        Path to log file.
+
+    Returns
+    -------
+    dict[str, Any]
+        Dictionary with structure information.
     """
     from ase import Atoms
 
-    # Clean up duplicate parameters
-    for key in (
-        "struct",
-        "struct_path",
-        "arch",
-        "device",
-        "model_path",
-        "read_kwargs",
-        "calc_kwargs",
-        "log_kwargs",
-    ):
-        inputs.pop(key, None)
+    info = {}
 
     if isinstance(struct, Atoms):
-        inputs["struct"] = {
+        info["struct"] = {
             "n_atoms": len(struct),
             "struct_path": struct_path,
             "formula": struct.get_chemical_formula(),
         }
     elif isinstance(struct, Sequence):
-        inputs["traj"] = {
+        info["traj"] = {
             "length": len(struct),
             "struct_path": struct_path,
             "struct": {
@@ -281,18 +263,30 @@ def save_struct_calc(
             },
         }
 
-    inputs["calc"] = {
-        "arch": arch,
-        "device": device,
-        "model_path": model_path,
-        "read_kwargs": read_kwargs,
-        "calc_kwargs": calc_kwargs,
-    }
+    return info
 
-    inputs["log"] = log
 
-    # Convert all paths to strings in inputs nested dictionary
-    dict_paths_to_strs(inputs)
+def get_config(*, params: dict[str, Any], all_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """
+    Get configuration and set kwargs dictionaries.
+
+    Parameters
+    ----------
+    params
+        CLI input parameters from ctx.
+    all_kwargs
+        Name and contents of all kwargs dictionaries.
+
+    Returns
+    -------
+    dict[str, Any]
+        Input parameters with parsed kwargs dictionaries substituted in.
+    """
+    for param in params:
+        if param in all_kwargs:
+            params[param] = all_kwargs[param]
+
+    return params
 
 
 def check_config(ctx: Context) -> None:

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -164,7 +164,7 @@ def start_summary(
     info
         Extra information to save.
     """
-    del config["config"]
+    config.pop("config", None)
 
     summary_contents = {
         "command": f"janus {command}",

--- a/tests/test_descriptors_cli.py
+++ b/tests/test_descriptors_cli.py
@@ -77,7 +77,8 @@ def test_descriptors():
         assert "command" in descriptors_summary
         assert "janus descriptors" in descriptors_summary["command"]
         assert "start_time" in descriptors_summary
-        assert "inputs" in descriptors_summary
+        assert "config" in descriptors_summary
+        assert "info" in descriptors_summary
         assert "end_time" in descriptors_summary
 
         assert "emissions" in descriptors_summary

--- a/tests/test_eos_cli.py
+++ b/tests/test_eos_cli.py
@@ -86,7 +86,8 @@ def test_eos():
         assert "command" in eos_summary
         assert "janus eos" in eos_summary["command"]
         assert "start_time" in eos_summary
-        assert "inputs" in eos_summary
+        assert "config" in eos_summary
+        assert "info" in eos_summary
         assert "end_time" in eos_summary
 
         assert "emissions" in eos_summary

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -383,7 +383,6 @@ def test_summary(tmp_path):
 
     assert "config" in geomopt_summary
     assert "minimize_kwargs" in geomopt_summary["config"]
-    assert "opt_kwargs" in geomopt_summary["config"]["minimize_kwargs"]
 
     assert "info" in geomopt_summary
     assert "struct" in geomopt_summary["info"]

--- a/tests/test_geomopt_cli.py
+++ b/tests/test_geomopt_cli.py
@@ -381,10 +381,13 @@ def test_summary(tmp_path):
     assert "start_time" in geomopt_summary
     assert "end_time" in geomopt_summary
 
-    assert "inputs" in geomopt_summary
-    assert "opt_kwargs" in geomopt_summary["inputs"]
-    assert "struct" in geomopt_summary["inputs"]
-    assert "n_atoms" in geomopt_summary["inputs"]["struct"]
+    assert "config" in geomopt_summary
+    assert "minimize_kwargs" in geomopt_summary["config"]
+    assert "opt_kwargs" in geomopt_summary["config"]["minimize_kwargs"]
+
+    assert "info" in geomopt_summary
+    assert "struct" in geomopt_summary["info"]
+    assert "n_atoms" in geomopt_summary["info"]["struct"]
 
     assert "emissions" in geomopt_summary
     assert geomopt_summary["emissions"] > 0
@@ -418,8 +421,8 @@ def test_config(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         geomopt_summary = yaml.safe_load(file)
 
-    assert "alpha" in geomopt_summary["inputs"]["opt_kwargs"]
-    assert geomopt_summary["inputs"]["opt_kwargs"]["alpha"] == 100
+    assert "alpha" in geomopt_summary["config"]["minimize_kwargs"]["opt_kwargs"]
+    assert geomopt_summary["config"]["minimize_kwargs"]["opt_kwargs"]["alpha"] == 100
 
 
 def test_invalid_config():

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -298,12 +298,13 @@ def test_summary(tmp_path):
     assert "command" in summary
     assert "janus md" in summary["command"]
     assert "start_time" in summary
-    assert "inputs" in summary
+    assert "config" in summary
+    assert "info" in summary
     assert "end_time" in summary
 
-    assert "ensemble" in summary["inputs"]
-    assert "struct" in summary["inputs"]
-    assert "n_atoms" in summary["inputs"]["struct"]
+    assert "ensemble" in summary["config"]
+    assert "struct" in summary["info"]
+    assert "n_atoms" in summary["info"]["struct"]
 
     assert "emissions" in summary
     assert summary["emissions"] > 0
@@ -339,12 +340,12 @@ def test_config(tmp_path):
         md_summary = yaml.safe_load(file)
 
     # Check temperature is passed correctly
-    assert md_summary["inputs"]["temp"] == 200
+    assert md_summary["config"]["temp"] == 200
     # Check explicit option overwrites config
-    assert md_summary["inputs"]["ensemble"] == "nve"
+    assert md_summary["config"]["ensemble"] == "nve"
     # Check nested dictionary
     assert (
-        md_summary["inputs"]["minimize_kwargs"]["filter_kwargs"]["hydrostatic_strain"]
+        md_summary["config"]["minimize_kwargs"]["filter_kwargs"]["hydrostatic_strain"]
         is True
     )
 

--- a/tests/test_neb_cli.py
+++ b/tests/test_neb_cli.py
@@ -81,7 +81,8 @@ def test_neb():
         assert "command" in neb_summary
         assert "janus neb" in neb_summary["command"]
         assert "start_time" in neb_summary
-        assert "inputs" in neb_summary
+        assert "config" in neb_summary
+        assert "info" in neb_summary
         assert "end_time" in neb_summary
 
         assert "emissions" in neb_summary

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -125,8 +125,7 @@ def test_bands_simple(tmp_path):
     assert "command" in phonon_summary
     assert "janus phonons" in phonon_summary["command"]
     assert "config" in phonon_summary
-    assert "calcs" in phonon_summary["config"]
-    assert phonon_summary["config"]["calcs"][0] == "bands"
+    assert phonon_summary["config"]["bands"]
 
 
 def test_hdf5(tmp_path):
@@ -269,9 +268,9 @@ def test_plot(tmp_path):
     assert summary_path.exists()
     with open(summary_path, encoding="utf8") as file:
         phonon_summary = yaml.safe_load(file)
-    assert phonon_summary["config"]["calcs"][0] == "bands"
-    assert phonon_summary["config"]["calcs"][1] == "dos"
-    assert phonon_summary["config"]["calcs"][2] == "pdos"
+    assert phonon_summary["config"]["bands"]
+    assert phonon_summary["config"]["dos"]
+    assert phonon_summary["config"]["pdos"]
 
 
 test_data = [

--- a/tests/test_phonons_cli.py
+++ b/tests/test_phonons_cli.py
@@ -73,7 +73,8 @@ def test_phonons():
         assert "command" in phonon_summary
         assert "janus phonons" in phonon_summary["command"]
         assert "start_time" in phonon_summary
-        assert "inputs" in phonon_summary
+        assert "config" in phonon_summary
+        assert "info" in phonon_summary
         assert "end_time" in phonon_summary
 
         assert "emissions" in phonon_summary
@@ -123,9 +124,9 @@ def test_bands_simple(tmp_path):
 
     assert "command" in phonon_summary
     assert "janus phonons" in phonon_summary["command"]
-    assert "inputs" in phonon_summary
-    assert "calcs" in phonon_summary["inputs"]
-    assert phonon_summary["inputs"]["calcs"][0] == "bands"
+    assert "config" in phonon_summary
+    assert "calcs" in phonon_summary["config"]
+    assert phonon_summary["config"]["calcs"][0] == "bands"
 
 
 def test_hdf5(tmp_path):
@@ -268,9 +269,9 @@ def test_plot(tmp_path):
     assert summary_path.exists()
     with open(summary_path, encoding="utf8") as file:
         phonon_summary = yaml.safe_load(file)
-    assert phonon_summary["inputs"]["calcs"][0] == "bands"
-    assert phonon_summary["inputs"]["calcs"][1] == "dos"
-    assert phonon_summary["inputs"]["calcs"][2] == "pdos"
+    assert phonon_summary["config"]["calcs"][0] == "bands"
+    assert phonon_summary["config"]["calcs"][1] == "dos"
+    assert phonon_summary["config"]["calcs"][2] == "pdos"
 
 
 test_data = [

--- a/tests/test_preprocess_cli.py
+++ b/tests/test_preprocess_cli.py
@@ -103,7 +103,7 @@ def test_preprocess(tmp_path):
         assert "command" in preprocess_summary
         assert "janus preprocess" in preprocess_summary["command"]
         assert "start_time" in preprocess_summary
-        assert "inputs" in preprocess_summary
+        assert "config" in preprocess_summary
         assert "end_time" in preprocess_summary
 
         assert "emissions" in preprocess_summary

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -250,14 +250,15 @@ def test_summary(tmp_path):
     assert "command" in sp_summary
     assert "janus singlepoint" in sp_summary["command"]
     assert "start_time" in sp_summary
-    assert "inputs" in sp_summary
+    assert "config" in sp_summary
+    assert "info" in sp_summary
     assert "end_time" in sp_summary
 
-    assert "properties" in sp_summary["inputs"]
-    assert "traj" in sp_summary["inputs"]
-    assert "length" in sp_summary["inputs"]["traj"]
-    assert "struct" in sp_summary["inputs"]["traj"]
-    assert "n_atoms" in sp_summary["inputs"]["traj"]["struct"]
+    assert "properties" in sp_summary["config"]
+    assert "traj" in sp_summary["info"]
+    assert "length" in sp_summary["info"]["traj"]
+    assert "struct" in sp_summary["info"]["traj"]
+    assert "n_atoms" in sp_summary["info"]["traj"]["struct"]
 
     assert "emissions" in sp_summary
     assert sp_summary["emissions"] > 0
@@ -293,8 +294,8 @@ def test_config(tmp_path):
     with open(summary_path, encoding="utf8") as file:
         sp_summary = yaml.safe_load(file)
 
-    assert "index" in sp_summary["inputs"]["calc"]["read_kwargs"]
-    assert sp_summary["inputs"]["calc"]["read_kwargs"]["index"] == 0
+    assert "index" in sp_summary["config"]["read_kwargs"]
+    assert sp_summary["config"]["read_kwargs"]["index"] == 0
 
 
 def test_invalid_config():

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -113,7 +113,7 @@ def test_train(tmp_path):
         assert "command" in train_summary
         assert "janus train" in train_summary["command"]
         assert "start_time" in train_summary
-        assert "inputs" in train_summary
+        assert "config" in train_summary
         assert "end_time" in train_summary
 
         assert "emissions" in train_summary


### PR DESCRIPTION
This saves the input parameters to CLI commands in the summary.

As described in #128, I think it makes most sense to save the config before any defaults are applied.

This is partly because where defaults are set varies between the CLI and Python modules for each command, accessing the "final" value of each parameter would not be trivial.

It also ensures consistency if this is used for a new config file, since in some cases, whether the parameter is using a default or has been explicitly set change behaviours, which would no longer be distinguishable if we stored the default.

In combination with #454. hopefully this won't be a problem in addressing the original #128 issue.

E.g.:

```
janus geomopt --struct tests/data/NaCl.cif --arch mace_mp --model-path small --opt-cell-lengths --write-traj --minimize-kwargs "{'opt_kwargs':{'trajectory':'test.traj'}}"
```

produces

```
command: janus geomopt
config:
  arch: mace_mp
  calc_kwargs: {}
  device: cpu
  file_prefix: null
  filter_func: null
  fmax: 0.1
  log: null
  minimize_kwargs:
    opt_kwargs:
      trajectory: test.traj
  model_path: small
  opt_cell_fully: false
  opt_cell_lengths: true
  optimizer: LBFGS
  out: null
  pressure: 0.0
  read_kwargs: {}
  steps: 1000
  struct: tests/data/NaCl.cif
  summary: null
  symmetrize: false
  symmetry_tolerance: 0.001
  tracker: true
  write_kwargs: {}
  write_traj: true
info:
  struct:
    formula: Cl4Na4
    n_atoms: 8
    struct_path: tests/data/NaCl.cif
start_time: 05/03/2025, 19:44:02
emissions: 4.319631282771114e-07
end_time: 05/03/2025, 19:44:14
```