### PR TITLE
Add MD progress bar

### DIFF
--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -1262,7 +1262,7 @@ class MolecularDynamics(BaseCalculation):
             if self.enable_progress_bar:
                 irun = track_progress(
                     irun,
-                    description=f"Simulating at {temp} K",
+                    description=f"Simulating at {temp} K...",
                     total=steps,
                 )
             # Run steps
@@ -1309,7 +1309,7 @@ class MolecularDynamics(BaseCalculation):
         if self.enable_progress_bar:
             irun = track_progress(
                 irun,
-                description=f"Simulating at {self.temp} K",
+                description=f"Simulating at {self.temp} K...",
                 total=steps,
             )
         # Run steps

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -1256,14 +1256,17 @@ class MolecularDynamics(BaseCalculation):
 
             self._set_target_temperature(temp)
 
-            irun = self.dyn.irun(heating_steps_per_temp)
+            irun = self.dyn.irun(steps)
             # Step 0
             next(irun)
+
             if self.enable_progress_bar:
+                completed = steps - heating_steps_per_temp
                 irun = track_progress(
                     irun,
                     description=f"Simulating at {temp} K...",
-                    total=steps,
+                    total=heating_steps_per_temp,
+                    completed=completed,
                 )
             # Run steps
             for _ in irun:
@@ -1310,7 +1313,8 @@ class MolecularDynamics(BaseCalculation):
             irun = track_progress(
                 irun,
                 description=f"Simulating at {self.temp} K...",
-                total=steps,
+                total=self.steps,
+                completed=md_offset,
             )
         # Run steps
         for _ in irun:

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -663,7 +663,7 @@ class MolecularDynamics(BaseCalculation):
         progress_bar = get_progress()
 
         task_id = progress_bar.add_task(
-            "Performing MD simulation...",
+            "Initialising MD simulation...",
             total=self.total_steps,
             completed=self.offset,
         )
@@ -696,7 +696,11 @@ class MolecularDynamics(BaseCalculation):
         if current_step == 0:
             return
 
-        progress_bar.update(task_id, completed=current_step)
+        progress_bar.update(
+            task_id,
+            completed=current_step,
+            description=f"Simulating at {self.temp} K...",
+        )
         progress_bar.refresh()
 
     def _set_info(self) -> None:

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -10,8 +10,12 @@ from math import isclose
 from os.path import getmtime
 from pathlib import Path
 import random
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from warnings import warn
+
+# Only needed for type hints
+if TYPE_CHECKING:
+    from rich.progress import Progress, TaskID
 
 from ase import Atoms
 from ase.geometry.analysis import Analysis
