### PR TITLE
Fix reading output in tutorial

### DIFF
--- a/docs/source/tutorials/md.ipynb
+++ b/docs/source/tutorials/md.ipynb
@@ -163,7 +163,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The final structures at each temperature are saved in `Cl32Na32-nvt-T300.0-final.xyz`, `Cl32Na32-nvt-T280.0-final.xyz`, ..., `Cl32Na32-nvt-T200.0-final.xyz`.\n",
+    "All output files are saved in a results directory, `janus_results`.\n",
+    "\n",
+    "Within this, the final structures at each temperature are saved in `Cl32Na32-nvt-T300.0-final.xyz`, `Cl32Na32-nvt-T280.0-final.xyz`, ..., `Cl32Na32-nvt-T200.0-final.xyz`.\n",
     "\n",
     "The statiscs from the simulation are also saved every 20 steps in `Cl32Na32-nvt-T300.0-T200.0-stats.dat`. This can then be analysed using the `Stats` module:"
    ]
@@ -174,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = Stats(\"Cl32Na32-nvt-T300.0-T200.0-stats.dat\")"
+    "data = Stats(\"janus_results/Cl32Na32-nvt-T300.0-T200.0-stats.dat\")"
    ]
   },
   {
@@ -299,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rdf = np.loadtxt(\"Cl32Na32-nve-T300-rdf.dat\")\n",
+    "rdf = np.loadtxt(\"janus_results/Cl32Na32-nve-T300-rdf.dat\")\n",
     "bins, counts = zip(*rdf)"
    ]
   },


### PR DESCRIPTION
Tutorials are failing to build, as they reference output files without their output directory. I'm testing locally too, but I think this addresses the files which don't exist.