### PR TITLE
Fix Python tutorials for Colab

### DIFF
--- a/docs/source/tutorials/python/eos.ipynb
+++ b/docs/source/tutorials/python/eos.ipynb
@@ -38,7 +38,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {

--- a/docs/source/tutorials/python/geom_opt.ipynb
+++ b/docs/source/tutorials/python/geom_opt.ipynb
@@ -38,7 +38,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {

--- a/docs/source/tutorials/python/md.ipynb
+++ b/docs/source/tutorials/python/md.ipynb
@@ -38,7 +38,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {

--- a/docs/source/tutorials/python/neb.ipynb
+++ b/docs/source/tutorials/python/neb.ipynb
@@ -71,7 +71,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {

--- a/docs/source/tutorials/python/phonons.ipynb
+++ b/docs/source/tutorials/python/phonons.ipynb
@@ -38,7 +38,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {

--- a/docs/source/tutorials/python/single_point.ipynb
+++ b/docs/source/tutorials/python/single_point.ipynb
@@ -47,7 +47,10 @@
    "source": [
     "# import locale\n",
     "# locale.getpreferredencoding = lambda: \"UTF-8\"\n",
-    "# !python3 -m pip install janus-core[all] data-tutorials"
+    "\n",
+    "# ! pip uninstall torch torchaudio torchvision numpy -y\n",
+    "# ! uv pip install janus-core[all] data-tutorials torch==2.5.1 --system\n",
+    "# get_ipython().kernel.do_shutdown(restart=True)"
    ]
   },
   {


### PR DESCRIPTION
Adds Colab torch/numpy fixes for Python tutorials, as introduced in #492 for the CLI equivalents.