### PR TITLE
Group CLI options

### DIFF
--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -18,6 +18,7 @@ from janus_core.cli.types import (
     ReadKwargsAll,
     StructPath,
     Summary,
+    Tracker,
     WriteKwargs,
 )
 from janus_core.cli.utils import yaml_converter_callback
@@ -33,20 +34,23 @@ def descriptors(
     struct: StructPath,
     invariants_only: Annotated[
         bool,
-        Option(help="Only calculate invariant descriptors."),
+        Option(
+            help="Only calculate invariant descriptors.", rich_help_panel="Calculation"
+        ),
     ] = True,
     calc_per_element: Annotated[
         bool,
-        Option(help="Calculate mean descriptors for each element."),
+        Option(
+            help="Calculate mean descriptors for each element.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     calc_per_atom: Annotated[
         bool,
-        Option(help="Calculate descriptors for each atom."),
+        Option(
+            help="Calculate descriptors for each atom.", rich_help_panel="Calculation"
+        ),
     ] = False,
-    arch: Architecture = "mace_mp",
-    device: Device = "cpu",
-    model_path: ModelPath = None,
-    file_prefix: FilePrefix = None,
     out: Annotated[
         Path | None,
         Option(
@@ -54,15 +58,21 @@ def descriptors(
                 "Path to save structure with calculated descriptors. Default is "
                 "inferred from name of structure file."
             ),
+            rich_help_panel="Calculation",
         ),
     ] = None,
-    read_kwargs: ReadKwargsAll = None,
+    # MLIP Calculator
+    arch: Architecture = "mace_mp",
+    device: Device = "cpu",
+    model_path: ModelPath = None,
     calc_kwargs: CalcKwargs = None,
+    # Structure I/O
+    file_prefix: FilePrefix = None,
+    read_kwargs: ReadKwargsAll = None,
     write_kwargs: WriteKwargs = None,
+    # Logging/summary
     log: LogPath = None,
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    tracker: Tracker = True,
     summary: Summary = None,
 ) -> None:
     """
@@ -80,24 +90,24 @@ def descriptors(
         Whether to calculate mean descriptors for each element. Default is False.
     calc_per_atom
         Whether to calculate descriptors for each atom. Default is False.
+    out
+        Path to save structure with calculated results. Default is inferred
+        `file_prefix`.
     arch
         MLIP architecture to use for calculations. Default is "mace_mp".
     device
         Device to run model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
+    calc_kwargs
+        Keyword arguments to pass to the selected calculator. Default is {}.
     file_prefix
         Prefix for output files, including directories. Default directory is
         ./janus_results, and default filename prefix is inferred from the input
         stucture filename.
-    out
-        Path to save structure with calculated results. Default is inferred
-        `file_prefix`.
     read_kwargs
         Keyword arguments to pass to ase.io.read. By default,
             read_kwargs["index"] is ":".
-    calc_kwargs
-        Keyword arguments to pass to the selected calculator. Default is {}.
     write_kwargs
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -26,7 +26,7 @@ app = Typer()
 
 
 @app.command()
-@use_config(yaml_converter_callback)
+@use_config(yaml_converter_callback, param_help="Path to configuration file.")
 def descriptors(
     # numpydoc ignore=PR02
     ctx: Context,

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -19,6 +19,7 @@ from janus_core.cli.types import (
     ReadKwargsLast,
     StructPath,
     Summary,
+    Tracker,
     WriteKwargs,
 )
 from janus_core.cli.utils import yaml_converter_callback
@@ -33,46 +34,73 @@ def eos(
     # numpydoc ignore=PR02
     ctx: Context,
     struct: StructPath,
-    min_volume: Annotated[float, Option(help="Minimum volume scale factor.")] = 0.95,
-    max_volume: Annotated[float, Option(help="Maximum volume scale factor.")] = 1.05,
-    n_volumes: Annotated[int, Option(help="Number of volumes.")] = 7,
+    min_volume: Annotated[
+        float,
+        Option(help="Minimum volume scale factor.", rich_help_panel="Calculation"),
+    ] = 0.95,
+    max_volume: Annotated[
+        float,
+        Option(help="Maximum volume scale factor.", rich_help_panel="Calculation"),
+    ] = 1.05,
+    n_volumes: Annotated[
+        int, Option(help="Number of volumes.", rich_help_panel="Calculation")
+    ] = 7,
     eos_type: Annotated[
         str,
         Option(
             click_type=Choice(get_args(EoSNames)),
             help="Type of fit for equation of state.",
+            rich_help_panel="Calculation",
         ),
     ] = "birchmurnaghan",
     minimize: Annotated[
-        bool, Option(help="Whether to minimize initial structure before calculations.")
+        bool,
+        Option(
+            help="Whether to minimize initial structure before calculations.",
+            rich_help_panel="Calculation",
+        ),
     ] = True,
     minimize_all: Annotated[
         bool,
-        Option(help="Whether to minimize all generated structures for calculations."),
+        Option(
+            help="Whether to minimize all generated structures for calculations.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     fmax: Annotated[
-        float, Option(help="Maximum force for optimization convergence.")
+        float,
+        Option(
+            help="Maximum force for optimization convergence.",
+            rich_help_panel="Calculation",
+        ),
     ] = 0.1,
     minimize_kwargs: MinimizeKwargs = None,
     write_structures: Annotated[
         bool,
-        Option(help="Whether to write out all genereated structures."),
+        Option(
+            help="Whether to write out all genereated structures.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
-    write_kwargs: WriteKwargs = None,
     plot_to_file: Annotated[
         bool,
-        Option(help="Whether to plot equation of state."),
+        Option(
+            help="Whether to plot equation of state.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
+    # MLIP Calculator
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     model_path: ModelPath = None,
-    read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
+    # Structure I/O
     file_prefix: FilePrefix = None,
+    read_kwargs: ReadKwargsLast = None,
+    write_kwargs: WriteKwargs = None,
+    # Logging/summary
     log: LogPath = None,
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    tracker: Tracker = True,
     summary: Summary = None,
 ) -> None:
     """
@@ -103,9 +131,6 @@ def eos(
         Other keyword arguments to pass to geometry optimizer. Default is {}.
     write_structures
         True to write out all genereated structures. Default is False.
-    write_kwargs
-        Keyword arguments to pass to ase.io.write to save generated structures.
-        Default is {}.
     plot_to_file
         Whether to save plot equation of state to svg. Default is False.
     arch
@@ -115,15 +140,18 @@ def eos(
         Device to run model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs
-        Keyword arguments to pass to ase.io.read. By default,
-            read_kwargs["index"] is -1.
     calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
     file_prefix
         Prefix for output files, including directories. Default directory is
         ./janus_results, and default filename prefix is inferred from the input
         stucture filename.
+    read_kwargs
+        Keyword arguments to pass to ase.io.read. By default,
+            read_kwargs["index"] is -1.
+    write_kwargs
+        Keyword arguments to pass to ase.io.write to save generated structures.
+        Default is {}.
     log
         Path to write logs to. Default is inferred from `file_prefix`.
     tracker

--- a/janus_core/cli/eos.py
+++ b/janus_core/cli/eos.py
@@ -28,7 +28,7 @@ app = Typer()
 
 
 @app.command()
-@use_config(yaml_converter_callback)
+@use_config(yaml_converter_callback, param_help="Path to configuration file.")
 def eos(
     # numpydoc ignore=PR02
     ctx: Context,

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -19,6 +19,7 @@ from janus_core.cli.types import (
     ReadKwargsLast,
     StructPath,
     Summary,
+    Tracker,
     WriteKwargs,
 )
 from janus_core.cli.utils import yaml_converter_callback
@@ -75,23 +76,37 @@ def geomopt(
     struct: StructPath,
     optimizer: Annotated[
         str | None,
-        Option(help="Name of ASE optimizer function to use."),
+        Option(
+            help="Name of ASE optimizer function to use.",
+            rich_help_panel="Calculation",
+        ),
     ] = "LBFGS",
     fmax: Annotated[
-        float, Option(help="Maximum force for convergence, in eV/Å.")
+        float,
+        Option(
+            help="Maximum force for convergence, in eV/Å.",
+            rich_help_panel="Calculation",
+        ),
     ] = 0.1,
-    steps: Annotated[int, Option(help="Maximum number of optimization steps.")] = 1000,
-    arch: Architecture = "mace_mp",
-    device: Device = "cpu",
-    model_path: ModelPath = None,
+    steps: Annotated[
+        int,
+        Option(
+            help="Maximum number of optimization steps.",
+            rich_help_panel="Calculation",
+        ),
+    ] = 1000,
     opt_cell_lengths: Annotated[
         bool,
-        Option(help="Optimize cell vectors, as well as atomic positions."),
+        Option(
+            help="Optimize cell vectors, as well as atomic positions.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     opt_cell_fully: Annotated[
         bool,
         Option(
             help="Fully optimize the cell vectors, angles, and atomic positions.",
+            rich_help_panel="Calculation",
         ),
     ] = False,
     filter_func: Annotated[
@@ -100,29 +115,39 @@ def geomopt(
             help=(
                 "Name of ASE filter/constraint function to use. If using "
                 "--opt-cell-lengths or --opt-cell-fully, defaults to "
-                "`FrechetCellFilter` if available, otherwise `ExpCellFilter`."
-            )
+                "`FrechetCellFilter`."
+            ),
+            rich_help_panel="Calculation",
         ),
     ] = None,
     pressure: Annotated[
-        float, Option(help="Scalar pressure when optimizing cell geometry, in GPa.")
+        float,
+        Option(
+            help="Scalar pressure when optimizing cell geometry, in GPa.",
+            rich_help_panel="Calculation",
+        ),
     ] = 0.0,
     symmetrize: Annotated[
-        bool, Option(help="Whether to refine symmetry after geometry optimization.")
+        bool,
+        Option(
+            help="Whether to refine symmetry after geometry optimization.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     symmetry_tolerance: Annotated[
         float,
         Option(
-            help="Atom displacement tolerance for spglib symmetry determination, in Å."
+            help="Atom displacement tolerance for spglib symmetry determination, in Å.",
+            rich_help_panel="Calculation",
         ),
     ] = 0.001,
-    file_prefix: FilePrefix = None,
     out: Annotated[
         Path | None,
         Option(
             help=(
                 "Path to save optimized structure. Default is inferred `file_prefix`."
             ),
+            rich_help_panel="Calculation",
         ),
     ] = None,
     write_traj: Annotated[
@@ -133,16 +158,22 @@ def geomopt(
                 'If traj_kwargs["filename"] is not specified, it is inferred '
                 "from `file_prefix`."
             ),
+            rich_help_panel="Calculation",
         ),
     ] = False,
-    read_kwargs: ReadKwargsLast = None,
-    calc_kwargs: CalcKwargs = None,
     minimize_kwargs: MinimizeKwargs = None,
+    # MLIP Calculator
+    arch: Architecture = "mace_mp",
+    device: Device = "cpu",
+    model_path: ModelPath = None,
+    calc_kwargs: CalcKwargs = None,
+    # Structure I/O
+    file_prefix: FilePrefix = None,
+    read_kwargs: ReadKwargsLast = None,
     write_kwargs: WriteKwargs = None,
+    # Logging/summary
     log: LogPath = None,
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    tracker: Tracker = True,
     summary: Summary = None,
 ) -> None:
     """
@@ -160,13 +191,6 @@ def geomopt(
         Set force convergence criteria for optimizer, in eV/Å. Default is 0.1.
     steps
         Set maximum number of optimization steps to run. Default is 1000.
-    arch
-        MLIP architecture to use for geometry optimization.
-        Default is "mace_mp".
-    device
-        Device to run model on. Default is "cpu".
-    model_path
-        Path to MLIP model. Default is `None`.
     opt_cell_lengths
         Whether to optimize cell vectors, as well as atomic positions, by setting
         `hydrostatic_strain` in the filter function. Default is False.
@@ -186,23 +210,30 @@ def geomopt(
     symmetry_tolerance
         Atom displacement tolerance for spglib symmetry determination, in Å.
         Default is 0.001.
-    file_prefix
-        Prefix for output files, including directories. Default directory is
-        ./janus_results, and default filename prefix is inferred from the input
-        stucture filename.
     out
         Path to save optimized structure, or last structure if optimization did not
         converge. Default is inferred from `file_prefix`.
     write_traj
         Whether to save a trajectory file of optimization frames.
         If traj_kwargs["filename"] is not specified, it is inferred from `file_prefix`.
-    read_kwargs
-        Keyword arguments to pass to ase.io.read. By default,
-            read_kwargs["index"] is -1.
-    calc_kwargs
-        Keyword arguments to pass to the selected calculator. Default is {}.
     minimize_kwargs
         Other keyword arguments to pass to geometry optimizer. Default is {}.
+    arch
+        MLIP architecture to use for geometry optimization.
+        Default is "mace_mp".
+    device
+        Device to run model on. Default is "cpu".
+    model_path
+        Path to MLIP model. Default is `None`.
+    calc_kwargs
+        Keyword arguments to pass to the selected calculator. Default is {}.
+    read_kwargs
+        Keyword arguments to pass to ase.io.read. By default,
+        read_kwargs["index"] is -1.
+    file_prefix
+        Prefix for output files, including directories. Default directory is
+        ./janus_results, and default filename prefix is inferred from the input
+        stucture filename.
     write_kwargs
         Keyword arguments to pass to ase.io.write when saving optimized structure.
         Default is {}.

--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -68,7 +68,7 @@ def _set_minimize_kwargs(
 
 
 @app.command()
-@use_config(yaml_converter_callback)
+@use_config(yaml_converter_callback, param_help="Path to configuration file.")
 def geomopt(
     # numpydoc ignore=PR02
     ctx: Context,

--- a/janus_core/cli/janus.py
+++ b/janus_core/cli/janus.py
@@ -17,7 +17,11 @@ from janus_core.cli.preprocess import preprocess
 from janus_core.cli.singlepoint import singlepoint
 from janus_core.cli.train import train
 
-app = Typer(name="janus", no_args_is_help=True)
+app = Typer(
+    name="janus",
+    no_args_is_help=True,
+    epilog="Try 'janus COMMAND --help' for subcommand options",
+)
 app.command(
     help="Perform single point calculations and save to file.",
     rich_help_panel="Calculations",

--- a/janus_core/cli/janus.py
+++ b/janus_core/cli/janus.py
@@ -51,11 +51,11 @@ app.command(
     rich_help_panel="Calculations",
 )(descriptors)
 app.command(
-    help="Running training for an MLIP.",
+    help="Train or fine-tune an MLIP.",
     rich_help_panel="Training",
 )(train)
 app.command(
-    help="Running preprocessing for an MLIP.",
+    help="Preprocess data before training.",
     rich_help_panel="Training",
 )(preprocess)
 

--- a/janus_core/cli/janus.py
+++ b/janus_core/cli/janus.py
@@ -18,19 +18,42 @@ from janus_core.cli.singlepoint import singlepoint
 from janus_core.cli.train import train
 
 app = Typer(name="janus", no_args_is_help=True)
-app.command(help="Perform single point calculations and save to file.")(singlepoint)
-app.command(help="Perform geometry optimization and save optimized structure to file.")(
-    geomopt
-)
 app.command(
-    help="Run molecular dynamics simulation, and save trajectory and statistics."
+    help="Perform single point calculations and save to file.",
+    rich_help_panel="Calculations",
+)(singlepoint)
+app.command(
+    help="Perform geometry optimization and save optimized structure to file.",
+    rich_help_panel="Calculations",
+)(geomopt)
+app.command(
+    help="Run molecular dynamics simulation, and save trajectory and statistics.",
+    rich_help_panel="Calculations",
 )(md)
-app.command(help="Calculate phonons and save results.")(phonons)
-app.command(help="Calculate equation of state.")(eos)
-app.command(help="Run Nudged Elastic Band method.")(neb)
-app.command(help="Calculate MLIP descriptors.")(descriptors)
-app.command(help="Running training for an MLIP.")(train)
-app.command(help="Running preprocessing for an MLIP.")(preprocess)
+app.command(
+    help="Calculate phonons and save results.",
+    rich_help_panel="Calculations",
+)(phonons)
+app.command(
+    help="Calculate equation of state.",
+    rich_help_panel="Calculations",
+)(eos)
+app.command(
+    help="Run Nudged Elastic Band method.",
+    rich_help_panel="Calculations",
+)(neb)
+app.command(
+    help="Calculate MLIP descriptors.",
+    rich_help_panel="Calculations",
+)(descriptors)
+app.command(
+    help="Running training for an MLIP.",
+    rich_help_panel="Training",
+)(train)
+app.command(
+    help="Running preprocessing for an MLIP.",
+    rich_help_panel="Training",
+)(preprocess)
 
 
 @app.callback(invoke_without_command=True, help="")

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -25,6 +25,7 @@ from janus_core.cli.types import (
     ReadKwargsLast,
     StructPath,
     Summary,
+    Tracker,
     WriteKwargs,
 )
 from janus_core.cli.utils import parse_correlation_kwargs, yaml_converter_callback
@@ -237,9 +238,7 @@ def md(
         Option(help="Random seed for numpy.random and random functions."),
     ] = None,
     log: LogPath = None,
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    tracker: Tracker = True,
     summary: Summary = None,
 ) -> None:
     """

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -66,12 +66,21 @@ def md(
         Option(
             click_type=Choice(get_args(Ensembles)),
             help="Name of thermodynamic ensemble.",
+            rich_help_panel="Calculation",
+            show_default=False,
         ),
     ],
     struct: StructPath,
-    steps: Annotated[int, Option(help="Number of steps in simulation.")] = 0,
-    timestep: Annotated[float, Option(help="Timestep for integrator, in fs.")] = 1.0,
-    temp: Annotated[float, Option(help="Temperature, in K.")] = 300.0,
+    steps: Annotated[
+        int, Option(help="Number of steps in MD simulation.", rich_help_panel="MD")
+    ] = 0,
+    timestep: Annotated[
+        float,
+        Option(help="Timestep for integrator, in fs.", rich_help_panel="Calculation"),
+    ] = 1.0,
+    temp: Annotated[
+        float, Option(help="Temperature, in K.", rich_help_panel="MD")
+    ] = 300.0,
     thermostat_time: Annotated[
         float,
         Option(
@@ -81,7 +90,8 @@ def md(
                 in fs. Default is 50 fs for NPT and NVT Nosé-Hoover, or 100 fs for
                 NPT-MTK.
                 """
-            )
+            ),
+            rich_help_panel="Ensemble configuration",
         ),
     ] = None,
     barostat_time: Annotated[
@@ -92,58 +102,82 @@ def md(
                 Barostat time for NPT, NPT-MTK or NPH simulation, in fs.
                 Default is 75 fs for NPT and NPH, or 1000 fs for NPT-MTK.
                 """
-            )
+            ),
+            rich_help_panel="Ensemble configuration",
         ),
     ] = None,
     bulk_modulus: Annotated[
-        float, Option(help="Bulk modulus for NPT or NPH simulation, in GPa.")
+        float,
+        Option(
+            help="Bulk modulus for NPT or NPH simulation, in GPa.",
+            rich_help_panel="Ensemble configuration",
+        ),
     ] = 2.0,
     pressure: Annotated[
-        float, Option(help="Pressure for NPT or NPH simulation, in GPa.")
+        float,
+        Option(
+            help="Pressure for NPT or NPH simulation, in GPa.",
+            rich_help_panel="Ensemble configuration",
+        ),
     ] = 0.0,
     friction: Annotated[
-        float, Option(help="Friction coefficient for NVT simulation, in fs^-1.")
+        float,
+        Option(
+            help="Friction coefficient for NVT simulation, in fs^-1.",
+            rich_help_panel="Ensemble configuration",
+        ),
     ] = 0.005,
     taut: Annotated[
         float,
         Option(
-            help="Temperature coupling time constant for NVT CSVR simulation, in fs."
+            help="Temperature coupling time constant for NVT CSVR simulation, in fs.",
+            rich_help_panel="Ensemble configuration",
         ),
     ] = 100.0,
     thermostat_chain: Annotated[
         int,
-        Option(help="Number of variables in thermostat chain for NPT MTK simulation."),
+        Option(
+            help="Number of variables in thermostat chain for NPT MTK simulation.",
+            rich_help_panel="Ensemble configuration",
+        ),
     ] = 3,
     barostat_chain: Annotated[
         int,
-        Option(help="Number of variables in barostat chain for NPT MTK simulation."),
+        Option(
+            help="Number of variables in barostat chain for NPT MTK simulation.",
+            rich_help_panel="Ensemble configuration",
+        ),
     ] = 3,
     thermostat_substeps: Annotated[
         int,
         Option(
-            help="Number of sub-steps in thermostat integration for NPT MTK simulation."
+            help=(
+                "Number of sub-steps in thermostat integration for NPT MTK simulation."
+            ),
+            rich_help_panel="Ensemble configuration",
         ),
     ] = 1,
     barostat_substeps: Annotated[
         int,
         Option(
-            help="Number of sub-steps in barostat integration for NPT MTK simulation."
+            help="Number of sub-steps in barostat integration for NPT MTK simulation.",
+            rich_help_panel="Ensemble configuration",
         ),
     ] = 1,
     ensemble_kwargs: EnsembleKwargs = None,
-    arch: Architecture = "mace_mp",
-    device: Device = "cpu",
-    model_path: ModelPath = None,
-    read_kwargs: ReadKwargsLast = None,
-    calc_kwargs: CalcKwargs = None,
     equil_steps: Annotated[
         int,
         Option(
-            help=("Maximum number of steps at which to perform optimization and reset")
+            help="Maximum number of steps at which to perform optimization and reset",
+            rich_help_panel="Calculation",
         ),
     ] = 0,
     minimize: Annotated[
-        bool, Option(help="Whether to minimize structure during equilibration.")
+        bool,
+        Option(
+            help="Whether to minimize structure during equilibration.",
+            rich_help_panel=("Calculation"),
+        ),
     ] = False,
     minimize_every: Annotated[
         int,
@@ -153,36 +187,68 @@ def md(
                 Frequency of minimizations. Default disables minimization after
                 beginning dynamics.
                 """
-            )
+            ),
+            rich_help_panel="Calculation",
         ),
     ] = -1,
     minimize_kwargs: MinimizeKwargs = None,
     rescale_velocities: Annotated[
-        bool, Option(help="Whether to rescale velocities during equilibration.")
+        bool,
+        Option(
+            help="Whether to rescale velocities during equilibration.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     remove_rot: Annotated[
-        bool, Option(help="Whether to remove rotation during equilibration.")
+        bool,
+        Option(
+            help="Whether to remove rotation during equilibration.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     rescale_every: Annotated[
-        int, Option(help="Frequency to rescale velocities during equilibration.")
+        int,
+        Option(
+            help="Frequency to rescale velocities during equilibration.",
+            rich_help_panel="Calculation",
+        ),
     ] = 10,
-    file_prefix: FilePrefix = None,
-    restart: Annotated[bool, Option(help="Whether restarting dynamics.")] = False,
+    restart: Annotated[
+        bool,
+        Option(help="Whether restarting dynamics.", rich_help_panel="Restart files"),
+    ] = False,
     restart_auto: Annotated[
-        bool, Option(help="Whether to infer restart file if restarting dynamics.")
+        bool,
+        Option(
+            help="Whether to infer restart file if restarting dynamics.",
+            rich_help_panel="Restart files",
+        ),
     ] = True,
     restart_stem: Annotated[
         Path | None,
-        Option(help="Stem for restart file name. Default inferred from `file_prefix`."),
+        Option(
+            help="Stem for restart file name. Default inferred from `file_prefix`.",
+            rich_help_panel="Restart files",
+        ),
     ] = None,
     restart_every: Annotated[
-        int, Option(help="Frequency of steps to save restart info.")
+        int,
+        Option(
+            help="Frequency of steps to save restart info.",
+            rich_help_panel="Restart files",
+        ),
     ] = 1000,
     rotate_restart: Annotated[
-        bool, Option(help="Whether to rotate restart files.")
+        bool,
+        Option(
+            help="Whether to rotate restart files.", rich_help_panel="Restart files"
+        ),
     ] = False,
     restarts_to_keep: Annotated[
-        int, Option(help="Restart files to keep if rotating.")
+        int,
+        Option(
+            help="Restart files to keep if rotating.", rich_help_panel="Restart files"
+        ),
     ] = 4,
     final_file: Annotated[
         Path | None,
@@ -192,7 +258,8 @@ def md(
                 File to save final configuration at each temperature of similation.
                 Default inferred from `file_prefix`.
                 """
-            )
+            ),
+            rich_help_panel="Final file",
         ),
     ] = None,
     stats_file: Annotated[
@@ -203,40 +270,87 @@ def md(
                 File to save thermodynamical statistics. Default inferred from
                 `file_prefix`.
                 """
-            )
+            ),
+            rich_help_panel="Statistics file",
         ),
     ] = None,
-    stats_every: Annotated[int, Option(help="Frequency to output statistics.")] = 100,
+    stats_every: Annotated[
+        int,
+        Option(
+            help="Frequency to output statistics.", rich_help_panel="Statistics file"
+        ),
+    ] = 100,
     traj_file: Annotated[
         Path | None,
-        Option(help="File to save trajectory. Default inferred from `file_prefix`."),
+        Option(
+            help="File to save trajectory. Default inferred from `file_prefix`.",
+            rich_help_panel="Trajectory file",
+        ),
     ] = None,
-    traj_append: Annotated[bool, Option(help="Whether to append trajectory.")] = False,
-    traj_start: Annotated[int, Option(help="Step to start saving trajectory.")] = 0,
+    traj_append: Annotated[
+        bool,
+        Option(help="Whether to append trajectory.", rich_help_panel="Trajectory file"),
+    ] = False,
+    traj_start: Annotated[
+        int,
+        Option(
+            help="Step to start saving trajectory.", rich_help_panel="Trajectory file"
+        ),
+    ] = 0,
     traj_every: Annotated[
-        int, Option(help="Frequency of steps to save trajectory.")
+        int,
+        Option(
+            help="Frequency of steps to save trajectory.",
+            rich_help_panel="Trajectory file",
+        ),
     ] = 100,
     temp_start: Annotated[
         float | None,
-        Option(help="Temperature to start heating, in K."),
+        Option(
+            help="Temperature to start heating, in K.",
+            rich_help_panel="Temperature ramp",
+        ),
     ] = None,
     temp_end: Annotated[
         float | None,
-        Option(help="Maximum temperature for heating, in K."),
+        Option(
+            help="Maximum temperature for heating, in K.",
+            rich_help_panel="Temperature ramp",
+        ),
     ] = None,
     temp_step: Annotated[
-        float | None, Option(help="Size of temperature steps when heating, in K.")
+        float | None,
+        Option(
+            help="Size of temperature steps when heating, in K.",
+            rich_help_panel="Temperature ramp",
+        ),
     ] = None,
     temp_time: Annotated[
-        float | None, Option(help="Time between heating steps, in fs.")
+        float | None,
+        Option(
+            help="Time between heating steps, in fs.",
+            rich_help_panel="Temperature ramp",
+        ),
     ] = None,
-    write_kwargs: WriteKwargs = None,
     post_process_kwargs: PostProcessKwargs = None,
     correlation_kwargs: CorrelationKwargs = None,
     seed: Annotated[
         int | None,
-        Option(help="Random seed for numpy.random and random functions."),
+        Option(
+            help="Random seed for numpy.random and random functions.",
+            rich_help_panel="Calculation",
+        ),
     ] = None,
+    # MLIP Calculator
+    arch: Architecture = "mace_mp",
+    device: Device = "cpu",
+    model_path: ModelPath = None,
+    calc_kwargs: CalcKwargs = None,
+    # Structure I/O
+    file_prefix: FilePrefix = None,
+    read_kwargs: ReadKwargsLast = None,
+    write_kwargs: WriteKwargs = None,
+    # Logging/summary
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
@@ -253,7 +367,7 @@ def md(
     struct
         Path of structure to simulate.
     steps
-        Number of steps in simulation. Default is 0.
+        Number of steps in MD simulation. Default is 0.
     timestep
         Timestep for integrator, in fs. Default is 1.0.
     temp

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -57,7 +57,7 @@ def _update_restart_files(summary: Path, restart_files: list[Path]) -> None:
 
 
 @app.command()
-@use_config(yaml_converter_callback)
+@use_config(yaml_converter_callback, param_help="Path to configuration file.")
 def md(
     # numpydoc ignore=PR02
     ctx: Context,

--- a/janus_core/cli/neb.py
+++ b/janus_core/cli/neb.py
@@ -30,7 +30,7 @@ app = Typer()
 
 
 @app.command()
-@use_config(yaml_converter_callback)
+@use_config(yaml_converter_callback, param_help="Path to configuration file.")
 def neb(
     # numpydoc ignore=PR02
     ctx: Context,

--- a/janus_core/cli/neb.py
+++ b/janus_core/cli/neb.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated, get_args
 
 from click import Choice
@@ -20,8 +21,8 @@ from janus_core.cli.types import (
     NebKwargs,
     NebOptKwargs,
     ReadKwargsLast,
-    StructPath,
     Summary,
+    Tracker,
     WriteKwargs,
 )
 from janus_core.cli.utils import yaml_converter_callback
@@ -34,55 +35,87 @@ app = Typer()
 def neb(
     # numpydoc ignore=PR02
     ctx: Context,
-    init_struct: StructPath | None = None,
-    final_struct: StructPath | None = None,
-    band_structs: StructPath | None = None,
+    init_struct: Annotated[
+        Path | None,
+        Option(
+            help="Path of initial structure in band.", rich_help_panel="Calculation"
+        ),
+    ] = None,
+    final_struct: Annotated[
+        Path | None,
+        Option(help="Path of final structure in band.", rich_help_panel="Calculation"),
+    ] = None,
+    band_structs: Annotated[
+        Path | None,
+        Option(help="Path of all band images.", rich_help_panel="Calculation"),
+    ] = None,
     neb_class: Annotated[
         str | None,
-        Option(help="Name of ASE NEB class to use."),
+        Option(help="Name of ASE NEB class to use.", rich_help_panel="Calculation"),
     ] = "NEB",
-    n_images: Annotated[int, Option(help="Number of images to use in NEB.")] = 15,
+    n_images: Annotated[
+        int,
+        Option(help="Number of images to use in NEB.", rich_help_panel="Calculation"),
+    ] = 15,
     write_band: Annotated[
         bool,
-        Option(help="Whether to write out all band images after optimization."),
+        Option(
+            help="Whether to write out all band images after optimization.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
-    write_kwargs: WriteKwargs = None,
     neb_kwargs: NebKwargs = None,
     interpolator: Annotated[
         str | None,
         Option(
             click_type=Choice(["ase", "pymatgen"]),
             help="Choice of interpolation strategy.",
+            rich_help_panel="Calculation",
         ),
     ] = "ase",
     interpolator_kwargs: InterpolationKwargs = None,
     optimizer: Annotated[
         str | None,
-        Option(help="Name of ASE NEB optimizer to use."),
+        Option(help="Name of ASE NEB optimizer to use.", rich_help_panel="Calculation"),
     ] = "NEBOptimizer",
-    fmax: Annotated[float, Option(help="Maximum force for NEB optimizer.")] = 0.1,
+    fmax: Annotated[
+        float,
+        Option(help="Maximum force for NEB optimizer.", rich_help_panel="Calculation"),
+    ] = 0.1,
     steps: Annotated[
-        int, Option(help="Maximum number of steps for optimization.")
+        int,
+        Option(
+            help="Maximum number of steps for optimization.",
+            rich_help_panel="Calculation",
+        ),
     ] = 100,
     optimizer_kwargs: NebOptKwargs = None,
     plot_band: Annotated[
         bool,
-        Option(help="Whether to plot and save NEB band."),
+        Option(
+            help="Whether to plot and save NEB band.", rich_help_panel="Calculation"
+        ),
     ] = False,
     minimize: Annotated[
-        bool, Option(help=" Whether to minimize initial and final structures.")
+        bool,
+        Option(
+            help=" Whether to minimize initial and final structures.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     minimize_kwargs: MinimizeKwargs = None,
+    # MLIP Calculator
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     model_path: ModelPath = None,
-    read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
+    # Structure I/O
     file_prefix: FilePrefix = None,
+    read_kwargs: ReadKwargsLast = None,
+    write_kwargs: WriteKwargs = None,
+    # Logging/summary
     log: LogPath = None,
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    tracker: Tracker = True,
     summary: Summary = None,
 ) -> None:
     """
@@ -108,8 +141,6 @@ def neb(
         Number of images to use in NEB. Default is 15.
     write_band
         Whether to write out all band images after optimization. Default is False.
-    write_kwargs
-        Keyword arguments to pass to ase.io.write when writing images.
     neb_kwargs
         Keyword arguments to pass to neb_class. Default is {}.
     interpolator
@@ -141,15 +172,17 @@ def neb(
         Device to run MLIP model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs
-        Keyword arguments to pass to ase.io.read. By default, read_kwargs["index"]
-        is -1 if using `init_struct` and `final_struct`, or ":" for `band_structs`.
     calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
     file_prefix
         Prefix for output files, including directories. Default directory is
         ./janus_results, and default filename prefix is inferred from the input
         stucture filename.
+    read_kwargs
+        Keyword arguments to pass to ase.io.read. By default, read_kwargs["index"]
+        is -1 if using `init_struct` and `final_struct`, or ":" for `band_structs`.
+    write_kwargs
+        Keyword arguments to pass to ase.io.write when writing images.
     log
         Path to write logs to. Default is inferred from `file_prefix`.
     tracker

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -22,6 +22,7 @@ from janus_core.cli.types import (
     ReadKwargsLast,
     StructPath,
     Summary,
+    Tracker,
 )
 from janus_core.cli.utils import yaml_converter_callback
 
@@ -41,19 +42,27 @@ def phonons(
             "in one of three forms: single integer ('2'), which specifies all "
             "diagonal elements; three integers ('1 2 3'), which specifies each "
             "individual diagonal element; or nine values ('1 2 3 4 5 6 7 8 9'), "
-            "which specifies all elements, filling the matrix row-wise."
+            "which specifies all elements, filling the matrix row-wise.",
+            rich_help_panel="Calculation",
         ),
     ] = "2 2 2",
     displacement: Annotated[
-        float, Option(help="Displacement for force constants calculation, in A.")
+        float,
+        Option(
+            help="Displacement for force constants calculation, in A.",
+            rich_help_panel="Calculation",
+        ),
     ] = 0.01,
     displacement_kwargs: DisplacementKwargs = None,
     mesh: Annotated[
-        tuple[int, int, int], Option(help="Mesh numbers along a, b, c axes.")
+        tuple[int, int, int],
+        Option(help="Mesh numbers along a, b, c axes.", rich_help_panel="Calculation"),
     ] = (10, 10, 10),
     bands: Annotated[
         bool,
-        Option(help="Whether to compute band structure."),
+        Option(
+            help="Whether to compute band structure.", rich_help_panel="Calculation"
+        ),
     ] = False,
     n_qpoints: Annotated[
         int,
@@ -61,7 +70,8 @@ def phonons(
             help=(
                 "Number of q-points to sample along generated path, including end "
                 "points. Unused if `qpoint_file` is specified"
-            )
+            ),
+            rich_help_panel="Calculation",
         ),
     ] = 51,
     qpoint_file: Annotated[
@@ -70,44 +80,82 @@ def phonons(
             help=(
                 "Path to yaml file with info to generate a path of q-points for band "
                 "structure."
-            )
+            ),
+            rich_help_panel="Calculation",
         ),
     ] = None,
-    dos: Annotated[bool, Option(help="Whether to calculate the DOS.")] = False,
+    dos: Annotated[
+        bool,
+        Option(help="Whether to calculate the DOS.", rich_help_panel="DOS"),
+    ] = False,
     dos_kwargs: DoSKwargs = None,
-    pdos: Annotated[bool, Option(help="Whether to calculate the PDOS.")] = False,
+    pdos: Annotated[
+        bool,
+        Option(help="Whether to calculate the PDOS.", rich_help_panel="PDOS"),
+    ] = False,
     pdos_kwargs: PDoSKwargs = None,
     thermal: Annotated[
-        bool, Option(help="Whether to calculate thermal properties.")
+        bool,
+        Option(
+            help="Whether to calculate thermal properties.",
+            rich_help_panel="Thermal Properties",
+        ),
     ] = False,
     temp_min: Annotated[
         float,
-        Option(help="Start temperature for thermal properties calculations, in K."),
+        Option(
+            help="Start temperature for thermal properties calculations, in K.",
+            rich_help_panel="Thermal Properties",
+        ),
     ] = 0.0,
     temp_max: Annotated[
         float,
-        Option(help="End temperature for thermal properties calculations, in K."),
+        Option(
+            help="End temperature for thermal properties calculations, in K.",
+            rich_help_panel="Thermal Properties",
+        ),
     ] = 1000.0,
     temp_step: Annotated[
         float,
-        Option(help="Temperature step for thermal properties calculations, in K."),
+        Option(
+            help="Temperature step for thermal properties calculations, in K.",
+            rich_help_panel="Thermal Properties",
+        ),
     ] = 50,
     symmetrize: Annotated[
-        bool, Option(help="Whether to symmetrize force constants.")
+        bool,
+        Option(
+            help="Whether to symmetrize force constants.", rich_help_panel="Calculation"
+        ),
     ] = False,
     minimize: Annotated[
-        bool, Option(help="Whether to minimize structure before calculations.")
+        bool,
+        Option(
+            help="Whether to minimize structure before calculations.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     fmax: Annotated[
-        float, Option(help="Maximum force for optimization convergence.")
+        float,
+        Option(
+            help="Maximum force for optimization convergence.",
+            rich_help_panel="Calculation",
+        ),
     ] = 0.1,
     minimize_kwargs: MinimizeKwargs = None,
     hdf5: Annotated[
-        bool, Option(help="Whether to save force constants in hdf5.")
+        bool,
+        Option(
+            help="Whether to save force constants in hdf5.",
+            rich_help_panel="Calculation",
+        ),
     ] = True,
     plot_to_file: Annotated[
         bool,
-        Option(help="Whether to plot band structure and/or dos/pdos when calculated."),
+        Option(
+            help="Whether to plot band structure and/or dos/pdos when calculated.",
+            rich_help_panel="Calculation",
+        ),
     ] = False,
     write_full: Annotated[
         bool,
@@ -115,18 +163,17 @@ def phonons(
             help=(
                 "Whether to write eigenvectors, group velocities, etc. to bands file."
             ),
+            rich_help_panel="Calculation",
         ),
     ] = True,
     arch: Architecture = "mace_mp",
     device: Device = "cpu",
     model_path: ModelPath = None,
-    read_kwargs: ReadKwargsLast = None,
     calc_kwargs: CalcKwargs = None,
     file_prefix: FilePrefix = None,
+    read_kwargs: ReadKwargsLast = None,
     log: LogPath = None,
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    tracker: Tracker = True,
     summary: Summary = None,
 ) -> None:
     """
@@ -200,15 +247,15 @@ def phonons(
         Device to run model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
-    read_kwargs
-        Keyword arguments to pass to ase.io.read. By default,
-            read_kwargs["index"] is 0.
     calc_kwargs
         Keyword arguments to pass to the selected calculator. Default is {}.
     file_prefix
         Prefix for output files, including directories. Default directory is
         ./janus_results, and default filename prefix is inferred from the input
         stucture filename.
+    read_kwargs
+        Keyword arguments to pass to ase.io.read. By default,
+            read_kwargs["index"] is 0.
     log
         Path to write logs to. Default is inferred from `file_prefix`.
     tracker

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -29,7 +29,7 @@ app = Typer()
 
 
 @app.command()
-@use_config(yaml_converter_callback)
+@use_config(yaml_converter_callback, param_help="Path to configuration file.")
 def phonons(
     # numpydoc ignore=PR02
     ctx: Context,

--- a/janus_core/cli/preprocess.py
+++ b/janus_core/cli/preprocess.py
@@ -7,26 +7,27 @@ from typing import Annotated
 
 from typer import Option, Typer
 
+from janus_core.cli.types import Tracker
+
 app = Typer()
 
 
 @app.command()
 def preprocess(
     mlip_config: Annotated[
-        Path, Option(help="Configuration file to pass to MLIP CLI.")
+        Path, Option(help="Configuration file to pass to MLIP CLI.", show_default=False)
     ],
-    log: Annotated[Path, Option(help="Path to save logs to.")] = Path(
-        "./janus_results/preprocess-log.yml"
-    ),
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    log: Annotated[
+        Path, Option(help="Path to save logs to.", rich_help_panel="Logging/summary")
+    ] = Path("./janus_results/preprocess-log.yml"),
+    tracker: Tracker = True,
     summary: Annotated[
         Path,
         Option(
             help=(
                 "Path to save summary of inputs, start/end time, and carbon emissions."
-            )
+            ),
+            rich_help_panel="Logging/summary",
         ),
     ] = Path("./janus_results/preprocess-summary.yml"),
 ):

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -19,6 +19,7 @@ from janus_core.cli.types import (
     ReadKwargsAll,
     StructPath,
     Summary,
+    Tracker,
     WriteKwargs,
 )
 from janus_core.cli.utils import yaml_converter_callback
@@ -32,10 +33,8 @@ app = Typer()
 def singlepoint(
     # numpydoc ignore=PR02
     ctx: Context,
+    # Calculation
     struct: StructPath,
-    arch: Architecture = "mace_mp",
-    device: Device = "cpu",
-    model_path: ModelPath = None,
     properties: Annotated[
         list[str] | None,
         Option(
@@ -44,9 +43,9 @@ def singlepoint(
                 "Properties to calculate. If not specified, 'energy', 'forces' "
                 "and 'stress' will be returned."
             ),
+            rich_help_panel="Calculation",
         ),
     ] = None,
-    file_prefix: FilePrefix = None,
     out: Annotated[
         Path | None,
         Option(
@@ -54,15 +53,21 @@ def singlepoint(
                 "Path to save structure with calculated results. Default is inferred "
                 "from `file_prefix`."
             ),
+            rich_help_panel="Calculation",
         ),
     ] = None,
-    read_kwargs: ReadKwargsAll = None,
+    # MLIP Calculator
+    arch: Architecture = "mace_mp",
+    device: Device = "cpu",
+    model_path: ModelPath = None,
     calc_kwargs: CalcKwargs = None,
+    # Structure I/O
+    file_prefix: FilePrefix = None,
+    read_kwargs: ReadKwargsAll = None,
     write_kwargs: WriteKwargs = None,
+    # Logging and summary
     log: LogPath = None,
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
+    tracker: Tracker = True,
     summary: Summary = None,
 ) -> None:
     """
@@ -74,6 +79,11 @@ def singlepoint(
         Typer (Click) Context. Automatically set.
     struct
         Path of structure to simulate.
+    properties
+        Physical properties to calculate. Default is ("energy", "forces", "stress").
+    out
+        Path to save structure with calculated results. Default is inferred from
+        `file_prefix`.
     arch
         MLIP architecture to use for single point calculations.
         Default is "mace_mp".
@@ -81,20 +91,15 @@ def singlepoint(
         Device to run model on. Default is "cpu".
     model_path
         Path to MLIP model. Default is `None`.
-    properties
-        Physical properties to calculate. Default is ("energy", "forces", "stress").
+    calc_kwargs
+        Keyword arguments to pass to the selected calculator. Default is {}.
+    read_kwargs
+        Keyword arguments to pass to ase.io.read. By default,
+            read_kwargs["index"] is ":".
     file_prefix
         Prefix for output files, including directories. Default directory is
         ./janus_results, and default filename prefix is inferred from the input
         stucture filename.
-    out
-        Path to save structure with calculated results. Default is inferred from
-        `file_prefix`.
-    read_kwargs
-        Keyword arguments to pass to ase.io.read. By default,
-            read_kwargs["index"] is ":".
-    calc_kwargs
-        Keyword arguments to pass to the selected calculator. Default is {}.
     write_kwargs
         Keyword arguments to pass to ase.io.write when saving results. Default is {}.
     log

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -28,7 +28,7 @@ app = Typer()
 
 
 @app.command()
-@use_config(yaml_converter_callback)
+@use_config(yaml_converter_callback, param_help="Path to configuration file.")
 def singlepoint(
     # numpydoc ignore=PR02
     ctx: Context,

--- a/janus_core/cli/train.py
+++ b/janus_core/cli/train.py
@@ -8,31 +8,22 @@ from typing import Annotated
 from typer import Option, Typer
 import yaml
 
+from janus_core.cli.types import LogPath, Summary, Tracker
+
 app = Typer()
 
 
 @app.command()
 def train(
     mlip_config: Annotated[
-        Path, Option(help="Configuration file to pass to MLIP CLI.")
+        Path, Option(help="Configuration file to pass to MLIP CLI.", show_default=False)
     ],
     fine_tune: Annotated[
         bool, Option(help="Whether to fine-tune a foundational model.")
     ] = False,
-    log: Annotated[Path, Option(help="Path to save logs to.")] = Path(
-        "./janus_results/train-log.yml"
-    ),
-    tracker: Annotated[
-        bool, Option(help="Whether to save carbon emissions of calculation")
-    ] = True,
-    summary: Annotated[
-        Path,
-        Option(
-            help=(
-                "Path to save summary of inputs, start/end time, and carbon emissions."
-            )
-        ),
-    ] = Path("./janus_results/train-summary.yml"),
+    log: LogPath = Path("./janus_results/train-log.yml"),
+    tracker: Tracker = True,
+    summary: Summary = Path("./janus_results/train-summary.yml"),
 ) -> None:
     """
     Run training for MLIP by passing a configuration file to the MLIP's CLI.

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -67,7 +67,14 @@ class TyperDict:
         return f"<TyperDict: value={self.value}>"
 
 
-StructPath = Annotated[Path, Option(help="Path of structure to simulate.")]
+StructPath = Annotated[
+    Path,
+    Option(
+        help="Path of structure to simulate.",
+        show_default=False,
+        rich_help_panel="Calculation",
+    ),
+]
 
 Architecture = Annotated[
     str | None,
@@ -87,7 +94,9 @@ Device = Annotated[
 ]
 ModelPath = Annotated[
     str | None,
-    Option(help="Path to MLIP model.", rich_help_panel="MLIP calculator"),
+    Option(
+        help="MLIP model name, or path to model.", rich_help_panel="MLIP calculator"
+    ),
 ]
 
 FilePrefix = Annotated[
@@ -99,7 +108,8 @@ FilePrefix = Annotated[
                 ./janus_results, and default filename prefix is inferred from the
                 input stucture filename.
                 """
-        )
+        ),
+        rich_help_panel="Structure I/O",
     ),
 ]
 
@@ -115,6 +125,7 @@ ReadKwargsAll = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Structure I/O",
     ),
 ]
 
