### PR TITLE
Fix error catching in tests

### DIFF
--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -108,11 +108,12 @@ def test_mlips(arch, device, kwargs):
         calculator = choose_calculator(arch=arch, device=device, **kwargs)
         assert calculator.parameters["version"] is not None
         assert calculator.parameters["model_path"] is not None
-    except (BadZipFile, URLError) as e:
-        if isinstance(e, BadZipFile) or "Connection timed out" in e.msg:
+    except BadZipFile:
+        pytest.skip("Model download failed")
+    except URLError as err:
+        if "Connection timed out" in err.reason:
             pytest.skip("Model download failed")
-        else:
-            raise e
+        raise err
 
 
 def test_invalid_arch():

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -130,11 +130,10 @@ def test_extras(arch, device, expected_energy, struct, kwargs):
         )
         energy = single_point.run()["energy"]
         assert energy == pytest.approx(expected_energy, rel=1e-5)
-    except URLError as e:
-        if "Connection timed out" in e.msg:
+    except URLError as err:
+        if "Connection timed out" in err.reason:
             pytest.skip("Model download failed")
-        else:
-            raise e
+        raise err
 
 
 def test_single_point_none():


### PR DESCRIPTION
Addresses comment from @oerc0122 in  #516, and fixes attribute from `URLError`, which I thought I'd corrected, but  slipped through.