### PR TITLE
Cancel concurrent documentation when publishing

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -19,6 +19,7 @@ jobs:
       id-token: write
     concurrency:
       group: "pages"
+      cancel-in-progress: True
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
As far as I can tell,  the publish workflow correctly builds an artefact with the tutorials run, but I think it doesn't get uploaded when the same commit (i.e. current `main`, which has been tagged) has already uploaded to pages.

This change means that the publish workflow should cancel the `docs` workflow, which from testing on my fork seems to fix this.

There remains a problem that this will be overwritten on the next push to `main` (#440), but hopefully this means we can at least have the outputs visible sometimes.