### PR TITLE
Fix docs status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Contributors to this project were funded by
 [ci-link]: https://github.com/stfc/janus-core/actions
 [cov-badge]: https://coveralls.io/repos/github/stfc/janus-core/badge.svg?branch=main
 [cov-link]: https://coveralls.io/github/stfc/janus-core?branch=main
-[docs-badge]: https://github.com/stfc/janus-core/actions/workflows/docs.yml/badge.svg
+[docs-badge]: https://img.shields.io/github/actions/workflow/status/stfc/janus-core/publish-on-pypi.yml?label=docs
 [docs-link]: https://stfc.github.io/janus-core/
 [pypi-badge]: https://badge.fury.io/py/janus-core.svg
 [pypi-link]: https://pypi.org/project/janus-core/


### PR DESCRIPTION
Resolves #506

Unfortunately we can't separate the success of the docs from the publishing success, but at least it will link to the docs again, even if it currently shows are failing (in general this should be rare...).