### PR TITLE
Update minimize_kwargs CLI help

### DIFF
--- a/janus_core/cli/types.py
+++ b/janus_core/cli/types.py
@@ -192,8 +192,9 @@ MinimizeKwargs = Annotated[
         parser=parse_dict_class,
         help=(
             """
-            Keyword arguments to pass to optimizer. Must be passed as a dictionary
-            wrapped in quotes, e.g. "{'key': value}".
+            Keyword arguments to pass to geometry optimizer, including "opt_kwargs",
+            "filter_kwargs", and "traj_kwargs". Must be passed as a dictionary wrapped
+            in quotes, e.g. "{'key': value}".
             """
         ),
         metavar="DICT",


### PR DESCRIPTION
Resolves #551

Clarifies the `--minimize-kwargs` help, used by `janus geomopt`, `janus md`, etc. due to ambiguity between geometry optimiser and ASE optimiser class keyword arguments (`minimise_kwargs` vs `opt_kwargs`).

Also states more explicitly that other kwargs e.g. `filter_kwargs` are set this way.