@@ -130,6 +141,7 @@ ReadKwargsLast = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Structure I/O",
     ),
 ]
 
@@ -140,11 +152,11 @@ CalcKwargs = Annotated[
         help=(
             """
             Keyword arguments to pass to selected calculator. Must be passed as a
-            dictionary wrapped in quotes, e.g. "{'key': value}". For the default
-            architecture ('mace_mp'), "{'model': 'small'}" is set unless overwritten.
+            dictionary wrapped in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",
+        rich_help_panel="MLIP calculator",
     ),
 ]
 
@@ -154,25 +166,12 @@ WriteKwargs = Annotated[
         parser=parse_dict_class,
         help=(
             """
-            Keyword arguments to pass to ase.io.write when saving results. Must be
-            passed as a dictionary wrapped in quotes, e.g. "{'key': value}".
+            Keyword arguments to pass to ase.io.write when saving any structures. Must
+            be passed as a dictionary wrapped in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",
-    ),
-]
-
-OptKwargs = Annotated[
-    TyperDict | None,
-    Option(
-        parser=parse_dict_class,
-        help=(
-            """
-            Keyword arguments to pass to optimizer. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key': value}".
-            """
-        ),
-        metavar="DICT",
+        rich_help_panel="Structure I/O",
     ),
 ]
 
