### PR TITLE
Update HTTPError message catch

### DIFF
--- a/tests/test_mlip_calculators.py
+++ b/tests/test_mlip_calculators.py
@@ -169,7 +169,7 @@ def test_mlips(arch, device, kwargs):
     except BadZipFile:
         pytest.skip("Model download failed")
     except HTTPError as err:  # Inherits from URLError, so check first
-        if "Service Unavailable" in err.msg or "Too Many Requests for url" in err.msg:
+        if "Service Unavailable" in err.msg or "Too Many Requests" in err.msg:
             pytest.skip("Model download failed")
         raise err
     except URLError as err:

--- a/tests/test_single_point.py
+++ b/tests/test_single_point.py
@@ -183,7 +183,7 @@ def test_extras(arch, device, expected_energy, struct, kwargs):
         energy = single_point.run()["energy"]
         assert energy == pytest.approx(expected_energy, rel=1e-3)
     except HTTPError as err:  # Inherits from URLError, so check first
-        if "Service Unavailable" in err.msg or "Too Many Requests for url" in err.msg:
+        if "Service Unavailable" in err.msg or "Too Many Requests" in err.msg:
             pytest.skip("Model download failed")
         raise err
     except URLError as err:


### PR DESCRIPTION
The error message for too many requests seems to have changed, so is not getting caught in our tests:

> urllib.error.HTTPError: HTTP Error 429: Too Many Requests

(From https://github.com/stfc/janus-core/actions/runs/17325947293/job/49190000318)