### PR TITLE
Fix typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ constraint-dependencies = [
     "tensorflow>=2.16.1",
     "tensorflow-io-gcs-filesystem<=0.31.0; sys_platform == 'win32'",
     "snowballstemmer<3",
+    "click<8.2.0",
 ]
 conflicts = [
     [


### PR DESCRIPTION
`click` 8.2.0 is causing issues with `typer` - see https://github.com/fastapi/typer/discussions/1215.

There is a PR to fix these issues, but it's been open for a little while (https://github.com/fastapi/typer/pull/1145), so I think setting a limit on `click` ourselves is probably best for now.