### PR TITLE
Add calculator option for dispersion correction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install updated e3nn dependencies
         run: |
-          uv sync --extra mattersim --extra fairchem
+          uv sync --extra mattersim --extra fairchem --extra d3
           uv pip install --reinstall pynvml
           uv pip install fairchem-core[torch-extras] --no-build-isolation
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install dgl dependencies
         run: |
-          uv sync --extra mace --extra m3gnet --extra alignn
+          uv sync --extra mace --extra m3gnet --extra alignn --extra d3
           uv pip install --reinstall pynvml
 
       - name: Run test suite for dgl dependencies

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install updated e3nn dependencies
         run: |
-          uv sync --extra mattersim --extra fairchem
+          uv sync --extra mattersim --extra fairchem --extra d3
           uv pip install --reinstall pynvml
           uv pip install "fairchem-core[torch-extras]" --no-build-isolation
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install dgl dependencies
         run: |
-          uv sync --extra mace --extra m3gnet --extra alignn
+          uv sync --extra mace --extra m3gnet --extra alignn --extra d3
           uv pip install --reinstall pynvml
 
       - name: Run test suite for dgl dependencies

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -243,4 +243,5 @@ nitpick_ignore = [
     ("py:class", "Progress"),
     ("py:class", "ProgressBar"),
     ("py:class", "typer.models.CallbackParam"),
+    ("py:class", "SumCalculator"),
 ]

--- a/docs/source/user_guide/get_started.rst
+++ b/docs/source/user_guide/get_started.rst
@@ -69,6 +69,7 @@ Currently supported MLIP ``extras`` are:
 
 Additional features can also be enabled as ``extras``:
 
+- ``d3``: `DFTD3 <https://github.com/pfnet-research/torch-dftd>`_
 - ``visualise``: `WEAS Widget <https://github.com/superstar54/weas-widget>`_
 - ``plumed``: `PLUMED <https://www.plumed.org>`_
 

--- a/docs/source/user_guide/python.rst
+++ b/docs/source/user_guide/python.rst
@@ -98,6 +98,60 @@ will return
     unless the same ``arch`` is chosen, in which case these values will also be overwritten.
 
 
+D3 Dispersion
+=============
+
+A PyTorch implementation of DFTD2 and DFTD3, using the `TorchDFTD3Calculator <https://github.com/pfnet-research/torch-dftd>`_,
+can be used to add dispersion corrections to MLIP predictions.
+
+The required Python pacakge is included with ``mace_mp``, but can also be installed as its own extra:
+
+.. code-block:: bash
+
+    pip install janus-core[d3]
+
+
+Once installed, dispersion can be added through ``calc_kwargs`` through the ``dispersion`` keyword,
+with ``dispersion_kwargs`` used to pass any further keywords to the ``TorchDFTD3Calculator``:
+
+.. code-block:: python
+
+    from ase import units
+
+    from janus_core.calculations.single_point import SinglePoint
+
+    single_point = SinglePoint(
+        struct="tests/data/NaCl.cif",
+        arch="mace_mp",
+        model="tests/models/mace_mp_small.model",
+        calc_kwargs={"dispersion": True, "dispersion_kwargs": {"cutoff":  95.0 * units.Bohr}}
+    )
+
+.. note::
+    In most cases, defaults for ``dispersion_kwargs`` are those set within ``TorchDFTD3Calculator``,
+    but in the case of ``mace_mp``, we mirror the corresponding defaults from the
+    ``mace.calculators.mace_mp`` function.
+
+
+The ``TorchDFTD3Calculator`` can also be added to any existing calculator if required:
+
+.. note::
+    Keyword arguments for ``TorchDFTD3Calculator`` should be passed directly here,
+    as shown with ``cutoff``. This will not have access to ``mace_mp`` default values,
+    so will always use defaults from ``TorchDFTD3Calculator``.
+
+
+.. code-block:: python
+
+    from ase import units
+
+    from janus_core.helpers.mlip_calculators import add_dispersion, choose_calculator
+
+    mace_calc = choose_calculator("mace_mp")
+    calc = add_dispersion(mace_calc, device="cpu", cutoff=95 * units.Bohr)
+
+
+
 Additional Calculators
 ======================
 

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, get_args
-import warnings
 
 from ase import units
 from ase.calculators.mixing import SumCalculator
