### PR TITLE
Update dpa

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ chgnet = [
     "chgnet == 0.4.0",
 ]
 dpa3 = [
-    "deepmd-kit",
+    "deepmd-kit == 3.1.0",
 ]
 grace = [
     "tensorpotential == 0.5.1",
@@ -274,6 +274,3 @@ conflicts = [
       { extra = "all" },
     ],
 ]
-
-[tool.uv.sources]
-deepmd-kit = { git = "https://github.com/deepmodeling/deepmd-kit.git", rev = "dpa3-alpha" }


### PR DESCRIPTION
I think we can drop the specific tag now, as DPA3 has been properly [released](https://github.com/deepmodeling/deepmd-kit/releases/tag/v3.1.0). This was also one of the main barriers to Python 3.13.