@@ -187,6 +186,7 @@ MinimizeKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -196,11 +196,12 @@ DoSKwargs = Annotated[
         parser=parse_dict_class,
         help=(
             """
-            Keyword arguments to pass to run_total_dos. Must be passed as a dictionary
+            Keyword arguments to pass to `run_total_dos`. Must be passed as a dictionary
             wrapped in quotes, e.g. "{'key' : value}".
             """
         ),
         metavar="DICT",
+        rich_help_panel="DOS",
     ),
 ]
 
@@ -210,11 +211,12 @@ PDoSKwargs = Annotated[
         parser=parse_dict_class,
         help=(
             """
-            Keyword arguments to pass to run_projected_dos. Must be passed as a
+            Keyword arguments to pass to `run_projected_dos`. Must be passed as a
             dictionary wrapped in quotes, e.g. "{'key' : value}".
             """
         ),
         metavar="DICT",
+        rich_help_panel="PDOS",
     ),
 ]
 
@@ -229,6 +231,7 @@ EnsembleKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Ensemble configuration",
     ),
 ]
 
@@ -243,6 +246,7 @@ DisplacementKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -257,6 +261,7 @@ PostProcessKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -271,6 +276,7 @@ NebKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -285,6 +291,7 @@ NebOptKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -299,6 +306,7 @@ InterpolationKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -313,6 +321,7 @@ PostProcessKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -328,6 +337,7 @@ CorrelationKwargs = Annotated[
             """
         ),
         metavar="DICT",
+        rich_help_panel="Calculation",
     ),
 ]
 
@@ -335,7 +345,7 @@ LogPath = Annotated[
     Path | None,
     Option(
         help="Path to save logs to. Default is inferred from `file_prefix`",
-        rich_help_panel="Logging",
+        rich_help_panel="Logging/summary",
     ),
 ]
 
@@ -343,7 +353,7 @@ Tracker = Annotated[
     bool,
     Option(
         help="Whether to save carbon emissions of calculation",
-        rich_help_panel="Logging",
+        rich_help_panel="Logging/summary",
     ),
 ]
 
@@ -353,6 +363,7 @@ Summary = Annotated[
         help=(
             "Path to save summary of inputs, start/end time, and carbon emissions. "
             "Default is inferred from `file_prefix`."
-        )
+        ),
+        rich_help_panel="Logging/summary",
     ),
 ]

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -74,6 +74,7 @@ Architecture = Annotated[
     Option(
         click_type=Choice(get_args(Architectures)),
         help="MLIP architecture to use for calculations.",
+        rich_help_panel="MLIP calculator",
     ),
 ]
 Device = Annotated[
@@ -81,9 +82,13 @@ Device = Annotated[
     Option(
         click_type=Choice(get_args(Devices)),
         help="Device to run calculations on.",
+        rich_help_panel="MLIP calculator",
     ),
 ]
-ModelPath = Annotated[str | None, Option(help="Path to MLIP model.")]
+ModelPath = Annotated[
+    str | None,
+    Option(help="Path to MLIP model.", rich_help_panel="MLIP calculator"),
+]
 
 FilePrefix = Annotated[
     Path | None,
@@ -328,7 +333,18 @@ CorrelationKwargs = Annotated[
 
 LogPath = Annotated[
     Path | None,
-    Option(help=("Path to save logs to. Default is inferred from `file_prefix`")),
+    Option(
+        help="Path to save logs to. Default is inferred from `file_prefix`",
+        rich_help_panel="Logging",
+    ),
+]
+
+Tracker = Annotated[
+    bool,
+    Option(
+        help="Whether to save carbon emissions of calculation",
+        rich_help_panel="Logging",
+    ),
 ]
 
 Summary = Annotated[


### PR DESCRIPTION
Resolves #484

I'm very open to alternative names/groupings, but at the moment I use "Calculations" for most calculation-specific options, "MLIP calculator" for calculator options, and "Structure I/O" for the most general structure input/output options.

One question is whether it makes sense to make the I/O section a bit broader, to include calculation-specific I/O e.g. `out`, `write-traj`, `plot-to-file`, etc, or keep it to only the most general ones as I have so far.

Outputs are along the lines of:

```
 Usage: janus singlepoint [OPTIONS]                                                                                                                                                                             
                                                                                                                                                                                                                
 Perform single point calculations and save to file.                                                                                                                                                            
                                                                                                                                                                                                                
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --config        TEXT  Path to configuration file.                                                                                                                                                            │
│ --help                Show this message and exit.                                                                                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Calculation ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *  --struct            PATH                            Path of structure to simulate. [required]                                                                                                             │
│    --properties        [energy|stress|forces|hessian]  Properties to calculate. If not specified, 'energy', 'forces' and 'stress' will be returned. [default: None]                                          │
│    --out               PATH                            Path to save structure with calculated results. Default is inferred from `file_prefix`. [default: None]                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ MLIP calculator ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --arch               [mace|mace_mp|mace_off|m3gnet|chgnet|alignn|sevennet|nequip|dpa3|orb|mattersim]  MLIP architecture to use for calculations. [default: mace_mp]                                          │
│ --device             [cpu|cuda|mps|xpu]                                                               Device to run calculations on. [default: cpu]                                                          │
│ --model-path         TEXT                                                                             MLIP model name, or path to model. [default: None]                                                     │
│ --calc-kwargs        DICT                                                                             Keyword arguments to pass to selected calculator. Must be passed as a dictionary wrapped in quotes,    │
│                                                                                                       e.g. "{'key': value}".                                                                                 │
│                                                                                                       [default: None]                                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Structure I/O ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --file-prefix         PATH  Prefix for output files, including directories. Default directory is ./janus_results, and default filename prefix is inferred from the input stucture filename. [default: None]  │
│ --read-kwargs         DICT  Keyword arguments to pass to ase.io.read. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}". By default, read_kwargs['index'] = ':', so all structures are │
│                             read.                                                                                                                                                                            │
│                             [default: None]                                                                                                                                                                  │
│ --write-kwargs        DICT  Keyword arguments to pass to ase.io.write when saving any structures. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}". [default: None]                   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Logging/summary ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --log                        PATH  Path to save logs to. Default is inferred from `file_prefix` [default: None]                                                                                              │
│ --tracker    --no-tracker          Whether to save carbon emissions of calculation [default: tracker]                                                                                                        │
│ --summary                    PATH  Path to save summary of inputs, start/end time, and carbon emissions. Default is inferred from `file_prefix`. [default: None]                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

and in some cases, I group things a little more e.g.

```
 Usage: janus md [OPTIONS]                                                                                                                                                                                                                    
                                                                                                                                                                                                                                              
 Run molecular dynamics simulation, and save trajectory and statistics.                                                                                                                                                                       
                                                                                                                                                                                                                                              
╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --config        TEXT  Path to configuration file.                                                                                                                                                                                          │
│ --help                Show this message and exit.                                                                                                                                                                                          │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Calculation ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ *  --ensemble                                          [nph|npt|nve|nvt|nvt-nh|nvt-csvr|npt-mtk]  Name of thermodynamic ensemble. [required]                                                                                               │
│ *  --struct                                            PATH                                       Path of structure to simulate. [required]                                                                                                │
│    --timestep                                          FLOAT                                      Timestep for integrator, in fs. [default: 1.0]                                                                                           │
│    --equil-steps                                       INTEGER                                    Maximum number of steps at which to perform optimization and reset [default: 0]                                                          │
│    --minimize               --no-minimize                                                         Whether to minimize structure during equilibration. [default: no-minimize]                                                               │
│    --minimize-every                                    INTEGER                                    Frequency of minimizations. Default disables minimization after beginning dynamics. [default: -1]                                        │
│    --minimize-kwargs                                   DICT                                       Keyword arguments to pass to optimizer. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}". [default: None]         │
│    --rescale-velocities     --no-rescale-velocities                                               Whether to rescale velocities during equilibration. [default: no-rescale-velocities]                                                     │
│    --remove-rot             --no-remove-rot                                                       Whether to remove rotation during equilibration. [default: no-remove-rot]                                                                │
│    --rescale-every                                     INTEGER                                    Frequency to rescale velocities during equilibration. [default: 10]                                                                      │
│    --post-process-kwargs                               DICT                                       Keyword arguments to pass to post-processer. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}". [default: None]    │
│    --correlation-kwargs                                DICT                                       Keyword arguments to pass to md for on-the-fly correlations. Must be passed as a list of dictionaries wrapped in quotes, e.g. "[{'key' : │
│                                                                                                   values}]".                                                                                                                               │
│                                                                                                   [default: None]                                                                                                                          │
│    --seed                                              INTEGER                                    Random seed for numpy.random and random functions. [default: None]                                                                       │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ MD ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --steps        INTEGER  Number of steps in MD simulation. [default: 0]                                                                                                                                                                     │
│ --temp         FLOAT    Temperature, in K. [default: 300.0]                                                                                                                                                                                │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Ensemble configuration ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --thermostat-time            FLOAT    Thermostat time for NPT, NPT-MTK or NVT Nosé-Hoover simulation, in fs. Default is 50 fs for NPT and NVT Nosé-Hoover, or 100 fs for NPT-MTK. [default: None]                                          │
│ --barostat-time              FLOAT    Barostat time for NPT, NPT-MTK or NPH simulation, in fs. Default is 75 fs for NPT and NPH, or 1000 fs for NPT-MTK. [default: None]                                                                   │
│ --bulk-modulus               FLOAT    Bulk modulus for NPT or NPH simulation, in GPa. [default: 2.0]                                                                                                                                       │
│ --pressure                   FLOAT    Pressure for NPT or NPH simulation, in GPa. [default: 0.0]                                                                                                                                           │
│ --friction                   FLOAT    Friction coefficient for NVT simulation, in fs^-1. [default: 0.005]                                                                                                                                  │
│ --taut                       FLOAT    Temperature coupling time constant for NVT CSVR simulation, in fs. [default: 100.0]                                                                                                                  │
│ --thermostat-chain           INTEGER  Number of variables in thermostat chain for NPT MTK simulation. [default: 3]                                                                                                                         │
│ --barostat-chain             INTEGER  Number of variables in barostat chain for NPT MTK simulation. [default: 3]                                                                                                                           │
│ --thermostat-substeps        INTEGER  Number of sub-steps in thermostat integration for NPT MTK simulation. [default: 1]                                                                                                                   │
│ --barostat-substeps          INTEGER  Number of sub-steps in barostat integration for NPT MTK simulation. [default: 1]                                                                                                                     │
│ --ensemble-kwargs            DICT     Keyword arguments to pass to ensemble initialization. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}". [default: None]                                                       │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Restart files ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --restart             --no-restart                    Whether restarting dynamics. [default: no-restart]                                                                                                                                   │
│ --restart-auto        --no-restart-auto               Whether to infer restart file if restarting dynamics. [default: restart-auto]                                                                                                        │
│ --restart-stem                               PATH     Stem for restart file name. Default inferred from `file_prefix`. [default: None]                                                                                                     │
│ --restart-every                              INTEGER  Frequency of steps to save restart info. [default: 1000]                                                                                                                             │
│ --rotate-restart      --no-rotate-restart             Whether to rotate restart files. [default: no-rotate-restart]                                                                                                                        │
│ --restarts-to-keep                           INTEGER  Restart files to keep if rotating. [default: 4]                                                                                                                                      │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Final file ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --final-file        PATH  File to save final configuration at each temperature of similation. Default inferred from `file_prefix`. [default: None]                                                                                         │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Statistics file ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --stats-file         PATH     File to save thermodynamical statistics. Default inferred from `file_prefix`. [default: None]                                                                                                                │
│ --stats-every        INTEGER  Frequency to output statistics. [default: 100]                                                                                                                                                               │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Trajectory file ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --traj-file                          PATH     File to save trajectory. Default inferred from `file_prefix`. [default: None]                                                                                                                │
│ --traj-append    --no-traj-append             Whether to append trajectory. [default: no-traj-append]                                                                                                                                      │
│ --traj-start                         INTEGER  Step to start saving trajectory. [default: 0]                                                                                                                                                │
│ --traj-every                         INTEGER  Frequency of steps to save trajectory. [default: 100]                                                                                                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Temperature ramp ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --temp-start        FLOAT  Temperature to start heating, in K. [default: None]                                                                                                                                                             │
│ --temp-end          FLOAT  Maximum temperature for heating, in K. [default: None]                                                                                                                                                          │
│ --temp-step         FLOAT  Size of temperature steps when heating, in K. [default: None]                                                                                                                                                   │
│ --temp-time         FLOAT  Time between heating steps, in fs. [default: None]                                                                                                                                                              │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ MLIP calculator ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --arch               [mace|mace_mp|mace_off|m3gnet|chgnet|alignn|sevennet|nequip|dpa3|orb|mattersim]  MLIP architecture to use for calculations. [default: mace_mp]                                                                        │
│ --device             [cpu|cuda|mps|xpu]                                                               Device to run calculations on. [default: cpu]                                                                                        │
│ --model-path         TEXT                                                                             MLIP model name, or path to model. [default: None]                                                                                   │
│ --calc-kwargs        DICT                                                                             Keyword arguments to pass to selected calculator. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}".           │
│                                                                                                       [default: None]                                                                                                                      │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Structure I/O ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --file-prefix         PATH  Prefix for output files, including directories. Default directory is ./janus_results, and default filename prefix is inferred from the input stucture filename. [default: None]                                │
│ --read-kwargs         DICT  Keyword arguments to pass to ase.io.read. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}". By default, read_kwargs['index'] = -1, so only the last structure is read. [default: None]  │
│ --write-kwargs        DICT  Keyword arguments to pass to ase.io.write when saving any structures. Must be passed as a dictionary wrapped in quotes, e.g. "{'key': value}". [default: None]                                                 │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Logging/summary ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --log                        PATH  Path to save logs to. Default is inferred from `file_prefix` [default: None]                                                                                                                            │
│ --tracker    --no-tracker          Whether to save carbon emissions of calculation [default: tracker]                                                                                                                                      │
│ --summary                    PATH  Path to save summary of inputs, start/end time, and carbon emissions. Default is inferred from `file_prefix`. [default: None]                                                                           │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```