@@ -205,13 +204,7 @@ def choose_calculator(
             model = model if model else "small"
             kwargs.setdefault("default_dtype", "float64")
 
-            # Remove dispersion (to be added later for any calculator)
-            if dispersion and not kwargs.get("dispersion", True):
-                warnings.warn(
-                    "`dispersion` set in two places. kwargs value will be used",
-                    stacklevel=2,
-                )
-            dispersion = kwargs.pop("dispersion", dispersion)
+            # Set mace_mp dispersion defaults
             dispersion_kwargs.setdefault("damping", kwargs.pop("damping", "bj"))
             dispersion_kwargs.setdefault("xc", kwargs.pop("dispersion_xc", "pbe"))
             dispersion_kwargs.setdefault(

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, get_args
+import warnings
 
+from ase import units
 from ase.calculators.mixing import SumCalculator
+from torch import get_default_dtype
+from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
 
 from janus_core.helpers.janus_types import Architectures, Devices, PathLike
 from janus_core.helpers.utils import none_to_dict
@@ -83,10 +87,42 @@ def _set_no_weights_only_load():
     environ.setdefault("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", "1")
 
 
+def add_dispersion(
+    calc: Calculator, device: Devices, dtype: torch.dtype, **kwargs
+) -> SumCalculator:
+    """
+    Add D3 dispersion calculator to existing calculator.
+
+    Parameters
+    ----------
+    calc
+        Calculator to add D3 correction to.
+    device
+        Device to run calculator on. Default is "cpu".
+    dtype
+        Calculation precision.
+    **kwargs
+        Additional keyword arguments passed to `TorchDFTD3Calculator`.
+
+    Returns
+    -------
+    SumCalculator
+        Configured calculator with D3 dispersion correction added.
+    """
+    d3_calc = TorchDFTD3Calculator(
+        device=device,
+        dtype=dtype,
+        **kwargs,
+    )
+    return SumCalculator([calc, d3_calc])
+
+
 def choose_calculator(
     arch: Architectures,
     device: Devices = "cpu",
     model: PathLike | None = None,
+    dispersion: bool = False,
+    dispersion_kwargs: dict[str, Any] | None = None,
     **kwargs,
 ) -> Calculator:
     """
@@ -100,6 +136,11 @@ def choose_calculator(
         Device to run calculator on. Default is "cpu".
     model
         MLIP model label, path to model, or loaded model. Default is `None`.
+    dispersion
+        Whether to add D3 dispersion.
+    dispersion_kwargs
+        Additional keyword arguments for `TorchDFTD3Calculator`. Defaults for mace_mp
+        are taken from mace_mp's defaults.
     **kwargs
         Additional keyword arguments passed to the selected calculator.
 
@@ -115,6 +156,8 @@ def choose_calculator(
     ValueError
         Invalid architecture specified.
     """
+    dispersion_kwargs = dispersion_kwargs if dispersion_kwargs else {}
+
     model = _set_model(model, kwargs)
 
     if device not in get_args(Devices):
@@ -145,6 +188,19 @@ def choose_calculator(
             # Default to "small" model and float64 precision
             model = model if model else "small"
             kwargs.setdefault("default_dtype", "float64")
+
+            # Remove dispersion (to be added later for any calculator)
+            if dispersion and not kwargs.get("dispersion", True):
+                warnings.warn(
+                    "`dispersion` set in two places. kwargs value will be used",
+                    stacklevel=2,
+                )
+            dispersion = kwargs.pop("dispersion", dispersion)
+            dispersion_kwargs.setdefault("damping", kwargs.pop("damping", "bj"))
+            dispersion_kwargs.setdefault("xc", kwargs.pop("dispersion_xc", "pbe"))
+            dispersion_kwargs.setdefault(
+                "cutoff", kwargs.pop("dispersion_cutoff", 40.0 * units.Bohr)
+            )
 
             calculator = mace_mp(model=model, device=device, **kwargs)
 
@@ -381,6 +437,11 @@ def choose_calculator(
     calculator.parameters["version"] = __version__
     calculator.parameters["arch"] = arch
     calculator.parameters["model"] = str(model)
+
+    if dispersion:
+        return add_dispersion(
+            calculator, device, get_default_dtype(), **dispersion_kwargs
+        )
 
     return calculator
 

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -87,7 +87,10 @@ def _set_no_weights_only_load():
 
 
 def add_dispersion(
-    calc: Calculator, device: Devices, dtype: torch.dtype, **kwargs
+    calc: Calculator,
+    device: Devices = "cpu",
+    dtype: torch.dtype | None = None,
+    **kwargs,
 ) -> SumCalculator:
     """
     Add D3 dispersion calculator to existing calculator.
@@ -99,7 +102,7 @@ def add_dispersion(
     device
         Device to run calculator on. Default is "cpu".
     dtype
-        Calculation precision.
+        Calculation precision. Default is current torch dtype.
     **kwargs
         Additional keyword arguments passed to `TorchDFTD3Calculator`.
 
@@ -112,6 +115,8 @@ def add_dispersion(
         from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
     except ImportError as err:
         raise ImportError("Please install the d3 extra.") from err
+
+    dtype = dtype if dtype else get_default_dtype()
 
     d3_calc = TorchDFTD3Calculator(
         device=device,
@@ -445,9 +450,7 @@ def choose_calculator(
     calculator.parameters["model"] = str(model)
 
     if dispersion:
-        return add_dispersion(
-            calculator, device, get_default_dtype(), **dispersion_kwargs
-        )
+        return add_dispersion(calc=calculator, device=device, **dispersion_kwargs)
 
     return calculator
 

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -114,7 +114,9 @@ def add_dispersion(
         dtype=dtype,
         **kwargs,
     )
-    return SumCalculator([calc, d3_calc])
+    sum_calc = SumCalculator([calc, d3_calc])
+    sum_calc.parameters = calc.parameters
+    return sum_calc
 
 
 def choose_calculator(

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -128,7 +128,7 @@ def add_dispersion(
     # Copy calculator parameters to make more accessible
     sum_calc.parameters = calc.parameters
     if "arch" in sum_calc.parameters:
-        sum_calc.parameters["arch"] = sum_calc.parameters["arch"] + "-d3"
+        sum_calc.parameters["arch"] = sum_calc.parameters["arch"] + "_d3"
 
     return sum_calc
 

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -16,7 +16,6 @@ import warnings
 from ase import units
 from ase.calculators.mixing import SumCalculator
 from torch import get_default_dtype
-from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
 
 from janus_core.helpers.janus_types import Architectures, Devices, PathLike
 from janus_core.helpers.utils import none_to_dict
@@ -109,6 +108,11 @@ def add_dispersion(
     SumCalculator
         Configured calculator with D3 dispersion correction added.
     """
+    try:
+        from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
+    except ImportError as err:
+        raise ImportError("Please install the d3 extra.") from err
+
     d3_calc = TorchDFTD3Calculator(
         device=device,
         dtype=dtype,

--- a/janus_core/helpers/mlip_calculators.py
+++ b/janus_core/helpers/mlip_calculators.py
@@ -124,7 +124,12 @@ def add_dispersion(
         **kwargs,
     )
     sum_calc = SumCalculator([calc, d3_calc])
+
+    # Copy calculator parameters to make more accessible
     sum_calc.parameters = calc.parameters
+    if "arch" in sum_calc.parameters:
+        sum_calc.parameters["arch"] = sum_calc.parameters["arch"] + "-d3"
+
     return sum_calc
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,8 @@ visualise = [
 ]
 all = [
     "janus-core[chgnet]",
-    "janus-core[dpa3]",
     "janus-core[grace]",
+    "janus-core[d3]",
     "janus-core[mace]",
     "janus-core[nequip]",
     "janus-core[orb]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dpa3 = [
     "deepmd-kit == 3.1.0",
 ]
 d3 = [
-    "torch-dftd==0.4.0",
+    "torch-dftd==0.5.1",
 ]
 grace = [
     "tensorpotential == 0.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,15 @@ chgnet = [
 dpa3 = [
     "deepmd-kit == 3.1.0",
 ]
+d3 = [
+    "torch-dftd==0.4.0",
+]
 grace = [
     "tensorpotential == 0.5.1",
 ]
 mace = [
     "mace-torch==0.3.13",
-    "torch-dftd==0.4.0",
+    "janus-core[d3]",
 ]
 nequip = [
     "nequip == 0.6.1",

--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -119,7 +119,7 @@ def test_dispersion():
     descriptors_disp.run()
 
     assert (
-        descriptors_disp.struct.info["mace_mp_descriptor"]
+        descriptors_disp.struct.info["mace_mp_d3_descriptor"]
         == descriptors.struct.info["mace_mp_descriptor"]
     )
 

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -8,7 +8,7 @@ from zipfile import BadZipFile
 
 import pytest
 
-from janus_core.helpers.mlip_calculators import choose_calculator
+from janus_core.helpers.mlip_calculators import add_dispersion, choose_calculator
 from tests.utils import skip_extras
 
 MODEL_PATH = Path(__file__).parent / "models"
@@ -244,3 +244,24 @@ def test_invalid_device(arch):
     """Test error raised if invalid device is specified."""
     with pytest.raises(ValueError):
         choose_calculator(arch=arch, device="invalid")
+
+
+def test_d3():
+    """Test adding D3 dispersion calculator automatically."""
+    skip_extras("mace_mp")
+
+    calculator = choose_calculator(arch="mace_mp", dispersion=True)
+    assert calculator.parameters["version"] is not None
+    assert calculator.parameters["model"] is not None
+    assert calculator.parameters["arch"] == "mace_mp-d3"
+
+
+def test_d3_manual():
+    """Test adding D3 dispersion calculator manually."""
+    skip_extras("mace_mp")
+
+    calculator = choose_calculator(arch="mace_mp")
+    calculator = add_dispersion(calculator)
+    assert calculator.parameters["version"] is not None
+    assert calculator.parameters["model"] is not None
+    assert calculator.parameters["arch"] == "mace_mp-d3"

--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -253,7 +253,7 @@ def test_d3():
     calculator = choose_calculator(arch="mace_mp", dispersion=True)
     assert calculator.parameters["version"] is not None
     assert calculator.parameters["model"] is not None
-    assert calculator.parameters["arch"] == "mace_mp-d3"
+    assert calculator.parameters["arch"] == "mace_mp_d3"
 
 
 def test_d3_manual():
@@ -264,4 +264,4 @@ def test_d3_manual():
     calculator = add_dispersion(calculator)
     assert calculator.parameters["version"] is not None
     assert calculator.parameters["model"] is not None
-    assert calculator.parameters["arch"] == "mace_mp-d3"
+    assert calculator.parameters["arch"] == "mace_mp_d3"

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -569,3 +569,30 @@ def test_dispersion(arch, pred):
     d3_results = sp_d3.run()
 
     assert (d3_results["energy"] - no_d3_results["energy"]) == pytest.approx(pred)
+
+
+def test_mace_mp_dispersion():
+    """Test mace_mp dispersion correction matches default."""
+    skip_extras("mace_mp")
+    pytest.importorskip("torch_dftd")
+
+    from mace.calculators import mace_mp
+
+    data_path = DATA_PATH / "benzene.xyz"
+    d3_energy = SinglePoint(
+        struct=data_path,
+        arch="mace_mp",
+        properties="energy",
+        calc_kwargs={"dispersion": True},
+    ).run()["energy"]
+
+    struct = read(data_path)
+    struct.calc = mace_mp(model="small", dispersion=True)
+
+    mace_d3_energy = SinglePoint(
+        struct=struct,
+        properties="energy",
+        calc_kwargs={"dispersion": False},
+    ).run()["energy"]
+
+    assert d3_energy == pytest.approx(mace_d3_energy)

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -537,10 +537,11 @@ def test_missing_arch(struct):
 @pytest.mark.parametrize(
     "arch, pred",
     [
+        ("m3gnet", -0.08281749),
         ("mace_mp", -0.29815768),
         ("mace_off", -0.08281747),
-        ("sevennet", -0.08281749),
         ("mattersim", -0.08281749),
+        ("sevennet", -0.08281749),
     ],
 )
 def test_dispersion(arch, pred):

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -547,6 +547,7 @@ def test_missing_arch(struct):
 def test_dispersion(arch, pred):
     """Test dispersion correction."""
     skip_extras(arch)
+    pytest.importorskip("torch_dftd")
 
     data_path = DATA_PATH / "benzene.xyz"
     sp_no_d3 = SinglePoint(

--- a/tests/test_singlepoint_cli.py
+++ b/tests/test_singlepoint_cli.py
@@ -434,10 +434,10 @@ def test_hessian(tmp_path):
     assert result.exit_code == 0
 
     atoms = read(results_path)
-    assert "mace_mp_energy" in atoms.info
-    assert "mace_mp_hessian" in atoms.info
-    assert "mace_stress" not in atoms.info
-    assert atoms.info["mace_mp_hessian"].shape == (24, 8, 3)
+    assert "mace_mp_d3_energy" in atoms.info
+    assert "mace_mp_d3_hessian" in atoms.info
+    assert "mace_mp_d3_stress" not in atoms.info
+    assert atoms.info["mace_mp_d3_hessian"].shape == (24, 8, 3)
     assert atoms.info["units"]["hessian"] == "ev/Ang^2"
 
 


### PR DESCRIPTION
Resolves #567

- Adds `d3` optional extra
- Adds `dispersion` and `dispersion_kwargs` to `choose_calculator`, allowing any calculator to be converted into a `SumCalculator` composed of the original calculator, and the `TorchDFTD3Calculator`.
  - This is not currently exposed directly to calculations, but can be set via `calc_kwargs`. The option remains open to add these as full parameters to all calculations in the future, and it's documented as is for now
- Adds `_d3` label to `calc.parameters.arch` e.g. `mace_mp_d3_energy`. This is also the case for values that don't depend on the dispersion, e.g. descriptors, but I thought it might be better to be consistent with the `arch` label. I'm also very happy to revert to `mace_mp_descriptors` if this is preferable.
- For `mace_mp`, I use their default parameters, as it felt like the least worst option, as I'm not sure it makes sense to apply these defaults for all calculators, but it would also be confusing changing the default `mace_mp` parameters.