### PR TITLE
Remove DGL MLIPs for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,14 +29,3 @@ jobs:
           # show timings of tests
           PYTEST_ADDOPTS: "--durations=0"
         run: uv run pytest
-
-      - name: Install dgl dependencies
-        run: |
-          uv sync --extra mace --extra m3gnet --extra alignn
-          uv pip install --reinstall pynvml
-
-      - name: Run test suite
-        env:
-          # show timings of tests
-          PYTEST_ADDOPTS: "--durations=0"
-        run: uv run pytest tests/test_mlip_calculators.py tests/test_single_point.py tests/test_eos.py

--- a/README.md
+++ b/README.md
@@ -51,15 +51,11 @@ python3 -m pip install janus-core[mace,chgnet,sevennet]
 ```
 
 > [!WARNING]
-> `matgl` and `alignn` depend on [dgl](https://github.com/dmlc/dgl?tab=readme-ov-file), which no
-> longer publishes to PyPI. If `janus-core` is installed with either of these extras, PyTorch will
-> automatically be set to 2.2.0 to ensure compatibility. However, this is incompatible with `chgnet`,
-> and may limit the available features in others, including `mace`. To use `matgl` and/or `alignn` with
-> more recent PyTorch release, please refer to the
-> [installation documentation](https://stfc.github.io/janus-core/user_guide/installation.html).
+> We are unable to support for automatic installation of all combinations of MLIPs, or MLIPs on all platforms.
+> Please refer to the [installation documentation](https://stfc.github.io/janus-core/user_guide/installation.html)
+> for more details.
 
-
-To install all MLIPs that do not depend on `dgl`:
+To install all MLIPs currently compatible with MACE, run:
 
 ```python
 python3 -m pip install janus-core[all]

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -36,18 +36,16 @@ For example, to install MACE, CHGNet, and SevenNet, run:
 
 .. warning::
 
-    ``matgl`` and ``alignn`` depend on `dgl <https://github.com/dmlc/dgl?tab=readme-ov-file>`_,
-    which no longer publishes to PyPI. If ``janus-core`` is installed with either of these extras,
-    PyTorch will automatically be set to 2.2.0 to ensure compatibility. However, this is incompatible
-    with ``chgnet``, and may limit the available features in others, including ``mace``. To use
-    ``matgl`` and/or ``alignn`` with more recent PyTorch release, please refer to the
-    :doc:`installation documentation </user_guide/installation>`.
+    We are unable to support for automatic installation of all combinations of MLIPs, or MLIPs on all platforms.
+    Please refer to the :doc:`installation documentation </user_guide/installation>` for more details.
 
-To install all MLIPs that do not depend on ``dgl``:
+
+To install all MLIPs currently compatible with MACE, run:
 
 .. code-block:: python
 
     python3 -m pip install janus-core[all]
+
 
 Currently supported extras are:
 

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -62,16 +62,40 @@ Some libraries are not installed by default, but may improve performance, such a
 - `PyTorch implementation of DFTD3 <https://github.com/CheukHinHoJerry/torch-dftd.git>`_, which can be used by MACE calculations on GPU
 
 
-Updating DGL
-------------
+
+MLIP Incompatibilies
+====================
+
+Due to the different requirements of the MLIPs we support, it is not always possible to install all combinations of ``extras``.
+
+
+MLIPs requiring DGL
+------------------
 
 `DGL <https://github.com/dmlc/dgl>`_, which is a dependency of ``alignn`` and ``matgl``, no longer
 publishes to PyPI, and no longer publishes any packages for Windows or MacOS.
 
-When installing these MLIPs, ``janus-core`` will therefore automatically install the ``dgl==2.1.0``,
-as well as ``torch==2.2.0``, to ensure full compatibility.
+When installing these MLIPs on Linux or MacOS, ``janus-core`` will therefore automatically install
+``dgl==2.1.0``, as well as ``torch==2.2.0``, to ensure full compatibility. However, this is incompatible
+with ``chgnet``, and may limit the available features in others, including ``mace``.
 
 To use ``alignn`` and/or ``matgl`` with more recent versions of PyTorch, ``torch`` and ``dgl`` must
 both be upgraded manually. Please refer to their
 `installation instructions <https://www.dgl.ai/pages/start.html>`_ to upgrade ``dgl``, ensuring
 that the PyTorch version, CUDA version, and OS are selected appropriately.
+
+
+MLIPs with different versions of e3nn
+-------------------------------------
+
+Several MLIP packages, including ``mattersim``, ``fairchem``, and newer versions of ``sevennet``,
+depend on versions of ``e3nn`` that are incompatible the version required by ``mace``. So these cannot
+be installed together.
+
+
+MLIPs with limited OS support
+-----------------------------
+
+Several MLIP packages have limited support on Windows We are currently unable to
+support ``orb``, ``mattersim``, ``alignn`` or ``matgl`` as ``extras`` on Windows, so they
+must be installed manually.

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -96,6 +96,6 @@ be installed together.
 MLIPs with limited OS support
 -----------------------------
 
-Several MLIP packages have limited support on Windows We are currently unable to
+Several MLIP packages have limited support on Windows. We are currently unable to
 support ``orb``, ``mattersim``, ``alignn`` or ``matgl`` as ``extras`` on Windows, so they
 must be installed manually.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,14 +83,14 @@ mattersim = [
 
 # MLIPs with dgl dependency
 alignn = [
-    "alignn == 2024.5.27",
-    "torch == 2.2",
-    "torchdata == 0.7.1",
+    "alignn == 2024.5.27; sys_platform != 'win32'",
+    "torch == 2.2; sys_platform != 'win32'",
+    "torchdata == 0.7.1; sys_platform != 'win32'",
 ]
 m3gnet = [
-    "matgl == 1.1.3",
-    "torch == 2.2",
-    "torchdata == 0.7.1",
+    "matgl == 1.1.3; sys_platform != 'win32'",
+    "torch == 2.2; sys_platform != 'win32'",
+    "torchdata == 0.7.1; sys_platform != 'win32'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
MLIPs that depend on `dgl` haven't actually been working on Windows, but the tests pass due to the skips (e.g. https://github.com/stfc/janus-core/actions/runs/14931210938/job/41947679259).

```
Run uv sync --extra mace --extra m3gnet --extra alignn
Resolved 386 packages in 2ms
error: Distribution `dgl==2.1.0 @ registry+[https://pypi.org/simple`](https://pypi.org/simple%60) can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're on Windows (`win_amd64`), but `dgl` (v2.1.0) only has wheels for the following platforms: `manylinux1_x86_64`, `manylinux2014_aarch64`, `macosx_11_0_arm64`, `macosx_11_0_x86_64`
```

In theory there are other versions of dgl published for Windows, but since they've both stopped publishing on PyPI and stopped publishing even in their own repo for Windows (and MacOS), I think leaving it up to users is probably fine.

This includes a bit of a tidy up of the docs to reduce duplication - essentially moving from `dgl` specific info to a more general statement, as there are various other conflicts now too.