### PR TITLE
Revert "bump version for release 0.7.5"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "janus-core"
-version = "0.7.5"
+version = "0.7.4"
 description = "Tools for machine learnt interatomic potentials"
 authors = [
     { name = "Elliott Kasoar" },


### PR DESCRIPTION
This reverts commit de6144d7693c1dc7553cfc98f1eb9b9597f2998b.

Tutorials failed to build, possibly due to changes to the output file locations.