### PR TITLE
Fix dev CI

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -38,4 +38,4 @@ jobs:
       env:
         # show timings of tests
         PYTEST_ADDOPTS: "--durations=0"
-      run: uv run pytest .
+      run: uv run --no-sync pytest .


### PR DESCRIPTION
Adds missing `--no-sync` option to `uv run` in dev CI workflow, which is required to prevent numpy being upgraded on `uv run`.

See: https://github.com/stfc/janus-core/pull/574#discussion_r2228786339