### PR TITLE
Tidy NEB error handling and tests

### DIFF
--- a/janus_core/calculations/neb.py
+++ b/janus_core/calculations/neb.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from copy import copy
-from typing import Any
+from typing import Any, get_args
 
 from ase import Atoms
 import ase.mep
@@ -297,6 +297,9 @@ class NEB(BaseCalculation):
         )
 
         if self.interpolator:
+            if interpolator not in get_args(Interpolators):
+                raise ValueError(f"Fit type must be one of: {get_args(Interpolators)}")
+
             if not isinstance(self.struct, Atoms):
                 raise ValueError("`init_struct` must be a single structure.")
             if not self.struct.calc:

--- a/janus_core/cli/neb.py
+++ b/janus_core/cli/neb.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, get_args
+from typing import Annotated
 
 from click import Choice
 from typer import Context, Option, Typer
@@ -204,7 +204,6 @@ def neb(
         parse_typer_dicts,
         start_summary,
     )
-    from janus_core.helpers.janus_types import Interpolators
 
     # Check options from configuration file are all valid
     check_config(ctx)
@@ -240,17 +239,6 @@ def neb(
         "calc_kwargs": calc_kwargs.copy(),
     }
     config = get_config(params=ctx.params, all_kwargs=all_kwargs)
-
-    if neb_structs:
-        if init_struct or final_struct:
-            raise ValueError(
-                "Initial and final structures cannot be specified in addition to the "
-                "band structures"
-            )
-        interpolator = None
-
-    if not neb_structs and interpolator not in get_args(Interpolators):
-        raise ValueError(f"Fit type must be one of: {get_args(Interpolators)}")
 
     log_kwargs = {"filemode": "w"}
     if log:

--- a/tests/test_neb.py
+++ b/tests/test_neb.py
@@ -163,3 +163,54 @@ def test_neb_plot(tmp_path):
     assert neb.results["barrier"] == pytest.approx(0.4790452267999399)
     assert neb.results["delta_E"] == pytest.approx(-2.814124400174478e-07)
     assert neb.results["max_force"] == pytest.approx(1.5425684122118983)
+
+
+@pytest.mark.parametrize("n_images", (-5, 0, 1.5))
+def test_invalid_n_images(LFPO_start_b, LFPO_end_b, n_images):
+    """Test setting invalid invalid n_images."""
+    with pytest.raises(ValueError):
+        NEB(
+            init_struct=LFPO_start_b,
+            final_struct=LFPO_end_b,
+            n_images=n_images,
+        )
+
+
+def test_invalid_interpolator(LFPO_start_b, LFPO_end_b):
+    """Test setting invalid interpolator."""
+    with pytest.raises(ValueError):
+        NEB(
+            init_struct=LFPO_start_b,
+            final_struct=LFPO_end_b,
+            interpolator="invalid",
+        )
+
+
+def test_missing_interpolator(LFPO_start_b, LFPO_end_b):
+    """Test setting missing interpolator."""
+    with pytest.raises(ValueError):
+        NEB(
+            init_struct=LFPO_start_b,
+            final_struct=LFPO_end_b,
+            interpolator=None,
+        )
+
+
+def test_invalid_structs(LFPO_start_b, LFPO_end_b):
+    """Test error raised if init_struct/final_struct are passed with neb_structs."""
+    with pytest.raises(ValueError):
+        NEB(
+            init_struct=LFPO_start_b,
+            neb_structs=DATA_PATH / "LiFePO4-neb-band.xyz",
+        )
+    with pytest.raises(ValueError):
+        NEB(
+            final_struct=LFPO_end_b,
+            neb_structs=DATA_PATH / "LiFePO4-neb-band.xyz",
+        )
+    with pytest.raises(ValueError):
+        NEB(
+            init_struct=LFPO_start_b,
+            final_struct=LFPO_end_b,
+            neb_structs=DATA_PATH / "LiFePO4-neb-band.xyz",
+        )


### PR DESCRIPTION
In preparation for #529, some tidying up of NEB error handling:

- Move all error catching into Python calculation, as there's nothing that we checked in the CLI that shouldn't be checked in the Python (and in the case of specifying the initial/final and full path, this was already the checked).
- Add a few new Python tests to cover cases where errors should be raised 