### PR TITLE
Fix an incorrect pressure unit in the documentation

### DIFF
--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -285,7 +285,7 @@ For all options, run ``janus geomopt --help``.
 Molecular dynamics
 ------------------
 
-Run an NPT molecular dynamics simulation (using the `MACE-MP <https://github.com/ACEsuit/mace-mp>`_ "small" force-field) at 300K and 1 bar for 1000 steps (1 ps, default time-step is 1 fs):
+Run an NPT molecular dynamics simulation (using the `MACE-MP <https://github.com/ACEsuit/mace-mp>`_ "small" force-field) at 300K and 1 GPa for 1000 steps (1 ps, default time-step is 1 fs):
 
 .. code-block:: bash
 


### PR DESCRIPTION
The example md command given in the documentation gives the unit of pressure as bar, but this does not seem to be correct and I believe that it should be GPa