### PR TITLE
Update Orb

### DIFF
--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -8,6 +8,7 @@ Similar in spirit to matcalc and quacc approaches
 
 from __future__ import annotations
 
+from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, get_args
 
@@ -71,9 +72,7 @@ def _set_model_path(
 
 def _set_no_weights_only_load():
     """Set environment variable to fix models for torch 2.6."""
-    import os
-
-    os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
+    environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
 
 
 def choose_calculator(

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -69,6 +69,13 @@ def _set_model_path(
     return model_path
 
 
+def _set_no_weights_only_load():
+    """Set environment variable to fix models for torch 2.6."""
+    import os
+
+    os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
+
+
 def choose_calculator(
     arch: Architectures = "mace",
     device: Devices = "cpu",
@@ -105,6 +112,9 @@ def choose_calculator(
 
     if device not in get_args(Devices):
         raise ValueError(f"`device` must be one of: {get_args(Devices)}")
+
+    # Fix torch 2.6 (must be before MLIP modules are loaded)
+    _set_no_weights_only_load()
 
     if arch == "mace":
         from mace import __version__

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -268,7 +268,7 @@ def choose_calculator(
         import orb_models.forcefield.pretrained as orb_ff
 
         # Default model
-        model_path = model_path if model_path else "orb_v2"
+        model_path = model_path if model_path else "orb_v3_conservative_20_omat"
 
         if isinstance(model_path, DirectForcefieldRegressor):
             model = model_path

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -264,22 +264,22 @@ def choose_calculator(
     elif arch == "orb":
         from orb_models import __version__
         from orb_models.forcefield.calculator import ORBCalculator
-        from orb_models.forcefield.graph_regressor import GraphRegressor
+        from orb_models.forcefield.direct_regressor import DirectForcefieldRegressor
         import orb_models.forcefield.pretrained as orb_ff
 
         # Default model
         model_path = model_path if model_path else "orb_v2"
 
-        if isinstance(model_path, GraphRegressor):
+        if isinstance(model_path, DirectForcefieldRegressor):
             model = model_path
-            model_path = "loaded_GraphRegressor"
+            model_path = "loaded_DirectForcefieldRegressor"
         else:
             try:
                 model = getattr(orb_ff, model_path.replace("-", "_"))()
             except AttributeError as e:
                 raise ValueError(
-                    "`model_path` must be a `GraphRegressor`, pre-trained model label "
-                    "(e.g. 'orb-v2'), or `None` (uses default, orb-v2)"
+                    "`model_path` must be a `DirectForcefieldRegressor`, pre-trained "
+                    "model label (e.g. 'orb-v2'), or `None` (uses default, orb-v2)"
                 ) from e
 
         calculator = ORBCalculator(model=model, device=device, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,7 @@ nequip = [
     "nequip == 0.6.1",
 ]
 orb = [
-    "orb-models == 0.4.2; sys_platform != 'win32'",
-    "pynanoflann; sys_platform != 'win32'",
+    "orb-models == 0.5.1; sys_platform != 'win32'",
 ]
 sevennet = [
     "sevenn == 0.10.3",
@@ -211,7 +210,6 @@ default-groups = [
 
 constraint-dependencies = [
     "dgl==2.1",
-    "torch<2.6",
     "tensorflow>=2.16.1",
     "tensorflow-io-gcs-filesystem<=0.31.0; sys_platform == 'win32'",
 ]
@@ -222,6 +220,14 @@ conflicts = [
     ],
     [
       { extra = "chgnet" },
+      { extra = "m3gnet" },
+    ],
+    [
+      { extra = "orb" },
+      { extra = "alignn" },
+    ],
+    [
+      { extra = "orb" },
       { extra = "m3gnet" },
     ],
     [
@@ -244,4 +250,3 @@ conflicts = [
 
 [tool.uv.sources]
 deepmd-kit = { git = "https://github.com/deepmodeling/deepmd-kit.git", rev = "dpa3-alpha" }
-pynanoflann = { git = "https://github.com/dwastberg/pynanoflann", rev = "af434039ae14bedcbb838a7808924d6689274168" }

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -80,7 +80,7 @@ def test_potential_energy(struct, expected, properties, prop_key, calc_kwargs, i
             "toluene.xyz",
             {"model_path": NEQUIP_PATH},
         ),
-        ("orb", "cpu", -27.08180809020996, "NaCl.cif", {}),
+        ("orb", "cpu", -27.08186149597168, "NaCl.cif", {}),
         ("orb", "cpu", -27.089094161987305, "NaCl.cif", {"model_path": "orb-v2"}),
         (
             "sevennet",
@@ -127,7 +127,7 @@ def test_extras(arch, device, expected_energy, struct, kwargs):
         **kwargs,
     )
     energy = single_point.run()["energy"]
-    assert energy == pytest.approx(expected_energy)
+    assert energy == pytest.approx(expected_energy, rel=1e-5)
 
 
 def test_single_point_none():

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -80,8 +80,8 @@ def test_potential_energy(struct, expected, properties, prop_key, calc_kwargs, i
             "toluene.xyz",
             {"model_path": NEQUIP_PATH},
         ),
-        ("orb", "cpu", -27.088973999023438, "NaCl.cif", {}),
-        ("orb", "cpu", -27.088973999023438, "NaCl.cif", {"model_path": "orb-v2"}),
+        ("orb", "cpu", -27.089094161987305, "NaCl.cif", {}),
+        ("orb", "cpu", -27.089094161987305, "NaCl.cif", {"model_path": "orb-v2"}),
         (
             "sevennet",
             "cpu",

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -80,7 +80,7 @@ def test_potential_energy(struct, expected, properties, prop_key, calc_kwargs, i
             "toluene.xyz",
             {"model_path": NEQUIP_PATH},
         ),
-        ("orb", "cpu", -27.089094161987305, "NaCl.cif", {}),
+        ("orb", "cpu", -27.08180809020996, "NaCl.cif", {}),
         ("orb", "cpu", -27.089094161987305, "NaCl.cif", {"model_path": "orb-v2"}),
         (
             "sevennet",


### PR DESCRIPTION
Resolves #507

Also applies a similar fix to MACE's for torch 2.6, by setting the `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD` environment variable, although I only set it if the user has not done so.

Otherwise we'd need to make Orb conflict with dependencies which do not have a fix yet (e.g. nequip, our current version of sevennet (#490)).