### PR TITLE
Add singlepoint and geomopt CLI tutorials

### DIFF
--- a/docs/source/tutorials/cli/geomopt.ipynb
+++ b/docs/source/tutorials/cli/geomopt.ipynb
@@ -1,0 +1,583 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/cli/geomopt.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4vcbRxmIhHLL"
+   },
+   "source": [
+    "# Geometry Optimization"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment (optional)\n",
+    "\n",
+    "These steps are required for Google Colab, but may work on other systems too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TF-EiWxyuMc7"
+   },
+   "outputs": [],
+   "source": [
+    "# import locale\n",
+    "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "# !python3 -m pip install janus-core[all] data-tutorials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Command-line help and options"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with `janus singlepoint`, we can check the options for geometry optimisation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running geometry optimisation calculation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we'll build a structure to optimise, as we did for single point calculations, but add in a deformation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.build import bulk\n",
+    "from ase.io import write\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
+    "NaCl[0].position = [1.5, 1.5, 1.5]\n",
+    "\n",
+    "write(\"data/NaCl-deformed.xyz\", NaCl)\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(NaCl)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can optimise the geometry of this structure in a similar manner to running `janus singlepoint`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --struct data/NaCl-deformed.xyz --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also change the optimisation function used, and specify an even lower force convergence criteria, `fmax` (the maximum force on all individual atoms):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Tip:</b> The optimizer must be a class defined in ASE.\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --struct data/NaCl-deformed.xyz --optimizer FIRE --fmax 0.005 --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with single point calculations, this saves a results file, corresponding to the optimised structure, as well as a summary and log:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls janus_results/NaCl-deformed*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now see the optimised structure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "traj = read(\"janus_results/NaCl-deformed-opt.extxyz\")\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(traj)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Trajectories"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also save the trajectory during optimisation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --struct data/NaCl-deformed.xyz --write-traj --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This creates an additional file, `janus_results/NaCl-deformed-traj.extxyz`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls janus_results/NaCl-deformed*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This allows us to visualise the optimisation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "traj = read(\"janus_results/NaCl-deformed-traj.extxyz\", index=\":\")\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(traj)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cell optimisation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also choose to modify the cell vectors during the optimisation. To allow only the cell lengths to change, we can run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --struct data/NaCl-deformed.xyz --write-traj --opt-cell-lengths --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, we can visualise this trajectory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "traj = read(\"janus_results/NaCl-deformed-traj.extxyz\", index=\":\")\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(traj)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also allow the cell angles to change:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --struct data/NaCl-deformed.xyz --write-traj --opt-cell-fully --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualising this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "traj = read(\"janus_results/NaCl-deformed-traj.extxyz\", index=\":\")\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(traj)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting the unit cell filter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Cell optimisation is carried out by appling an ASE `filter` to the structure. By default, this is the `FrechetCellFilter`, but you may wish to apply others, such as the `ExpCellFilter`. This is passed as a string, and must correspond to a class defined in ASE.\n",
+    "\n",
+    "Key word arguments can also be passed to these filters. For example, we can maintain constant volume using the following configuration file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile geomopt_config_1.yml\n",
+    "\n",
+    "struct: data/NaCl-deformed.xyz\n",
+    "opt_cell_fully: True\n",
+    "filter_func: ExpCellFilter\n",
+    "minimize_kwargs:\n",
+    "  filter_kwargs:\n",
+    "    constant_volume: True\n",
+    "tracker: False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Tip:</b> This is equivalent to:\n",
+    "\n",
+    "--struct data/NaCl-deformed.xyz --opt-cell-fully --filter-func ExpCellFilter --minimize-kwargs \"{'filter_kwargs': {'constant_volume' : True} --no-tracker\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --config geomopt_config_1.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualising this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "traj = read(\"janus_results/NaCl-deformed-traj.extxyz\", index=\":\")\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(traj)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constant pressure and symmetry refinement"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also choose to optimise at a fixed pressure (in GPa), and refine the symmetry of the final structure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --struct data/NaCl-deformed.xyz --write-traj --pressure 10 --opt-cell-fully --symmetrize --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualising this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "traj = read(\"janus_results/NaCl-deformed-traj.extxyz\", index=\":\")\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(traj)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing MACE to SevenNet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's compare to the structure optimised by SevenNet:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile geomopt_config_mace.yml\n",
+    "\n",
+    "struct: data/NaCl-deformed.xyz\n",
+    "arch: mace_mp\n",
+    "opt_cell_fully: True\n",
+    "minimize_kwargs:\n",
+    "  filter_kwargs:\n",
+    "    constant_volume: True\n",
+    "pressure: 10\n",
+    "file_prefix: janus_results/NaCl-mace\n",
+    "tracker: False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile geomopt_config_sevennet.yml\n",
+    "\n",
+    "struct: data/NaCl-deformed.xyz\n",
+    "arch: sevennet\n",
+    "opt_cell_fully: True\n",
+    "minimize_kwargs:\n",
+    "  filter_kwargs:\n",
+    "    constant_volume: True\n",
+    "pressure: 10\n",
+    "file_prefix: janus_results/NaCl-sevennet\n",
+    "tracker: False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus geomopt --config geomopt_config_mace.yml\n",
+    "! janus geomopt --config geomopt_config_sevennet.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualising the final structures:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "mace_opt = read(\"janus_results/NaCl-mace-opt.extxyz\")\n",
+    "sevennet_opt = read(\"janus_results/NaCl-sevennet-opt.extxyz\")\n",
+    "opt_comparison = [mace_opt, sevennet_opt]\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(opt_comparison)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "authorship_tag": "ABX9TyNvtIsPHVgkt0NvUv51T6ZG",
+   "gpuType": "T4",
+   "include_colab_link": true,
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/docs/source/tutorials/cli/singlepoint.ipynb
+++ b/docs/source/tutorials/cli/singlepoint.ipynb
@@ -225,6 +225,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can check the units corresponding to these quantities, which are also saved in the \"info\" dictionary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(results.info[\"units\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Using configuration files"
    ]
   },

--- a/docs/source/tutorials/cli/singlepoint.ipynb
+++ b/docs/source/tutorials/cli/singlepoint.ipynb
@@ -1,0 +1,669 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "view-in-github"
+   },
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stfc/janus-core/blob/main/docs/source/tutorials/cli/singlepoint.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Command-line interface (CLI) with single point calculations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "4vcbRxmIhHLL"
+   },
+   "source": [
+    "`janus-core` contains various machine learnt interatomic potentials (MLIPs), including MACE based models (MACE-MP, MACE-OFF), CHGNet, SevenNet and more, full list on https://github.com/stfc/janus-core.\n",
+    "\n",
+    "Other will be added as their utility is proven beyond a specific material."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment (optional)\n",
+    "\n",
+    "These steps are required for Google Colab, but may work on other systems too:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TF-EiWxyuMc7"
+   },
+   "outputs": [],
+   "source": [
+    "# import locale\n",
+    "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
+    "# !python3 -m pip install janus-core[all] data-tutorials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `data_tutorials` to get the data required for this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data_tutorials.data import get_data\n",
+    "\n",
+    "get_data(\n",
+    "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
+    "    filename=[\"sucrose.xyz\", \"NaCl-set.xyz\"],\n",
+    "    folder=\"data\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Command-line help and options"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once `janus-core` is installed, the `janus` CLI command should be available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Help for individual `janus` commands also be requested, describing all available options: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "857K7R9Cenca"
+   },
+   "source": [
+    "## Running single point calculations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we need a file to perform calculations on. Here, we build a periodic salt structure, visualise it, and write out to a file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Tip:</b> We use the ASE and WEAS Widget libaries here to build the structure and visualise it.\n",
+    "We discuss these tools in more detail in the Python tutorials. \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.build import bulk\n",
+    "from ase.io import write\n",
+    "from weas_widget import WeasWidget\n",
+    "\n",
+    "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
+    "\n",
+    "write(\"data/NaCl.xyz\", NaCl)\n",
+    "\n",
+    "v=WeasWidget()\n",
+    "v.from_ase(NaCl)\n",
+    "v.avr.model_style = 1\n",
+    "v.avr.show_hydrogen_bonds = True\n",
+    "v"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can use an MLIP to run single point calculations. By default, this uses the MACE-MP model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --struct data/NaCl.xyz --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Results from CLI calculations are saved in a newly created directory, `janus_results`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls janus_results/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now read the output file back into ASE, to see the saved energy, stresses, and forces:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ase.io import read\n",
+    "\n",
+    "results = read(\"janus_results/NaCl-results.extxyz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Energy: {results.info[\"mace_mp_energy\"]}\")\n",
+    "print()\n",
+    "print(f\"Stress: {results.info[\"mace_mp_stress\"]}\")\n",
+    "print()\n",
+    "print(f\"Forces: {results.arrays[\"mace_mp_forces\"]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using configuration files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All options to `janus` commands can be specified through a YAML input file. These are text files of the form:\n",
+    "\n",
+    "```bash\n",
+    "key: value\n",
+    "list_key:\n",
+    "  - list_value_1\n",
+    "  - list_value_2\n",
+    "nested_key_1:\n",
+    "  nested_key_2: nested_value\n",
+    "```\n",
+    "\n",
+    "which, in Python, would correspond to a dictionary of the form:\n",
+    "\n",
+    "```python\n",
+    "{\n",
+    "    \"key\": value,\n",
+    "    \"list_key\": [list_value_1, list_value_2],\n",
+    "    \"nested_key\": {\"nested_key_2\": nested_value},\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Although you can specify every option, let's first write a minimal configuration file for `janus singlepoint`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile singlepoint_config_1.yml\n",
+    "\n",
+    "struct: data/NaCl.xyz\n",
+    "tracker: False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then use this configuration file to re-run the calculation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --config singlepoint_config_1.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Options in the configuration files can be overwritten when running a command. For example, the following configuration file also defines the `file_prefix`, which specifies any directories and the prefix of the file names to be output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile singlepoint_config_2.yml\n",
+    "\n",
+    "struct: data/NaCl.xyz\n",
+    "file_prefix: examples/NaCl\n",
+    "tracker: False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now use this configuration file, but replace `file_prefix`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --config singlepoint_config_2.yml --file-prefix outputs/salt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> In the CLI, arguments are separated by \"-\", while in configuration files, they are specified by \"_\"\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This creates a new output directory, `outputs`, as well as starting all output files with \"salt-\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! ls outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running multiple calculations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, results from `janus singlepoint` are saved in two forms. For energies, this is an \"info\" dictionary, and a \"results\" dictionary.\n",
+    "\n",
+    "One set of dictionary keys will be labelled with the MLIP model used (\"mace_mp_energy\", \"mace_mp_stress\", \"mace_mp_forces\"), which ensures these are not overwritten when running calculations with multiple models.\n",
+    "\n",
+    "The unlabelled set of keys (\"energy\", \"forces\", \"stress\") allow ASE to use the results for further calculations, but will be overwritten if a new calculation is run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(results.info.keys())\n",
+    "print(results.arrays.keys())\n",
+    "print(results.calc.results.keys())\n",
+    "\n",
+    "print()\n",
+    "print(results.calc.results[\"energy\"])\n",
+    "print(results.get_potential_energy())\n",
+    "print(results.get_total_energy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, if we re-run the calculation using SevenNet, saving the results to a new output file, we see that \"mace_mp_energy\" is still saved, other unlabelled results are updated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --struct janus_results/NaCl-results.extxyz --arch sevennet --out janus_results/NaCl-updated-results.extxyz --no-tracker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "updated_results = read(\"janus_results/NaCl-updated-results.extxyz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(updated_results.info.keys())\n",
+    "print(updated_results.arrays.keys())\n",
+    "print(updated_results.calc.results.keys())\n",
+    "\n",
+    "print()\n",
+    "print(updated_results.info[\"mace_mp_energy\"])\n",
+    "print(updated_results.info[\"sevennet_energy\"])\n",
+    "print(updated_results.calc.results[\"energy\"])\n",
+    "print(updated_results.get_potential_energy())\n",
+    "print(updated_results.get_total_energy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Output files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to the resulting structure file, all calculations run through the CLI generate log (`NaCl-singlepoint-log.yml`) and summary (`NaCl-singlepoint-summary.yml`) files.\n",
+    "\n",
+    "In this case, the log file captures timestamps for the start and end of the calculation, but it will also capture any Python warnings generated, and carbon tracking information:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! cat janus_results/NaCl-singlepoint-log.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The summary file contains:\n",
+    "\n",
+    "- The main command run\n",
+    "- The CLI options specified\n",
+    "- Basic information about the structure\n",
+    "- Output files generated by the calculation\n",
+    "- Start and end times of the calculation\n",
+    "- Carbon tracking summary, if applicable "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! cat janus_results/NaCl-singlepoint-summary.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reusing configuration files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can extract the configuration used to run our first calculation from the summary file, reusing it with a slight modification.\n",
+    "\n",
+    "First, we read in the configuration via the summary file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "with open(\"janus_results/NaCl-singlepoint-summary.yml\", encoding=\"utf8\") as file:\n",
+    "    summary = yaml.safe_load(file)\n",
+    "\n",
+    "config = summary[\"config\"]\n",
+    "print(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's change the structure to run the calculations on, ensure we read all images the file (this is actaully the default for single point calculations), and change the calculated property:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config[\"struct\"] = \"data/NaCl-set.xyz\"\n",
+    "config[\"read_kwargs\"] = {\"index\": \":\"} # Key word arguments, passed to ase.io.read`\n",
+    "config[\"properties\"] = [\"hessian\"] # This must be a list, even for a single quantity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we write this file out, and use it to run our calculation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"singlepoint_config_3.yml\", \"w\", encoding=\"utf8\") as file:\n",
+    "    yaml.dump(config, file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! cat singlepoint_config_3.yml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --config singlepoint_config_3.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can read in these results, ensuring we read in all structures from the file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NaCl_set_results = read(\"janus_results/NaCl-set-results.extxyz\", index=\":\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(NaCl_set_results[0].info[\"mace_mp_hessian\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting keyword arguments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All `janus` commands accept keyword arguments (kwargs), which are input in the form of Python dictionaries: `{\"key\": value}`.\n",
+    "\n",
+    "One useful example is passing options that are specific to an MLIP calculator.\n",
+    "\n",
+    "For example, MACE has an option to run with D3 dispersion correction, through the `dispersion` option. In the command-line, this can be set using:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --config singlepoint_config_1.yml --calc-kwargs \"{'dispersion': True}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To avoid the complications of nested quotations, setting this in the configuration file is preferable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile singlepoint_config_4.yml\n",
+    "\n",
+    "struct: data/NaCl.xyz\n",
+    "tracker: False\n",
+    "calc_kwargs:\n",
+    "  dispersion: True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! janus singlepoint --config singlepoint_config_4.yml --calc-kwargs \"{'dispersion': True}\""
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "authorship_tag": "ABX9TyNvtIsPHVgkt0NvUv51T6ZG",
+   "gpuType": "T4",
+   "include_colab_link": true,
+   "private_outputs": true,
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/tutorials/cli/singlepoint.ipynb
+++ b/docs/source/tutorials/cli/singlepoint.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "get_data(\n",
     "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
-    "    filename=[\"sucrose.xyz\", \"NaCl-set.xyz\"],\n",
+    "    filename=[\"NaCl-set.xyz\"],\n",
     "    folder=\"data\",\n",
     ")"
    ]


### PR DESCRIPTION
Tries to introduce:

- Getting help (janus and commands)
- Running single point calculations
- Building and using config files
- Running calculations with different MLIPs
  - Arguable could come later, but helps explain what info the results actually contains, so it felt useful here
- Summary and log files
- Reusing configurations via the summary
  - Again, in some ways not a priority, but I use it as a way to show different calculations and multiple structures
- Setting kwargs via --kwargs and, preferably, a config file