### PR TITLE
Fix docs warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
         uses: pandoc/actions/setup@v1
 
       - name: Install dependencies
-        run: uv sync
+        run: |
+          uv sync --extra mace
+          uv pip install --reinstall pynvml
 
       - name: Build docs
         run: cd docs && uv run make html

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -70,7 +70,7 @@ Due to the different requirements of the MLIPs we support, it is not always poss
 
 
 MLIPs requiring DGL
-------------------
+-------------------
 
 `DGL <https://github.com/dmlc/dgl>`_, which is a dependency of ``alignn`` and ``matgl``, no longer
 publishes to PyPI, and no longer publishes any packages for Windows or MacOS.


### PR DESCRIPTION
Fixes warning from underline being too short, and missing mace imports, which have knock-on effects for training/pre-processing.