@@ -44,6 +48,7 @@ from janus_core.helpers.janus_types import (
 )
 from janus_core.helpers.struct_io import input_structs, output_structs
 from janus_core.helpers.utils import (
+    ProgressBar,
     build_file_dir,
     none_to_dict,
     set_minimize_logging,
@@ -162,6 +167,10 @@ class MolecularDynamics(BaseCalculation):
     seed
         Random seed used by numpy.random and random functions, such as in Langevin.
         Default is None.
+    enable_progress_bar
+        Whether to show a progress bar. Default is False.
+    progress_bar_update_every
+        How many timesteps between progress bar updates. Default is 1.
 
     Attributes
     ----------
@@ -223,6 +232,8 @@ class MolecularDynamics(BaseCalculation):
         post_process_kwargs: PostProcessKwargs | None = None,
         correlation_kwargs: list[CorrelationKwargs] | None = None,
         seed: int | None = None,
+        enable_progress_bar: bool = False,
+        progress_bar_update_every: int = 1,
     ) -> None:
         """
         Initialise molecular dynamics simulation configuration.
@@ -330,6 +341,10 @@ class MolecularDynamics(BaseCalculation):
         seed
             Random seed used by numpy.random and random functions, such as in Langevin.
             Default is None.
+        enable_progress_bar
+            Whether to show a progress bar. Default is False.
+        progress_bar_update_every
+            How many timesteps between progress bar updates. Default is 1.
         """
         (
             read_kwargs,
@@ -377,6 +392,8 @@ class MolecularDynamics(BaseCalculation):
         self.post_process_kwargs = post_process_kwargs
         self.correlation_kwargs = correlation_kwargs
         self.seed = seed
+        self.enable_progress_bar = enable_progress_bar
+        self.progress_bar_update_every = progress_bar_update_every
 
         if "append" in self.write_kwargs:
             raise ValueError("`append` cannot be specified when writing files")
@@ -425,6 +442,15 @@ class MolecularDynamics(BaseCalculation):
                 raise ValueError(
                     "Temperature ramp requested for ensemble with no thermostat"
                 )
+
+        if self.ramp_temp:
+            self.heating_steps_per_temp = int(self.temp_time // self.timestep)
+
+            # Always include start temperature in ramp, and include end temperature
+            # if separated by an integer number of temperature steps
+            self.heating_n_temps = int(
+                1 + abs(self.temp_end - self.temp_start) // self.temp_step
+            )
 
             # Validate start and end temperatures
             if self.temp_start < 0 or self.temp_end < 0:
@@ -1147,6 +1173,20 @@ class MolecularDynamics(BaseCalculation):
         else:
             raise ValueError("Temperature set for ensemble with no thermostat.")
 
+    def _update_progress_bar(self, progress_bar: Progress, task_id: TaskID):
+        """
+        Update the progress bar for MD run.
+
+        Parameters
+        ----------
+        progress_bar
+            The progress bar to be updated.
+        task_id
+            The task ID of the task created by `ProgressBar.add_task()`.
+        """
+        progress_bar.update(task_id, completed=self.dyn.nsteps + self.offset)
+        progress_bar.refresh()
+
     def run(self) -> None:
         """Run molecular dynamics simulation and/or temperature ramp."""
         self._set_info_units(self.info_unit_keys)
@@ -1172,9 +1212,22 @@ class MolecularDynamics(BaseCalculation):
         if self.minimize and self.minimize_every > 0:
             self.dyn.attach(self._optimize_structure, interval=self.minimize_every)
 
-        # Note current time
-        self.struct.info["real_time"] = datetime.datetime.now()
-        self._run_dynamics()
+        with ProgressBar(disable=not self.enable_progress_bar) as progress_bar:
+            if self.enable_progress_bar:
+                total_steps = self.steps
+                if self.ramp_temp:
+                    total_steps += self.heating_n_temps * self.heating_steps_per_temp
+                task_id = progress_bar.add_task(
+                    "Performing MD simulation...",
+                    total=total_steps,
+                    completed=self.offset,
+                )
+                update_func = partial(self._update_progress_bar, progress_bar, task_id)
+                self.dyn.attach(update_func, interval=self.progress_bar_update_every)
+
+            # Note current time
+            self.struct.info["real_time"] = datetime.datetime.now()
+            self._run_dynamics()
 
         if self.post_process_kwargs:
             self._post_process()
@@ -1194,23 +1247,18 @@ class MolecularDynamics(BaseCalculation):
 
         # Run temperature ramp
         if self.ramp_temp:
-            heating_steps = int(self.temp_time // self.timestep)
-
             if self.logger and not np.isclose(self.temp_time % self.timestep, 0.0):
-                rounded_temp_step = heating_steps * self.timestep / units.fs
+                rounded_temp_step = self.heating_n_steps * self.timestep / units.fs
                 self.logger.info(
                     "Temperature ramp step time rounded to nearest timestep "
                     f"({rounded_temp_step:.5} fs)"
                 )
 
-            # Always include start temperature in ramp, and include end temperature
-            # if separated by an integer number of temperature steps
-            n_temps = int(1 + abs(self.temp_end - self.temp_start) // self.temp_step)
-
             # Add or subtract temperatures
             ramp_sign = 1 if (self.temp_end - self.temp_start) > 0 else -1
             temps = [
-                self.temp_start + ramp_sign * i * self.temp_step for i in range(n_temps)
+                self.temp_start + ramp_sign * i * self.temp_step
+                for i in range(self.heating_n_temps)
             ]
 
             if self.restart:
@@ -1244,7 +1292,7 @@ class MolecularDynamics(BaseCalculation):
                     self.created_final_file = True
                     continue
                 self._set_target_temperature(temp)
-                self.dyn.run(steps)
+                self.dyn.run(self.heating_steps_per_temp)
                 self._write_final_state()
                 self.created_final_file = True
 

--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -699,7 +699,7 @@ class MolecularDynamics(BaseCalculation):
         progress_bar.update(
             task_id,
             completed=current_step,
-            description=f"Simulating at {self.temp} K...",
+            description=f"Simulating at {self.temp:.1f} K...",
         )
         progress_bar.refresh()
 

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -28,10 +28,10 @@ from janus_core.helpers.janus_types import (
     PhononCalcs,
 )
 from janus_core.helpers.utils import (
-    ProgressBar,
     build_file_dir,
     none_to_dict,
     set_minimize_logging,
+    track_progress,
 )
 
 
@@ -522,7 +522,7 @@ class Phonons(BaseCalculation):
         disp_supercells = phonon.supercells_with_displacements
 
         if self.enable_progress_bar:
-            disp_supercells = ProgressBar().track(
+            disp_supercells = track_progress(
                 disp_supercells, description="Computing displacements..."
             )
 

--- a/janus_core/calculations/phonons.py
+++ b/janus_core/calculations/phonons.py
@@ -28,10 +28,10 @@ from janus_core.helpers.janus_types import (
     PhononCalcs,
 )
 from janus_core.helpers.utils import (
+    ProgressBar,
     build_file_dir,
     none_to_dict,
     set_minimize_logging,
-    track_progress,
 )
 
 
@@ -522,8 +522,8 @@ class Phonons(BaseCalculation):
         disp_supercells = phonon.supercells_with_displacements
 
         if self.enable_progress_bar:
-            disp_supercells = track_progress(
-                disp_supercells, "Computing displacements..."
+            disp_supercells = ProgressBar().track(
+                disp_supercells, description="Computing displacements..."
             )
 
         phonon.forces = [

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -22,7 +22,7 @@ from janus_core.helpers.janus_types import (
 )
 from janus_core.helpers.mlip_calculators import check_calculator
 from janus_core.helpers.struct_io import output_structs
-from janus_core.helpers.utils import ProgressBar, none_to_dict
+from janus_core.helpers.utils import none_to_dict, track_progress
 
 
 class SinglePoint(BaseCalculation):
@@ -253,7 +253,7 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = ProgressBar().track(
+                struct_sequence = track_progress(
                     struct_sequence, description="Computing potential energies..."
                 )
             return [struct.get_potential_energy() for struct in struct_sequence]
@@ -272,7 +272,7 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = ProgressBar().track(
+                struct_sequence = track_progress(
                     struct_sequence, description="Computing forces..."
                 )
             return [struct.get_forces() for struct in struct_sequence]
@@ -291,7 +291,7 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = ProgressBar().track(
+                struct_sequence = track_progress(
                     struct_sequence, description="Computing stresses..."
                 )
             return [struct.get_stress() for struct in struct_sequence]
@@ -336,7 +336,7 @@ class SinglePoint(BaseCalculation):
             struct_sequence = self.struct
             if self.enable_progress_bar:
                 print("There should be a progress bar...")
-                struct_sequence = ProgressBar().track(
+                struct_sequence = track_progress(
                     struct_sequence, description="Computing Hessian..."
                 )
             return [self._calc_hessian(struct) for struct in struct_sequence]

--- a/janus_core/calculations/single_point.py
+++ b/janus_core/calculations/single_point.py
@@ -22,7 +22,7 @@ from janus_core.helpers.janus_types import (
 )
 from janus_core.helpers.mlip_calculators import check_calculator
 from janus_core.helpers.struct_io import output_structs
-from janus_core.helpers.utils import none_to_dict, track_progress
+from janus_core.helpers.utils import ProgressBar, none_to_dict
 
 
 class SinglePoint(BaseCalculation):
@@ -253,8 +253,8 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(
-                    struct_sequence, "Computing potential energies..."
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing potential energies..."
                 )
             return [struct.get_potential_energy() for struct in struct_sequence]
 
@@ -272,7 +272,9 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(struct_sequence, "Computing forces...")
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing forces..."
+                )
             return [struct.get_forces() for struct in struct_sequence]
 
         return self.struct.get_forces()
@@ -289,8 +291,8 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(
-                    struct_sequence, "Computing stresses..."
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing stresses..."
                 )
             return [struct.get_stress() for struct in struct_sequence]
 
@@ -333,8 +335,9 @@ class SinglePoint(BaseCalculation):
         if isinstance(self.struct, Sequence):
             struct_sequence = self.struct
             if self.enable_progress_bar:
-                struct_sequence = track_progress(
-                    struct_sequence, "Computing Hessian..."
+                print("There should be a progress bar...")
+                struct_sequence = ProgressBar().track(
+                    struct_sequence, description="Computing Hessian..."
                 )
             return [self._calc_hessian(struct) for struct in struct_sequence]
 

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -12,10 +12,10 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
-    EnableProgressBar,
     FilePrefix,
     LogPath,
     ModelPath,
+    ProgressBar,
     ReadKwargsAll,
     StructPath,
     Summary,
@@ -76,7 +76,7 @@ def descriptors(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
-    enable_progress_bar: EnableProgressBar = True,
+    progress_bar: ProgressBar = True,
 ) -> None:
     """
     Calculate MLIP descriptors for the given structure(s).
@@ -121,7 +121,7 @@ def descriptors(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
-    enable_progress_bar
+    progress_bar
         Whether to show progress bar.
     config
         Path to yaml configuration file to define the above options. Default is None.
@@ -181,7 +181,7 @@ def descriptors(
         "write_results": True,
         "write_kwargs": write_kwargs,
         "file_prefix": file_prefix,
-        "enable_progress_bar": enable_progress_bar,
+        "enable_progress_bar": progress_bar,
     }
 
     # Initialise descriptors

--- a/janus_core/cli/descriptors.py
+++ b/janus_core/cli/descriptors.py
@@ -12,6 +12,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    EnableProgressBar,
     FilePrefix,
     LogPath,
     ModelPath,
@@ -75,6 +76,7 @@ def descriptors(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
+    enable_progress_bar: EnableProgressBar = True,
 ) -> None:
     """
     Calculate MLIP descriptors for the given structure(s).
@@ -119,6 +121,8 @@ def descriptors(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
+    enable_progress_bar
+        Whether to show progress bar.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -177,7 +181,7 @@ def descriptors(
         "write_results": True,
         "write_kwargs": write_kwargs,
         "file_prefix": file_prefix,
-        "enable_progress_bar": True,
+        "enable_progress_bar": enable_progress_bar,
     }
 
     # Initialise descriptors

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -16,13 +16,13 @@ from janus_core.cli.types import (
     CalcKwargs,
     CorrelationKwargs,
     Device,
-    EnableProgressBar,
     EnsembleKwargs,
     FilePrefix,
     LogPath,
     MinimizeKwargs,
     ModelPath,
     PostProcessKwargs,
+    ProgressBar,
     ReadKwargsLast,
     StructPath,
     Summary,
@@ -358,7 +358,7 @@ def md(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
-    enable_progress_bar: EnableProgressBar = True,
+    progress_bar: ProgressBar = True,
     update_progress_every: Annotated[
         int,
         Option(
@@ -500,7 +500,7 @@ def md(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
-    enable_progress_bar
+    progress_bar
         Whether to show progress bar.
     update_progress_every
         Number of timesteps between progress bar updates. Default is steps / 100,
@@ -630,7 +630,7 @@ def md(
         "post_process_kwargs": post_process_kwargs,
         "correlation_kwargs": correlation_kwargs,
         "seed": seed,
-        "enable_progress_bar": enable_progress_bar,
+        "enable_progress_bar": progress_bar,
         "update_progress_every": update_progress_every,
     }
 

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -357,6 +357,17 @@ def md(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
+    enable_progress_bar: Annotated[
+        bool,
+        Option(
+            "--enable-progress-bar/--disable-progress-bar",
+            help="Whether to show progress bar.",
+        ),
+    ] = True,
+    progress_bar_update_every: Annotated[
+        int,
+        Option(help="How many timesteps between progress bar updates. Default is 1."),
+    ] = 1,
 ) -> None:
     """
     Run molecular dynamics simulation, and save trajectory and statistics.
@@ -490,6 +501,10 @@ def md(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
+    enable_progress_bar
+        Whether to show progress bar.
+    progress_bar_update_every
+        How many timesteps between progress bar updates. Default is 1.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -615,6 +630,8 @@ def md(
         "post_process_kwargs": post_process_kwargs,
         "correlation_kwargs": correlation_kwargs,
         "seed": seed,
+        "enable_progress_bar": enable_progress_bar,
+        "progress_bar_update_every": progress_bar_update_every,
     }
 
     # Instantiate MD ensemble

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -16,6 +16,7 @@ from janus_core.cli.types import (
     CalcKwargs,
     CorrelationKwargs,
     Device,
+    EnableProgressBar,
     EnsembleKwargs,
     FilePrefix,
     LogPath,
@@ -357,18 +358,13 @@ def md(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
-    enable_progress_bar: Annotated[
-        bool,
-        Option(
-            "--enable-progress-bar/--disable-progress-bar",
-            help="Whether to show progress bar.",
-        ),
-    ] = True,
+    enable_progress_bar: EnableProgressBar = True,
     update_progress_every: Annotated[
         int,
         Option(
-            help="How many timesteps between progress bar updates. "
-            "Default is steps/100, rounded up."
+            help="Number of timesteps between progress bar updates. "
+            "Default is steps / 100, rounded up.",
+            rich_help_panel="Logging/summary",
         ),
     ] = None,
 ) -> None:
@@ -507,8 +503,8 @@ def md(
     enable_progress_bar
         Whether to show progress bar.
     update_progress_every
-        How many timesteps between progress bar updates.
-        Default is steps/100, rounded up.
+        Number of timesteps between progress bar updates. Default is steps / 100,
+        rounded up.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """

--- a/janus_core/cli/md.py
+++ b/janus_core/cli/md.py
@@ -364,10 +364,13 @@ def md(
             help="Whether to show progress bar.",
         ),
     ] = True,
-    progress_bar_update_every: Annotated[
+    update_progress_every: Annotated[
         int,
-        Option(help="How many timesteps between progress bar updates. Default is 1."),
-    ] = 1,
+        Option(
+            help="How many timesteps between progress bar updates. "
+            "Default is steps/100, rounded up."
+        ),
+    ] = None,
 ) -> None:
     """
     Run molecular dynamics simulation, and save trajectory and statistics.
@@ -503,8 +506,9 @@ def md(
         is inferred from `file_prefix`.
     enable_progress_bar
         Whether to show progress bar.
-    progress_bar_update_every
-        How many timesteps between progress bar updates. Default is 1.
+    update_progress_every
+        How many timesteps between progress bar updates.
+        Default is steps/100, rounded up.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -631,7 +635,7 @@ def md(
         "correlation_kwargs": correlation_kwargs,
         "seed": seed,
         "enable_progress_bar": enable_progress_bar,
-        "progress_bar_update_every": progress_bar_update_every,
+        "update_progress_every": update_progress_every,
     }
 
     # Instantiate MD ensemble

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -14,12 +14,12 @@ from janus_core.cli.types import (
     Device,
     DisplacementKwargs,
     DoSKwargs,
-    EnableProgressBar,
     FilePrefix,
     LogPath,
     MinimizeKwargs,
     ModelPath,
     PDoSKwargs,
+    ProgressBar,
     ReadKwargsLast,
     StructPath,
     Summary,
@@ -183,7 +183,7 @@ def phonons(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
-    enable_progress_bar: EnableProgressBar = True,
+    progress_bar: ProgressBar = True,
 ) -> None:
     """
     Perform phonon calculations and write out results.
@@ -272,7 +272,7 @@ def phonons(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
-    enable_progress_bar
+    progress_bar
         Whether to show progress bar.
     config
         Path to yaml configuration file to define the above options. Default is None.
@@ -390,7 +390,7 @@ def phonons(
         "write_results": True,
         "write_full": write_full,
         "file_prefix": file_prefix,
-        "enable_progress_bar": enable_progress_bar,
+        "enable_progress_bar": progress_bar,
     }
 
     # Initialise phonons

--- a/janus_core/cli/phonons.py
+++ b/janus_core/cli/phonons.py
@@ -14,6 +14,7 @@ from janus_core.cli.types import (
     Device,
     DisplacementKwargs,
     DoSKwargs,
+    EnableProgressBar,
     FilePrefix,
     LogPath,
     MinimizeKwargs,
@@ -182,6 +183,7 @@ def phonons(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
+    enable_progress_bar: EnableProgressBar = True,
 ) -> None:
     """
     Perform phonon calculations and write out results.
@@ -270,6 +272,8 @@ def phonons(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
+    enable_progress_bar
+        Whether to show progress bar.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -386,7 +390,7 @@ def phonons(
         "write_results": True,
         "write_full": write_full,
         "file_prefix": file_prefix,
-        "enable_progress_bar": True,
+        "enable_progress_bar": enable_progress_bar,
     }
 
     # Initialise phonons

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -13,6 +13,7 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
+    EnableProgressBar,
     FilePrefix,
     LogPath,
     ModelPath,
@@ -69,6 +70,7 @@ def singlepoint(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
+    enable_progress_bar: EnableProgressBar = True,
 ) -> None:
     """
     Perform single point calculations and save to file.
@@ -109,6 +111,8 @@ def singlepoint(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
+    enable_progress_bar
+        Whether to show progress bar.
     config
         Path to yaml configuration file to define the above options. Default is None.
     """
@@ -163,7 +167,7 @@ def singlepoint(
         "attach_logger": True,
         "log_kwargs": log_kwargs,
         "track_carbon": tracker,
-        "enable_progress_bar": True,
+        "enable_progress_bar": enable_progress_bar,
     }
 
     # Initialise singlepoint structure and calculator

--- a/janus_core/cli/singlepoint.py
+++ b/janus_core/cli/singlepoint.py
@@ -13,10 +13,10 @@ from janus_core.cli.types import (
     Architecture,
     CalcKwargs,
     Device,
-    EnableProgressBar,
     FilePrefix,
     LogPath,
     ModelPath,
+    ProgressBar,
     ReadKwargsAll,
     StructPath,
     Summary,
@@ -70,7 +70,7 @@ def singlepoint(
     log: LogPath = None,
     tracker: Tracker = True,
     summary: Summary = None,
-    enable_progress_bar: EnableProgressBar = True,
+    progress_bar: ProgressBar = True,
 ) -> None:
     """
     Perform single point calculations and save to file.
@@ -111,7 +111,7 @@ def singlepoint(
     summary
         Path to save summary of inputs, start/end time, and carbon emissions. Default
         is inferred from `file_prefix`.
-    enable_progress_bar
+    progress_bar
         Whether to show progress bar.
     config
         Path to yaml configuration file to define the above options. Default is None.
@@ -167,7 +167,7 @@ def singlepoint(
         "attach_logger": True,
         "log_kwargs": log_kwargs,
         "track_carbon": tracker,
-        "enable_progress_bar": enable_progress_bar,
+        "enable_progress_bar": progress_bar,
     }
 
     # Initialise singlepoint structure and calculator

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -368,7 +368,7 @@ Summary = Annotated[
     ),
 ]
 
-EnableProgressBar = Annotated[
+ProgressBar = Annotated[
     bool,
     Option(help="Whether to show progress bar.", rich_help_panel="Logging/summary"),
 ]

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -367,3 +367,8 @@ Summary = Annotated[
         rich_help_panel="Logging/summary",
     ),
 ]
+
+EnableProgressBar = Annotated[
+    bool,
+    Option(help="Whether to show progress bar.", rich_help_panel="Logging/summary"),
+]

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -370,6 +370,33 @@ def _dump_csv(
         print(",".join(map(format, cols, formats)), file=file)
 
 
+def get_progress() -> Progress:
+    """
+    Set up rich progress bar.
+
+    Returns
+    -------
+    Progress
+        Initialised progress bar.
+    """
+    text_column = TextColumn("{task.description}")
+    bar_column = BarColumn(
+        bar_width=None,
+        complete_style=Style(color="#FBBB10"),
+        finished_style=Style(color="#E38408"),
+    )
+    completion_column = MofNCompleteColumn()
+    time_column = TimeRemainingColumn()
+    return Progress(
+        text_column,
+        bar_column,
+        completion_column,
+        time_column,
+        expand=True,
+        auto_refresh=False,
+    )
+
+
 def track_progress(
     sequence: Sequence | Iterable,
     description: str,
@@ -402,22 +429,7 @@ def track_progress(
     Iterable
         An iterable of the values in the sequence.
     """
-    text_column = TextColumn("{task.description}")
-    bar_column = BarColumn(
-        bar_width=None,
-        complete_style=Style(color="#FBBB10"),
-        finished_style=Style(color="#E38408"),
-    )
-    completion_column = MofNCompleteColumn()
-    time_column = TimeRemainingColumn()
-    progress = Progress(
-        text_column,
-        bar_column,
-        completion_column,
-        time_column,
-        expand=True,
-        auto_refresh=False,
-    )
+    progress = get_progress()
 
     with progress:
         yield from progress.track(

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -371,7 +371,11 @@ def _dump_csv(
 
 
 def track_progress(
-    sequence: Sequence | Iterable, description: str, total: int | None = None
+    sequence: Sequence | Iterable,
+    description: str,
+    total: int | None = None,
+    completed: int = 0,
+    update_period: float = 0.1,
 ) -> Iterable:
     """
     Track the progress of iterating over a sequence.
@@ -388,6 +392,10 @@ def track_progress(
         The text to display to the left of the progress bar.
     total
         Total number of iteration steps. Defaults to length of sequence.
+    completed
+        Total number of iterations already completed. Default is 0.
+    update_period
+        Minimum time (in seconds) between calls to update(). Default is 0.1.
 
     Yields
     ------
@@ -412,7 +420,13 @@ def track_progress(
     )
 
     with progress:
-        yield from progress.track(sequence, description=description, total=total)
+        yield from progress.track(
+            sequence=sequence,
+            total=total,
+            completed=completed,
+            description=description,
+            update_period=update_period,
+        )
 
 
 def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -370,44 +370,49 @@ def _dump_csv(
         print(",".join(map(format, cols, formats)), file=file)
 
 
-class ProgressBar(Progress):
+def track_progress(
+    sequence: Sequence | Iterable, description: str, total: int | None
+) -> Iterable:
     """
-    Progress bar with preset formatting.
+    Track the progress of iterating over a sequence.
 
-    Inherits from `rich.progress.Progress`, providing preset formatting.
+    This is done by displaying a progress bar in the console using the rich library.
+    The function is an iterator over the sequence, updating the progress bar each
+    iteration.
 
     Parameters
     ----------
-        **kwargs
-            Keyword arguments passed on to `rich.progress.Progress`.
+    sequence
+        The sequence to iterate over. Must support "len".
+    description
+        The text to display to the left of the progress bar.
+    total
+        Total number of iteration steps. Defaults to length of sequence.
+
+    Yields
+    ------
+    Iterable
+        An iterable of the values in the sequence.
     """
+    text_column = TextColumn("{task.description}")
+    bar_column = BarColumn(
+        bar_width=None,
+        complete_style=Style(color="#FBBB10"),
+        finished_style=Style(color="#E38408"),
+    )
+    completion_column = MofNCompleteColumn()
+    time_column = TimeRemainingColumn()
+    progress = Progress(
+        text_column,
+        bar_column,
+        completion_column,
+        time_column,
+        expand=True,
+        auto_refresh=False,
+    )
 
-    def __init__(self, **kwargs):
-        """
-        Initialise a `rich` progress bar with preset formatting.
-
-        Parameters
-        ----------
-        **kwargs
-            Keyword arguments passed on to `rich.progress.Progress`.
-        """
-        text_column = TextColumn("{task.description}")
-        bar_column = BarColumn(
-            bar_width=None,
-            complete_style=Style(color="#FBBB10"),
-            finished_style=Style(color="#E38408"),
-        )
-        completion_column = MofNCompleteColumn()
-        time_column = TimeRemainingColumn()
-        super().__init__(
-            text_column,
-            bar_column,
-            completion_column,
-            time_column,
-            expand=True,
-            auto_refresh=False,
-            **kwargs,
-        )
+    with progress:
+        yield from progress.track(sequence, description=description, total=total)
 
 
 def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -371,7 +371,7 @@ def _dump_csv(
 
 
 def track_progress(
-    sequence: Sequence | Iterable, description: str, total: int | None
+    sequence: Sequence | Iterable, description: str, total: int | None = None
 ) -> Iterable:
     """
     Track the progress of iterating over a sequence.

--- a/janus_core/helpers/utils.py
+++ b/janus_core/helpers/utils.py
@@ -370,45 +370,44 @@ def _dump_csv(
         print(",".join(map(format, cols, formats)), file=file)
 
 
-def track_progress(sequence: Sequence | Iterable, description: str) -> Iterable:
+class ProgressBar(Progress):
     """
-    Track the progress of iterating over a sequence.
+    Progress bar with preset formatting.
 
-    This is done by displaying a progress bar in the console using the rich library.
-    The function is an iterator over the sequence, updating the progress bar each
-    iteration.
+    Inherits from `rich.progress.Progress`, providing preset formatting.
 
     Parameters
     ----------
-    sequence
-        The sequence to iterate over. Must support "len".
-    description
-        The text to display to the left of the progress bar.
-
-    Yields
-    ------
-    Iterable
-        An iterable of the values in the sequence.
+        **kwargs
+            Keyword arguments passed on to `rich.progress.Progress`.
     """
-    text_column = TextColumn("{task.description}")
-    bar_column = BarColumn(
-        bar_width=None,
-        complete_style=Style(color="#FBBB10"),
-        finished_style=Style(color="#E38408"),
-    )
-    completion_column = MofNCompleteColumn()
-    time_column = TimeRemainingColumn()
-    progress = Progress(
-        text_column,
-        bar_column,
-        completion_column,
-        time_column,
-        expand=True,
-        auto_refresh=False,
-    )
 
-    with progress:
-        yield from progress.track(sequence, description=description)
+    def __init__(self, **kwargs):
+        """
+        Initialise a `rich` progress bar with preset formatting.
+
+        Parameters
+        ----------
+        **kwargs
+            Keyword arguments passed on to `rich.progress.Progress`.
+        """
+        text_column = TextColumn("{task.description}")
+        bar_column = BarColumn(
+            bar_width=None,
+            complete_style=Style(color="#FBBB10"),
+            finished_style=Style(color="#E38408"),
+        )
+        completion_column = MofNCompleteColumn()
+        time_column = TimeRemainingColumn()
+        super().__init__(
+            text_column,
+            bar_column,
+            completion_column,
+            time_column,
+            expand=True,
+            auto_refresh=False,
+            **kwargs,
+        )
 
 
 def check_files_exist(config: dict, req_file_keys: Sequence[PathLike]) -> None:

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1348,13 +1348,10 @@ def test_progress_bar_complete(tmp_path, capsys, ensemble, tag):
     """Test progress bar completes in all ensembles."""
     file_prefix = tmp_path / f"Cl4Na4-{tag}-T300.0"
 
-    single_point = SinglePoint(
+    md = ensemble(
         struct=DATA_PATH / "NaCl.cif",
         arch="mace",
-        calc_kwargs={"model": MODEL_PATH},
-    )
-    md = ensemble(
-        struct=single_point.struct,
+        model_path=MODEL_PATH,
         steps=2,
         file_prefix=file_prefix,
         enable_progress_bar=True,

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1339,7 +1339,7 @@ def test_progress_bar_complete(tmp_path, capsys, ensemble, tag):
     file_prefix = tmp_path / f"Cl4Na4-{tag}-T300.0"
 
     single_point = SinglePoint(
-        struct_path=DATA_PATH / "NaCl.cif",
+        struct=DATA_PATH / "NaCl.cif",
         arch="mace",
         calc_kwargs={"model": MODEL_PATH},
     )

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -692,7 +692,7 @@ def test_stats(tmp_path, ensemble, tag):
 
 
 @pytest.mark.parametrize("ensemble", ensembles_with_thermostat)
-def test_heating(tmp_path, ensemble):
+def test_heating(tmp_path, capsys, ensemble):
     """Test heating with no MD."""
     file_prefix = tmp_path / "NaCl-heating"
     final_file = tmp_path / "NaCl-heating-final.extxyz"
@@ -716,6 +716,7 @@ def test_heating(tmp_path, ensemble):
         temp_step=20,
         temp_time=2,
         log_kwargs={"filename": log_file},
+        enable_progress_bar=True,
     )
     md.run()
     assert_log_contains(
@@ -728,6 +729,9 @@ def test_heating(tmp_path, ensemble):
     )
 
     assert final_file.exists()
+
+    # Check progress bar has completed.
+    assert "━━ 2/2" in capsys.readouterr().out
 
 
 @pytest.mark.parametrize("ensemble", ensembles_without_thermostat)
@@ -782,7 +786,7 @@ def test_noramp_heating(tmp_path, ensemble):
 
 
 @pytest.mark.parametrize("ensemble", ensembles_with_thermostat)
-def test_heating_md(tmp_path, ensemble):
+def test_heating_md(tmp_path, capsys, ensemble):
     """Test heating followed by MD."""
     file_prefix = tmp_path / "NaCl-heating"
     stats_path = tmp_path / "NaCl-heating-stats.dat"
@@ -805,6 +809,7 @@ def test_heating_md(tmp_path, ensemble):
         temp_step=10,
         temp_time=2,
         log_kwargs={"filename": log_file},
+        enable_progress_bar=True,
     )
     md.run()
     assert_log_contains(
@@ -828,6 +833,11 @@ def test_heating_md(tmp_path, ensemble):
     assert stat_data.labels[0] == "# Step"
     assert stat_data.units[0] == ""
     assert stat_data.units[target_t_col] == "K"
+
+    # Check progress bar has completed.
+    out = capsys.readouterr().out
+    assert "━━ 9/9" in out  # Total progress
+    assert "━━ 5/5" in out  # Const T progress
 
 
 def test_heating_restart(tmp_path):

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -838,7 +838,7 @@ def test_heating_md(tmp_path, capsys, ensemble):
     assert "━━ 9/9" in capsys.readouterr().out
 
 
-def test_heating_restart(tmp_path):
+def test_heating_restart(tmp_path, capsys):
     """Test restarting during temperature ramp."""
     file_prefix = tmp_path / "NaCl-heating"
 
@@ -867,6 +867,7 @@ def test_heating_restart(tmp_path):
         temp_step=10,
         temp_time=2,
         restart=True,
+        enable_progress_bar=True,
     )
     md_restart.run()
 
@@ -876,6 +877,9 @@ def test_heating_restart(tmp_path):
     assert stat_data.data[4, target_t_col] == 20
     assert stat_data.data[5, target_t_col] == 30
     assert stat_data.data[8, target_t_col] == 30
+
+    # Check progress bar is correct.
+    assert "━━ 8/8" in capsys.readouterr().out
 
 
 def test_heating_files():
@@ -998,7 +1002,7 @@ def test_ramp_negative(tmp_path):
         )
 
 
-def test_cooling(tmp_path):
+def test_cooling(tmp_path, capsys):
     """Test cooling with no MD."""
     file_prefix = tmp_path / "NaCl-cooling"
     final_path = tmp_path / "NaCl-cooling-final.extxyz"
@@ -1023,6 +1027,7 @@ def test_cooling(tmp_path):
         temp_step=10,
         temp_time=1,
         log_kwargs={"filename": log_file},
+        enable_progress_bar=True,
     )
     nvt.run()
     assert_log_contains(
@@ -1042,6 +1047,9 @@ def test_cooling(tmp_path):
     assert stats.rows == 3
     assert stats.data[0, 16] == 20.0
     assert stats.data[2, 16] == 10.0
+
+    # Check progress bar
+    assert "━━ 2/2" in capsys.readouterr().out
 
 
 def test_heating_too_short(tmp_path):

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -836,7 +836,7 @@ def test_heating_md(tmp_path, capsys, ensemble):
 
     # Check progress bar has completed.
     out = capsys.readouterr().out
-    assert "━━ 9/9" in out  # Total progress
+    assert "━━ 2/2" in out  # Ramp progress
     assert "━━ 5/5" in out  # Const T progress
 
 

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -835,9 +835,7 @@ def test_heating_md(tmp_path, capsys, ensemble):
     assert stat_data.units[target_t_col] == "K"
 
     # Check progress bar has completed.
-    out = capsys.readouterr().out
-    assert "━━ 2/2" in out  # Ramp progress
-    assert "━━ 5/5" in out  # Const T progress
+    assert "━━ 9/9" in capsys.readouterr().out
 
 
 def test_heating_restart(tmp_path):

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -929,3 +929,29 @@ def test_consistent_stats_traj(tmp_path, ensemble, output_every, heating):
 
         assert len(target_temps) == len(stats_target_temps)
         assert target_temps == pytest.approx(stats_target_temps, rel=1e5)
+
+
+def test_no_progress(tmp_path):
+    """Test disabling progress bar."""
+    file_prefix = tmp_path / "nvt"
+
+    result = runner.invoke(
+        app,
+        [
+            "md",
+            "--ensemble",
+            "nvt",
+            "--struct",
+            DATA_PATH / "NaCl.cif",
+            "--no-tracker",
+            "--file-prefix",
+            file_prefix,
+            "--steps",
+            2,
+            "--no-progress-bar",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    assert "2/2" not in result.output

--- a/tests/test_md_cli.py
+++ b/tests/test_md_cli.py
@@ -157,6 +157,8 @@ def test_md(ensemble):
 
         check_output_files(summary=summary, output_files=output_files)
 
+        assert "━━ 2/2" in result.output
+
     finally:
         shutil.rmtree(results_dir, ignore_errors=True)
         clear_log_handlers()
@@ -834,6 +836,9 @@ def test_auto_restart(tmp_path):
     # Includes header and steps 0, 3, and steps 5, 6, 7
     assert len(lines) == 6
     assert int(lines[-1].split()[0]) == 7
+
+    # Check progress bar counted restart steps correctly
+    assert "7/7" in result.stdout
 
 
 def test_no_carbon(tmp_path):


### PR DESCRIPTION
Resolves #405

See examples for the next week: https://asciinema.org/a/gQeyJo9JJPvSWFkuLVCkdnfHV

Or permanent example:
![image](https://github.com/user-attachments/assets/096a40c0-63b4-4e76-a1cd-4750beb56a6f)

This combines aspects of #444 and #457.

Thanks to @k-harris27, we do now have the option to use ASE's `irun`, and wrap this with the `rich` progress tracker, but unfortunately this seems to provide limited options for reducing the frequency of updates, since each `next(irun)` causes the bar to refresh. This ends up having a noticeable (consistently 4-5% from tests up to around 25 min on my laptop) impact on performance, so I think we need to limit the frequency of updates, which requires a more manual process.

To simplify things, I've gone with a single progress bar, but the description changes according to the current step.

