### PR TITLE
Use uv build and fix built content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,8 +152,12 @@ pre-commit = [
 ]
 
 [build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
+requires = ["uv_build>=0.8.4,<0.9.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = "janus_core"
+module-root = ""
 
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)


### PR DESCRIPTION
Replaces `pdm` (which was always relatively arbitrary) with relatively new (but now relatively stable) uv build backend.

More importantly, fixes the zipped contents, which has been including `/tests`, which is why the upload was starting to exceed 100 MB and being rejected by PyPI, as this included various models for testing.

Please do not merge until #578 is merged.