### PR TITLE
Update ASE documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ for additional information, or [open an issue](https://github.com/stfc/janus-cor
 
 ## Features
 
-Unless stated otherwise, MLIP calculators and calculations rely heavily on [ASE](https://wiki.fysik.dtu.dk/ase/).
+Unless stated otherwise, MLIP calculators and calculations rely heavily on [ASE](https://ase-lib.org).
 
 Current and planned features include:
 
@@ -147,7 +147,7 @@ Jupyter Notebook tutorials illustrating the use of currently available calculati
 
 ### Calculation outputs
 
-By default, calculations performed will modify the underlying [ase.Atoms](https://wiki.fysik.dtu.dk/ase/ase/atoms.html) object
+By default, calculations performed will modify the underlying [ase.Atoms](https://ase-lib.org/ase/atoms.html) object
 to store information in the `Atoms.info` and `Atoms.arrays` dictionaries about the MLIP used.
 
 Additional dictionary keys include `arch`, corresponding to the MLIP architecture used,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ numpydoc_class_members_toctree = False
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "ase": ("https://wiki.fysik.dtu.dk/ase/", None),
+    "ase": ("https://ase-lib.org/", None),
     "phonopy": ("https://phonopy.github.io/phonopy/", None),
     "codecarbon": ("https://mlco2.github.io/codecarbon/", None),
     "torch": ("https://pytorch.org/docs/stable", None),

--- a/docs/source/developer_guide/tutorial.rst
+++ b/docs/source/developer_guide/tutorial.rst
@@ -5,7 +5,7 @@ Tutorial
 Adding a new MLIP
 =================
 
-Integration of new MLIPs currently requires a corresponding `ASE calculator <https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html>`_.
+Integration of new MLIPs currently requires a corresponding `ASE calculator <https://ase-lib.org/ase/calculators/calculators.html>`_.
 
 The following steps can then be taken, using `ORB <https://github.com/orbital-materials/orb-models>`_ as an example:
 

--- a/docs/source/user_guide/command_line.rst
+++ b/docs/source/user_guide/command_line.rst
@@ -191,7 +191,7 @@ will save the main output file to ``./results/NaCl.extxyz``, but the summary and
 Data saved
 ++++++++++
 
-By default, calculations performed will modify the underlying `ase.Atoms <https://wiki.fysik.dtu.dk/ase/ase/atoms.html>`_ object
+By default, calculations performed will modify the underlying `ase.Atoms <https://ase-lib.org/ase/atoms.html>`_ object
 to store information in the ``Atoms.info`` and ``Atoms.arrays`` dictionaries about the MLIP used.
 
 Additional dictionary keys include ``arch``, corresponding to the MLIP architecture used,
@@ -453,7 +453,7 @@ In addition to the standard `Molecular dynamics`_ output files, this will also s
 and any other output files specified by the input file, such as ``COLVAR`` in this example.
 
 .. warning::
-    `Unit conversions <https://wiki.fysik.dtu.dk/ase/ase/calculators/plumed.html#units>`_ are necessary to maintain consistency with ASE.
+    `Unit conversions <https://ase-lib.org/ase/calculators/plumed.html#units>`_ are necessary to maintain consistency with ASE.
 
 
 Equation of State
@@ -607,7 +607,7 @@ Run the Nudged Elastic Band method (using the `MACE-MP <https://github.com/ACEsu
     janus neb --init-struct tests/data/N2.xyz --final-struct tests/data/2N.xyz --arch mace_mp --minimize
 
 
-This will use ASE's built-in `interpolation <https://wiki.fysik.dtu.dk/ase/ase/neb.html#interpolation>`_
+This will use ASE's built-in `interpolation <https://ase-lib.org/ase/neb.html#interpolation>`_
 between the minimized initial and final structures, before applying ASE's ``NEBOptimizer``, an adaptive ODE solver,
 to the NEB.
 
@@ -623,7 +623,7 @@ this can be passed instead of the initial and final structures:
 
 
 Additional options include using `pymatgen to interpolate <https://pymatgen.org/pymatgen.core.html#pymatgen.core.structure.IStructure.interpolate>`_,
-with the ``--interpolator`` option, using `DyNEB <https://wiki.fysik.dtu.dk/ase/ase/neb.html#ase.mep.dyneb.DyNEB>`_ for scaled and dynamic
+with the ``--interpolator`` option, using `DyNEB <https://ase-lib.org/ase/neb.html#ase.mep.dyneb.DyNEB>`_ for scaled and dynamic
 optimizations of images through the ``--neb-method`` option, and changing the optimizer using the ``--neb-optimizer`` option.
 
 

--- a/docs/source/user_guide/python.rst
+++ b/docs/source/user_guide/python.rst
@@ -156,12 +156,12 @@ Additional Calculators
 ======================
 
 Although ``janus-core`` only directly supports the MLIP calculators listed in :doc:`Getting started </user_guide/get_started>`,
-any valid `ASE calculator <https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html>`_
+any valid `ASE calculator <https://ase-lib.org/ase/calculators/calculators.html>`_
 can be attached to a structure, including calculators for currently unsupported MLIPs.
 
 This structure can then be passed to ``janus-core`` calculations, which can be run as usual.
 
-For example, performing geometry optimisation using the (`ASE built-in <https://wiki.fysik.dtu.dk/ase/ase/calculators/others.html#lennard-jones>`_) Lennard Jones potential calculator:
+For example, performing geometry optimisation using the (`ASE built-in <https://ase-lib.org/ase/calculators/others.html#lennard-jones>`_) Lennard Jones potential calculator:
 
 .. code-block:: python
 


### PR DESCRIPTION
Resolves #584

I think the catches all the links in our documentation, but the main priority is updating `intersphinx_mapping`, to fix warnings when building the docs, as other links generally redirect for now.