### PR TITLE
Fix CLI tutorials for Colab

### DIFF
--- a/docs/source/tutorials/cli/geomopt.ipynb
+++ b/docs/source/tutorials/cli/geomopt.ipynb
@@ -38,7 +38,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {
@@ -84,9 +87,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "from ase.build import bulk\n",
     "from ase.io import write\n",
     "from weas_widget import WeasWidget\n",
+    "\n",
+    "Path(\"data\").mkdir(exist_ok=True)\n",
     "\n",
     "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
     "NaCl[0].position = [1.5, 1.5, 1.5]\n",
@@ -375,7 +382,7 @@
     "<div class=\"alert alert-block alert-info\">\n",
     "<b>Tip:</b> This is equivalent to:\n",
     "\n",
-    "--struct data/NaCl-deformed.xyz --opt-cell-fully --filter-func ExpCellFilter --minimize-kwargs \"{'filter_kwargs': {'constant_volume' : True} --no-tracker\n",
+    "--struct data/NaCl-deformed.xyz --opt-cell-fully --filter-func ExpCellFilter --minimize-kwargs \"{'filter_kwargs': {'constant_volume' : True}\" --no-tracker\n",
     "</div>\n"
    ]
   },
@@ -500,27 +507,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile geomopt_config_sevennet.yml\n",
-    "\n",
-    "struct: data/NaCl-deformed.xyz\n",
-    "arch: sevennet\n",
-    "opt_cell_fully: True\n",
-    "minimize_kwargs:\n",
-    "  filter_kwargs:\n",
-    "    constant_volume: True\n",
-    "pressure: 10\n",
-    "file_prefix: janus_results/NaCl-sevennet\n",
-    "tracker: False"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "! janus geomopt --config geomopt_config_mace.yml\n",
-    "! janus geomopt --config geomopt_config_sevennet.yml"
+    "! janus geomopt --config geomopt_config_mace.yml --arch sevennet --file-prefix janus_results/NaCl-sevennet"
    ]
   },
   {

--- a/docs/source/tutorials/cli/md.ipynb
+++ b/docs/source/tutorials/cli/md.ipynb
@@ -38,7 +38,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {
@@ -120,6 +123,8 @@
     "stats_every: 10\n",
     "traj_every: 10\n",
     "restart_every: 50\n",
+    "\n",
+    "tracker: False\n",
     "\n",
     "# If you have an Nvidia GPU.\n",
     "#device: cuda"
@@ -373,6 +378,8 @@
     "    a_kwargs: {'components': ['xy', 'yz', 'zx']}\n",
     "    points: 250\n",
     "\n",
+    "tracker: False\n",
+    "\n",
     "# If you have an Nvidia GPU.\n",
     "#device: cuda"
    ]
@@ -491,6 +498,8 @@
     "stats_every: 10\n",
     "traj_every: 10\n",
     "\n",
+    "tracker: False\n",
+    "\n",
     "# If you have an Nvidia GPU.\n",
     "#device: cuda"
    ]
@@ -543,11 +552,6 @@
     "\n",
     "Experimentally NaCl melts at about 1074 Kelvin at atmospheric pressure."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/tutorials/cli/neb.ipynb
