### PR TITLE
Fix documentation warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,8 @@ intersphinx_mapping = {
     "phonopy": ("https://phonopy.github.io/phonopy/", None),
     "codecarbon": ("https://mlco2.github.io/codecarbon/", None),
     "torch": ("https://pytorch.org/docs/stable", None),
-    "matplotlib": ("https://matplotlib.org/stable/", None,)
+    "matplotlib": ("https://matplotlib.org/stable/", None),
+    "rich": ("https://rich.readthedocs.io/en/stable/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -228,4 +229,6 @@ nitpick_ignore = [
     ("py:class", "Context"),
     ("py:class", "Path"),
     ("py:class", "Figure"),
+    ("py:class", "Progress"),
+    ("py:class", "ProgressBar"),
 ]


### PR DESCRIPTION
This doesn't throw an error, but we currently get two types of warning when building the docs, one of which we can fix with `intersphinx`, and one which needs to be ignored:

```
<unknown>:1: WARNING: py:class reference target not found: rich.progress.Progress [ref.class]
```
```
/Users/elliottkasoar/Documents/PSDI/janus-core/docs/source/apidoc/janus_core.rst:252: WARNING: py:class reference target not found: Progress [ref.class]
```