### PR TITLE
Fix catching BadZipFile

### DIFF
--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -109,7 +109,7 @@ def test_mlips(arch, device, kwargs):
         assert calculator.parameters["version"] is not None
         assert calculator.parameters["model_path"] is not None
     except (BadZipFile, URLError) as e:
-        if "Connection timed out" in e.msg or isinstance(e, BadZipFile):
+        if isinstance(e, BadZipFile) or "Connection timed out" in e.msg:
             pytest.skip("Model download failed")
         else:
             raise e


### PR DESCRIPTION
`BadZipFile` doesn't have a `.msg`, which this line was supposed to fix, but I implemented the fix in the wrong order.