+++ b/docs/source/tutorials/cli/neb.ipynb
@@ -58,7 +58,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {
@@ -77,7 +80,7 @@
     "from data_tutorials.data import get_data\n",
     "\n",
     "get_data(\n",
-    "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
+    "    url=\"https://raw.githubusercontent.com/stfc/janus-core/main/docs/source/tutorials/data/\",\n",
     "    filename=[\"ethanol_reactants.extxyz\", \"ethanol_products.extxyz\",\"ethanol_reactants_1water.extxyz\",\"ethanol_products_1water.extxyz\",\"ethanol_reactants_2water.extxyz\",\"ethanol_products_2water.extxyz\"],\n",
     "    folder=\"data\",\n",
     ")"
@@ -131,9 +134,10 @@
     "minimize: True\n",
     "plot_band: True\n",
     "write_band: True\n",
-    "calc-kwargs:\n",
+    "calc_kwargs:\n",
     "      dispersion: True\n",
-    "      model: medium-omat-0"
+    "      model: medium-omat-0\n",
+    "tracker: False"
    ]
   },
   {
@@ -305,11 +309,6 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### extra bits\n",
     "\n",
@@ -317,16 +316,6 @@
     "- analyse the barrier height trend.\n",
     "- consider redoing the same exercise with a different potential... remember if you use mace-off dispersion needs to be off.\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/tutorials/cli/phonons.ipynb
+++ b/docs/source/tutorials/cli/phonons.ipynb
@@ -45,7 +45,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {
@@ -153,7 +156,7 @@
     "calc-kwargs:\n",
     "    model:  medium-mpa-0\n",
     "device: cpu\n",
-    "\n"
+    "tracker: False"
    ]
   },
   {
@@ -243,7 +246,7 @@
     "    skin: 0 \n",
     "    model:  medium-mpa-0\n",
     "device: cpu\n",
-    "\n"
+    "tracker: False"
    ]
   },
   {
@@ -316,7 +319,7 @@
     "    skin: 0 \n",
     "    model:  medium-mpa-0\n",
     "device: cpu\n",
-    "\n"
+    "tracker: False"
    ]
   },
   {
@@ -380,7 +383,7 @@
     "    skin: 0 \n",
     "    model:  medium-mpa-0\n",
     "device: cpu\n",
-    "\n"
+    "tracker: False"
    ]
   },
   {
@@ -419,7 +422,7 @@
    "outputs": [],
    "source": [
     "get_data(\n",
-    "    url=\"https://raw.githubusercontent.com/stfc/janus-tutorials/main/data/\",\n",
+    "    url=\"https://raw.githubusercontent.com/stfc/janus-core/main/docs/source/tutorials/data/\",\n",
     "    filename=[\"mof-5.cif\",\"paths.yaml\"],\n",
     "    folder=\"data\",\n",
     ")"
@@ -431,7 +434,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "mof5 = read(\"data/mof-5.cif\")\n",
     "v=WeasWidget()\n",
     "v.from_ase(mof5)\n",
@@ -471,7 +473,7 @@
     "    skin: 0 \n",
     "    model:  medium-mpa-0\n",
     "device: cpu\n",
-    "\n"
+    "tracker: False"
    ]
   },
   {
@@ -506,7 +508,7 @@
    "outputs": [],
    "source": [
     "from IPython.display import SVG, display\n",
-    "display(SVG(\"janus_results/mof-5-bs-dos.svg\"))\n"
+    "display(SVG(\"janus_results/mof-5-bs-dos.svg\"))"
    ]
   },
   {
@@ -542,7 +544,7 @@
     "    skin: 0 \n",
     "    model:  medium-mpa-0\n",
     "device: cpu\n",
-    "\n"
+    "tracker: False"
    ]
   },
   {
@@ -569,7 +571,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(SVG(\"janus_results/mof-5-bs-dos.svg\"))\n"
+    "display(SVG(\"janus_results/mof-5-bs-dos.svg\"))"
    ]
   },
   {
@@ -584,11 +586,6 @@
     "\n",
     "this is part of this paper if you want to know more: https://arxiv.org/abs/2412.02877"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/source/tutorials/cli/singlepoint.ipynb
+++ b/docs/source/tutorials/cli/singlepoint.ipynb
@@ -47,7 +47,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {
@@ -214,11 +217,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Energy: {results.info[\"mace_mp_energy\"]}\")\n",
+    "print(f\"Energy: {results.info['mace_mp_energy']}\")\n",
     "print()\n",
-    "print(f\"Stress: {results.info[\"mace_mp_stress\"]}\")\n",
+    "print(f\"Stress: {results.info['mace_mp_stress']}\")\n",
     "print()\n",
-    "print(f\"Forces: {results.arrays[\"mace_mp_forces\"]}\")"
+    "print(f\"Forces: {results.arrays['mace_mp_forces']}\")"
    ]
   },
   {
@@ -285,6 +288,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! cat singlepoint_config_1.yml"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -341,7 +353,8 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> In the CLI, arguments are separated by \"-\", while in configuration files, they are specified by \"_\"\n",
+    "<b>Note:</b> In the CLI, multi-word arguments must be separated by \"-\".\n",
+    "In configuration files, they are preferably separated by \"_\", although \"-\" should be converted automatically.\n",
     "</div>"
    ]
   },
@@ -619,7 +632,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! janus singlepoint --config singlepoint_config_1.yml --calc-kwargs \"{'dispersion': True}\""
+    "! janus singlepoint --config singlepoint_config_1.yml --calc-kwargs \"{'dispersion': True}\" --out janus_results/NaCl-dispersion-results.extxyz"
    ]
   },
   {
@@ -640,7 +653,8 @@
     "struct: data/NaCl.xyz\n",
     "tracker: False\n",
     "calc_kwargs:\n",
-    "  dispersion: True"
+    "  dispersion: True\n",
+    "out: janus_results/NaCl-dispersion-results.extxyz"
    ]
   },
   {
@@ -649,7 +663,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! janus singlepoint --config singlepoint_config_4.yml --calc-kwargs \"{'dispersion': True}\""
+    "! janus singlepoint --config singlepoint_config_4.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Comparing the results before and after the correction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dispersion_results = read(\"janus_results/NaCl-dispersion-results.extxyz\")\n",
+    "\n",
+    "print(f\"Original results: {results.info['mace_mp_energy']}\")\n",
+    "print(f\"Results with dispersion correction: {dispersion_results.info['mace_mp_energy']}\")"
    ]
   }
  ],


### PR DESCRIPTION
Resolves #485

This adds a few changes needed to run successfully in Colab:

- Downgrading NumPy, which is installed by default
  - This also requires restarting the session, which is done automatically as part of these changes
- Downgrade torch
  - MACE should work with torch 2.6, but our current version of SevenNet does not, which I think it mostly because MACE forces an old version of e3nn (MACE introduced a [workaround](https://github.com/ACEsuit/mace/issues/555), whereas SevenNet has recently upgraded e3nn  - see #490)
  - We also need to remove torchaudio (and also torchvision, to be safe), as this is pre-installed, but raises an error
- Ensures the `./data` exists for geomopt.ipynb
- Disables all carbon tracking, since this seems to throw errors in Colab (may be worth revisiting, at least once sudo is [hopefully removed for MacOS](https://github.com/mlco2/codecarbon/pull/752))
- Fixes data links


Also tides up a few cells in minor ways