### PR TITLE
Fix writing optimisation trajectory to new directory

### DIFF
--- a/janus_core/calculations/geom_opt.py
+++ b/janus_core/calculations/geom_opt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 import warnings
 
@@ -243,9 +244,11 @@ class GeomOpt(BaseCalculation):
                     "Please use traj_kwargs['filename'] to save the trajectory"
                 )
 
+            # Set filenames for trajectory, and ensure directories exist
             self.traj_kwargs.setdefault(
                 "filename", self._build_filename("traj.extxyz").absolute()
             )
+            Path(self.traj_kwargs["filename"]).parent.mkdir(parents=True, exist_ok=True)
             self.opt_kwargs["trajectory"] = str(self.traj_kwargs["filename"])
 
         elif self.traj_kwargs:

--- a/tests/test_geom_opt.py
+++ b/tests/test_geom_opt.py
@@ -379,3 +379,40 @@ def test_missing_arch(struct):
     """Test missing arch."""
     with pytest.raises(ValueError, match="A calculator must be attached"):
         GeomOpt(struct=struct)
+
+
+def test_traj_new_dir(tmp_path):
+    """Test writing trajectory extxyz in new directory via file_prefix."""
+    new_dir = tmp_path / "test" / "test"
+    traj_path = new_dir / "NaCl-traj.extxyz"
+
+    optimizer = GeomOpt(
+        struct=DATA_PATH / "NaCl.cif",
+        arch="mace_mp",
+        model=MODEL_PATH,
+        write_traj=True,
+        file_prefix=new_dir / "NaCl",
+    )
+    optimizer.run()
+    assert traj_path.exists()
+    traj = read(traj_path, index=":")
+    assert len(traj) == 3
+
+
+def test_traj_kwargs_new_dir(tmp_path):
+    """Test writing trajectory in new directory via traj_kwargs."""
+    new_dir = tmp_path / "test" / "test"
+    traj_path = new_dir / "NaCl-traj.traj"
+
+    optimizer = GeomOpt(
+        struct=DATA_PATH / "NaCl.cif",
+        arch="mace_mp",
+        model=MODEL_PATH,
+        write_traj=True,
+        file_prefix=tmp_path / "NaCl",
+        traj_kwargs={"filename": traj_path},
+    )
+    optimizer.run()
+    assert traj_path.exists()
+    traj = read(traj_path, index=":")
+    assert len(traj) == 3


### PR DESCRIPTION
Resolves #522

(Tests added fail before changes added in the second commit)

As discussed in the issue, there are different options for solving this. For now, this simply creates the directory for the trajectory file, which allows initialisation of the dynamics as usual.

The other alternative discussed with @oerc0122 was potentially initialising the trajectory file to be written in a temporary directory, but I think that has the potential to be more confusing if a user inspects the `Trajectory` object, and the way that the [trajectory is attached to the dynamics](https://gitlab.com/ase/ase/-/blob/master/ase/optimize/optimize.py?ref_type=heads#L126) may make this quite messy.