### PR TITLE
Add warning for deprecated CLI parameters

### DIFF
--- a/janus_core/cli/geomopt.py
+++ b/janus_core/cli/geomopt.py
@@ -23,7 +23,7 @@ from janus_core.cli.types import (
     Tracker,
     WriteKwargs,
 )
-from janus_core.cli.utils import yaml_converter_callback
+from janus_core.cli.utils import deprecated_option, yaml_converter_callback
 
 app = Typer()
 
@@ -127,7 +127,12 @@ def geomopt(
     ] = None,
     filter_func: Annotated[
         str | None,
-        Option(help="Deprecated. Please use --filter", rich_help_panel="Calculation"),
+        Option(
+            help="Deprecated. Please use --filter",
+            rich_help_panel="Calculation",
+            callback=deprecated_option,
+            hidden=True,
+        ),
     ] = None,
     pressure: Annotated[
         float,

--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Annotated, get_args
 from click import Choice
 from typer import Option
 
+from janus_core.cli.utils import deprecated_option
 from janus_core.helpers.janus_types import Architectures, Devices
 
 if TYPE_CHECKING:
@@ -101,7 +102,12 @@ Model = Annotated[
 ]
 ModelPath = Annotated[
     str | None,
-    Option(help="Deprecated. Please use --model", rich_help_panel="MLIP calculator"),
+    Option(
+        help="Deprecated. Please use --model",
+        rich_help_panel="MLIP calculator",
+        callback=deprecated_option,
+        hidden=True,
+    ),
 ]
 
 FilePrefix = Annotated[

--- a/janus_core/cli/utils.py
+++ b/janus_core/cli/utils.py
@@ -9,6 +9,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from typer import CallbackParam, secho
+from typer.colors import YELLOW
 from typer_config import conf_callback_factory, yaml_loader
 import yaml
 
@@ -409,3 +411,25 @@ def parse_correlation_kwargs(kwargs: CorrelationKwargs) -> list[dict]:
 
         parsed_kwargs.append(cor_kwargs)
     return parsed_kwargs
+
+
+# Callback to print warning for deprecated options
+def deprecated_option(param: CallbackParam, value: Any):
+    """
+    Print warning for deprecated option.
+
+    Parameters
+    ----------
+    param
+        Callback parameters from typer.
+    value
+        Value of parameter.
+
+    Returns
+    -------
+    Any
+        Unmodified parameter value.
+    """
+    if value:
+        secho(f"Warning: --{param.name} is deprecated.", fg=YELLOW)
+    return value


### PR DESCRIPTION
- Hides deprecated CLI options
- Prints warning if deprecated option is used
- ~Updates CLI dependencies~ (not strictly needed, but relevant, and helped establish that #547 still cannot be used with typer, even with click 8.2 installed)
  - Removed, as there's currently a bug related to help with no commands (i.e. just running `janus`): https://github.com/fastapi/typer/pull/1240