### PR TITLE
Check exact and fuzzy matches in Stats

### DIFF
--- a/janus_core/helpers/stats.py
+++ b/janus_core/helpers/stats.py
@@ -7,6 +7,7 @@ from difflib import get_close_matches
 from functools import singledispatchmethod
 import re
 from typing import TypeVar
+from warnings import warn
 
 from numpy import float64, genfromtxt, zeros
 from numpy.typing import NDArray
@@ -73,10 +74,15 @@ class Stats:
     @_getind.register
     def _(self, lab: str) -> int:  # numpydoc ignore=GL08
         labels = [label.lower() for label in self.labels]
-        match = get_close_matches(lab.lower(), labels, n=1)
-        if len(match) == 0:
+        if lab.lower() in labels:
+            return labels.index(lab.lower())
+        matches = get_close_matches(lab.lower(), labels)
+        if len(matches) == 0:
             raise IndexError(f"{lab} not found in labels")
-        return labels.index(match[0])
+        if len(matches) > 1:
+            warn(f"multiple matches found for label {lab}: {matches}", stacklevel=2)
+
+        return labels.index(matches[0])
 
     @singledispatchmethod
     def __getitem__(self, ind) -> NDArray[float64]:

--- a/janus_core/helpers/stats.py
+++ b/janus_core/helpers/stats.py
@@ -71,17 +71,21 @@ class Stats:
 
     @_getind.register
     def _(self, lab: str) -> int:  # numpydoc ignore=GL08
-        # Case-insensitive fuzzy match, only has to be `in` the labels
-        index = next(
-            (
-                index
-                for index, label in enumerate(self.labels)
-                if lab.lower() in label.lower()
-            ),
-            None,
-        )
-        if index is None:
-            raise IndexError(f"{lab} not found in labels")
+        fuzzy_matches = []
+        for index, label in enumerate(self.labels):
+            # Exact (case-insensitive) match.
+            if lab.lower() == label.lower():
+                return index
+            if lab.lower() in label.lower():
+                fuzzy_matches.append((index, label.lower()))
+        # Case-insensitive fuzzy match, only has to be `in` the labels.
+        if len(fuzzy_matches) == 1:
+            # A unique fuzzy match.
+            return fuzzy_matches[0][0]
+        if len(fuzzy_matches) > 1:
+            # Fuzzy match to the shortest label (e.g. 'Time' vs. 'Real_time').
+            return sorted(fuzzy_matches, key=lambda x: len(x[1]))[0][0]
+        raise IndexError(f"{lab} not found in labels")
         return index
 
     @singledispatchmethod

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -76,6 +76,23 @@ class TestStats:
         """Test getitem indexing working correctly."""
         assert (self.data[ind] == self.data.data[:, expectedcol]).all()
 
+    @pytest.mark.parametrize(
+        "label, expectedindex",
+        (
+            ("Time", 2),
+            ("time", 2),
+            ("ti", 2),
+            ("real", 1),
+            ("pxx", 10),
+            ("vol", 8),
+            ("T", 5),
+            ("p", 9),
+        ),
+    )
+    def test_str_getitem(self, label, expectedindex):
+        """Test getitem from a str."""
+        assert self.data._getind(label) == expectedindex
+
     def test_repr(self, capsys):
         """Test repr working correctly."""
         print(self.data)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -93,6 +93,12 @@ class TestStats:
         """Test getitem from a str."""
         assert self.data._getind(label) == expectedindex
 
+    @pytest.mark.parametrize("label", ("px", "ti", "Target"))
+    def test_str_getitem_warns(self, label):
+        """Test warnings issued from ambiguous getitem."""
+        with pytest.warns(UserWarning, match="multiple matches found for label"):
+            self.data._getind(label)
+
     def test_repr(self, capsys):
         """Test repr working correctly."""
         print(self.data)


### PR DESCRIPTION
This is perhaps one way to address #442

I think there are 3 points:

- 'Exact' (case insensitive) matches should always work e.g. ```t``` or ```T``` should match ```t``` (temperature) rather that ```Step```. Currently I don't think you can get temperature from a string since ```'t'``` always goes to step and the units are stripped so ```'T [K]'``` throws ```IndexError: T K not found in labels```.
- Fuzzy matching should be preserved, it is useful to keep 'vol' returning Volume I think.
- But what to do about multiple fuzzy matches?  Currently I return the shortest matching key (so ```'TI'``` matches ```'Time'``` not ```'Real Time'```.

Maybe there are better ways to handle multiple fuzzy matches?