### PR TITLE
Remove SevenNet from tutorials

### DIFF
--- a/docs/source/tutorials/cli/geomopt.ipynb
+++ b/docs/source/tutorials/cli/geomopt.ipynb
@@ -50,7 +50,7 @@
     "# ! pip uninstall torch torchaudio torchvision transformers -y # Uninstall pre-installed torch\n",
     "# ! uv pip install torch==2.5.1 # Install pinned version of torch\n",
     "\n",
-    "# ! uv pip install janus-core[mace,sevennet,visualise] data-tutorials --system # Install janus-core with MACE, SevenNet, and WeasWidget, and data-tutorials\n",
+    "# ! uv pip install janus-core[mace,orb,visualise] data-tutorials --system # Install janus-core with MACE, Orb, and WeasWidget, and data-tutorials\n",
     "\n",
     "# get_ipython().kernel.do_shutdown(restart=True) # Restart kernel to update libraries. This may warn that your session has crashed."
    ]
@@ -502,14 +502,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Comparing MACE to SevenNet"
+    "## Comparing MACE to Orb"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, let's compare to the structure optimised by SevenNet:"
+    "Finally, let's compare to the structure optimised by Orb:"
    ]
   },
   {
@@ -538,7 +538,7 @@
    "outputs": [],
    "source": [
     "! janus geomopt --config geomopt_config_mace.yml\n",
-    "! janus geomopt --config geomopt_config_mace.yml --arch sevennet --file-prefix janus_results/NaCl-sevennet"
+    "! janus geomopt --config geomopt_config_mace.yml --arch orb --file-prefix janus_results/NaCl-orb"
    ]
   },
   {
@@ -558,8 +558,8 @@
     "from weas_widget import WeasWidget\n",
     "\n",
     "mace_opt = read(\"janus_results/NaCl-mace-opt.extxyz\")\n",
-    "sevennet_opt = read(\"janus_results/NaCl-sevennet-opt.extxyz\")\n",
-    "opt_comparison = [mace_opt, sevennet_opt]\n",
+    "orb_opt = read(\"janus_results/NaCl-orb-opt.extxyz\")\n",
+    "opt_comparison = [mace_opt, orb_opt]\n",
     "\n",
     "v=WeasWidget()\n",
     "v.from_ase(opt_comparison)\n",

--- a/docs/source/tutorials/cli/singlepoint.ipynb
+++ b/docs/source/tutorials/cli/singlepoint.ipynb
@@ -23,7 +23,7 @@
     "id": "4vcbRxmIhHLL"
    },
    "source": [
-    "`janus-core` contains various machine learnt interatomic potentials (MLIPs), including MACE based models (MACE-MP, MACE-OFF), CHGNet, SevenNet and more, full list on https://github.com/stfc/janus-core.\n",
+    "`janus-core` contains various machine learnt interatomic potentials (MLIPs), including MACE based models (MACE-MP, MACE-OFF), CHGNet, Orb and more, full list on https://github.com/stfc/janus-core.\n",
     "\n",
     "Other will be added as their utility is proven beyond a specific material."
    ]
@@ -59,7 +59,7 @@
     "# ! pip uninstall torch torchaudio torchvision transformers -y # Uninstall pre-installed torch\n",
     "# ! uv pip install torch==2.5.1 # Install pinned version of torch\n",
     "\n",
-    "# ! uv pip install janus-core[mace,sevennet,visualise] data-tutorials --system # Install janus-core with MACE, SevenNet, and WeasWidget, and data-tutorials\n",
+    "# ! uv pip install janus-core[mace,orb,visualise] data-tutorials --system # Install janus-core with MACE, Orb, and WeasWidget, and data-tutorials\n",
     "\n",
     "# get_ipython().kernel.do_shutdown(restart=True) # Restart kernel to update libraries. This may warn that your session has crashed."
    ]
@@ -450,7 +450,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For example, if we re-run the calculation using SevenNet, saving the results to a new output file, we see that \"mace_mp_energy\" is still saved, other unlabelled results are updated:"
+    "For example, if we re-run the calculation using Orb, saving the results to a new output file, we see that \"mace_mp_energy\" is still saved, other unlabelled results are updated:"
    ]
   },
   {
@@ -459,7 +459,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! janus singlepoint --struct janus_results/NaCl-results.extxyz --arch sevennet --out janus_results/NaCl-updated-results.extxyz --no-tracker"
+    "! janus singlepoint --struct janus_results/NaCl-results.extxyz --arch orb --out janus_results/NaCl-updated-results.extxyz --no-tracker"
    ]
   },
   {
@@ -483,7 +483,7 @@
     "\n",
     "print()\n",
     "print(updated_results.info[\"mace_mp_energy\"])\n",
-    "print(updated_results.info[\"sevennet_energy\"])\n",
+    "print(updated_results.info[\"orb_energy\"])\n",
     "print(updated_results.calc.results[\"energy\"])\n",
     "print(updated_results.get_potential_energy())\n",
     "print(updated_results.get_total_energy())"

--- a/docs/source/tutorials/python/eos.ipynb
+++ b/docs/source/tutorials/python/eos.ipynb
@@ -50,7 +50,7 @@
     "# ! pip uninstall torch torchaudio torchvision transformers -y # Uninstall pre-installed torch\n",
     "# ! uv pip install torch==2.5.1 # Install pinned version of torch\n",
     "\n",
-    "# ! uv pip install janus-core[mace,sevennet,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, SevenNet, CHGNet, and WeasWidget, and data-tutorials\n",
+    "# ! uv pip install janus-core[mace,orb,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, Orb, CHGNet, and WeasWidget, and data-tutorials\n",
     "\n",
     "# get_ipython().kernel.do_shutdown(restart=True) # Restart kernel to update libraries. This may warn that your session has crashed."
    ]
@@ -292,7 +292,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Comparing MACE to CHGNeT and SevenNet"
+    "### Comparing MACE to CHGNeT and Orb"
    ]
   },
   {
@@ -301,14 +301,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sevennet_eos = EoS(\n",
+    "orb_eos = EoS(\n",
     "    struct=α_quartz.copy(),\n",
-    "    arch=\"sevennet\",\n",
+    "    arch=\"orb\",\n",
     "    device=\"cpu\",\n",
     "    minimize_kwargs={\"filter_class\": None},\n",
     ").run()\n",
     "\n",
-    "sevennet_eos[\"eos\"].plot(show=True)"
+    "orb_eos[\"eos\"].plot(show=True)"
    ]
   },
   {
@@ -334,19 +334,19 @@
    "outputs": [],
    "source": [
     "print(f\"MACE energy [eV]: {mace_eos['e_0']}\")\n",
-    "print(f\"SevenNet energy [eV]: {sevennet_eos['e_0']}\")\n",
+    "print(f\"Orb energy [eV]: {orb_eos['e_0']}\")\n",
     "print(f\"CHGNeT energy [eV]: {chgnet_eos['e_0']}\")\n",
     "\n",
     "print()\n",
     "\n",
     "print(f\"MACE volume [Å^3]: {mace_eos['v_0']}\")\n",
-    "print(f\"SevenNet volume [Å^3]: {sevennet_eos['v_0']}\")\n",
+    "print(f\"Orb volume [Å^3]: {orb_eos['v_0']}\")\n",
     "print(f\"CHGNeT volume [Å^3]: {chgnet_eos['v_0']}\")\n",
     "\n",
     "print()\n",
     "\n",
     "print(f\"MACE bulk_modulus [GPa]: {mace_eos['bulk_modulus']}\")\n",
-    "print(f\"SevenNet bulk_modulus [GPa]: {sevennet_eos['bulk_modulus']}\")\n",
+    "print(f\"Orb bulk_modulus [GPa]: {orb_eos['bulk_modulus']}\")\n",
     "print(f\"CHGNeT bulk_modulus [GPa]: {chgnet_eos['bulk_modulus']}\")"
    ]
   }

--- a/docs/source/tutorials/python/geom_opt.ipynb
+++ b/docs/source/tutorials/python/geom_opt.ipynb
@@ -50,7 +50,7 @@
     "# ! pip uninstall torch torchaudio torchvision transformers -y # Uninstall pre-installed torch\n",
     "# ! uv pip install torch==2.5.1 # Install pinned version of torch\n",
     "\n",
-    "# ! uv pip install janus-core[mace,sevennet,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, SevenNet, CHGNet, and WeasWidget, and data-tutorials\n",
+    "# ! uv pip install janus-core[mace,orb,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, Orb, CHGNet, and WeasWidget, and data-tutorials\n",
     "\n",
     "# get_ipython().kernel.do_shutdown(restart=True) # Restart kernel to update libraries. This may warn that your session has crashed."
    ]
@@ -317,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Comparing MACE to CHGNet and SevenNet"
+    "## Comparing MACE to CHGNet and Orb"
    ]
   },
   {
@@ -345,14 +345,13 @@
     ")\n",
     "optimized_NaCl_chgnet.run()\n",
     "\n",
-    "optimized_NaCl_sevennet = GeomOpt(\n",
+    "optimized_NaCl_orb = GeomOpt(\n",
     "    struct=NaCl.copy(),\n",
-    "    arch=\"sevennet\",\n",
+    "    arch=\"orb\",\n",
     "    device=\"cpu\",\n",
-    "    calc_kwargs={\"default_dtype\": \"float64\"},\n",
     "    fmax=0.01,\n",
     ")\n",
-    "optimized_NaCl_sevennet.run()"
+    "optimized_NaCl_orb.run()"
    ]
   },
   {
@@ -365,7 +364,7 @@
     "\n",
     "print(f\"Final energy (MACE): {optimized_NaCl_mace.struct.get_potential_energy()}\")\n",
     "print(f\"Final energy (CHGNet): {optimized_NaCl_chgnet.struct.get_potential_energy()}\")\n",
-    "print(f\"Final energy (SevenNet): {optimized_NaCl_sevennet.struct.get_potential_energy()}\")"
+    "print(f\"Final energy (Orb): {optimized_NaCl_orb.struct.get_potential_energy()}\")"
    ]
   }
  ],

--- a/docs/source/tutorials/python/neb.ipynb
+++ b/docs/source/tutorials/python/neb.ipynb
@@ -63,7 +63,7 @@
     "# ! pip uninstall torch torchaudio torchvision transformers -y # Uninstall pre-installed torch\n",
     "# ! uv pip install torch==2.5.1 # Install pinned version of torch\n",
     "\n",
-    "# ! uv pip install janus-core[mace,sevennet,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, SevenNet, CHGNet, and WeasWidget, and data-tutorials\n",
+    "# ! uv pip install janus-core[mace,orb,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, Orb, CHGNet, and WeasWidget, and data-tutorials\n",
     "\n",
     "# get_ipython().kernel.do_shutdown(restart=True) # Restart kernel to update libraries. This may warn that your session has crashed."
    ]
@@ -110,7 +110,7 @@
     "# model_params = {\"arch\": \"mace_mp\", \"model\": \"medium-mpa-0\"}\n",
     "# model_params = {\"arch\": \"mace_mp\", \"model\": \"medium-omat-0\"}\n",
     "# model_params = {\"arch\": \"chgnet\"}\n",
-    "# model_params = {\"arch\": \"sevennet\"}"
+    "# model_params = {\"arch\": \"orb\"}"
    ]
   },
   {

--- a/docs/source/tutorials/python/phonons.ipynb
+++ b/docs/source/tutorials/python/phonons.ipynb
@@ -50,7 +50,7 @@
     "# ! pip uninstall torch torchaudio torchvision transformers -y # Uninstall pre-installed torch\n",
     "# ! uv pip install torch==2.5.1 # Install pinned version of torch\n",
     "\n",
-    "# ! uv pip install janus-core[mace,sevennet,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, SevenNet, CHGNet, and WeasWidget, and data-tutorials\n",
+    "# ! uv pip install janus-core[mace,orb,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, Orb, CHGNet, and WeasWidget, and data-tutorials\n",
     "\n",
     "# get_ipython().kernel.do_shutdown(restart=True) # Restart kernel to update libraries. This may warn that your session has crashed."
    ]
@@ -373,7 +373,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Comparing the band structure from MACE to CHGNet and SevenNet:"
+    "## Comparing the band structure from MACE to CHGNet and Orb:"
    ]
   },
   {
@@ -421,7 +421,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Calculate band structure using SevenNet"
+    "### Calculate band structure using Orb"
    ]
   },
   {
@@ -430,9 +430,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phonons_sevennet = Phonons(\n",
+    "phonons_orb = Phonons(\n",
     "    struct=NaCl.copy(),\n",
-    "    arch=\"sevennet\",\n",
+    "    arch=\"orb\",\n",
     "    device=\"cpu\",\n",
     "    supercell=[2, 2, 2],\n",
     "    displacement=0.01,\n",
@@ -455,7 +455,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phonons_sevennet.calc_bands(write_bands=True)"
+    "phonons_orb.calc_bands(write_bands=True)"
    ]
   },
   {
@@ -473,7 +473,7 @@
    "source": [
     "phonons_mace.write_bands(plot_file=\"MACE.svg\")\n",
     "phonons_chgnet.write_bands(plot_file=\"chgnet.svg\")\n",
-    "phonons_sevennet.write_bands(plot_file=\"sevennet.svg\")"
+    "phonons_orb.write_bands(plot_file=\"orb.svg\")"
    ]
   },
   {

--- a/docs/source/tutorials/python/single_point.ipynb
+++ b/docs/source/tutorials/python/single_point.ipynb
@@ -23,7 +23,7 @@
     "id": "4vcbRxmIhHLL"
    },
    "source": [
-    "`janus-core` contains various machine learnt interatomic potentials (MLIPs), including MACE based models (MACE-MP, MACE-OFF), CHGNet, SevenNet and more, full list on https://github.com/stfc/janus-core.\n",
+    "`janus-core` contains various machine learnt interatomic potentials (MLIPs), including MACE based models (MACE-MP, MACE-OFF), CHGNet, Orb and more, full list on https://github.com/stfc/janus-core.\n",
     "\n",
     "Other will be added as their utility is proven beyond a specific material."
    ]
@@ -59,7 +59,7 @@
     "# ! pip uninstall torch torchaudio torchvision transformers -y # Uninstall pre-installed torch\n",
     "# ! uv pip install torch==2.5.1 # Install pinned version of torch\n",
     "\n",
-    "# ! uv pip install janus-core[mace,sevennet,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, SevenNet, CHGNet, and WeasWidget, and data-tutorials\n",
+    "# ! uv pip install janus-core[mace,orb,chgnet,visualise] data-tutorials --system # Install janus-core with MACE, Orb, CHGNet, and WeasWidget, and data-tutorials\n",
     "\n",
     "# get_ipython().kernel.do_shutdown(restart=True) # Restart kernel to update libraries. This may warn that your session has crashed."
    ]
@@ -148,10 +148,10 @@
     "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
     "sp = SinglePoint(\n",
     "    struct=NaCl,\n",
-    "    arch=\"sevennet\",\n",
+    "    arch=\"orb\",\n",
     "    device=device,\n",
     ")\n",
-    "res_sevennet = sp.run()\n",
+    "res_orb = sp.run()\n",
     "\n",
     "NaCl = bulk(\"NaCl\", \"rocksalt\", a=5.63, cubic=True)\n",
     "sp = SinglePoint(\n",
@@ -162,7 +162,7 @@
     "res_chgnet = sp.run()\n",
     "\n",
     "print(f\"    MACE[eV]: {res_mace['energy']}\")\n",
-    "print(f\"SevenNet[eV]: {res_sevennet['energy']}\")\n",
+    "print(f\"Orb[eV]: {res_orb['energy']}\")\n",
     "print(f\"  CHGNeT[eV]: {res_chgnet['energy']}\")"
    ]
   },
@@ -288,21 +288,21 @@
     "chgnet_energy = np.array([s.info[\"chgnet_energy\"] / len(s) for s in sp.struct])\n",
     "rmse_chgnet = np.linalg.norm(chgnet_energy - dft_energy) / np.sqrt(len(dft_energy))\n",
     "\n",
-    "sp = SinglePoint(struct=\"data/NaCl-set.xyz\", arch=\"sevennet\", device=device)\n",
+    "sp = SinglePoint(struct=\"data/NaCl-set.xyz\", arch=\"orb\", device=device)\n",
     "sp.run()\n",
     "\n",
-    "sevennet_energy = np.array([s.info[\"sevennet_energy\"] / len(s) for s in sp.struct])\n",
-    "rmse_sevennet = np.linalg.norm(sevennet_energy - dft_energy) / np.sqrt(len(dft_energy))\n",
+    "orb_energy = np.array([s.info[\"orb_energy\"] / len(s) for s in sp.struct])\n",
+    "rmse_orb = np.linalg.norm(orb_energy - dft_energy) / np.sqrt(len(dft_energy))\n",
     "\n",
     "print(\n",
     "    f\"rmse: mace_mp = {rmse_mace}, chgnet = {rmse_chgnet}, \"\n",
-    "    f\"sevennet = {rmse_sevennet} eV/atom\"\n",
+    "    f\"orb = {rmse_orb} eV/atom\"\n",
     ")\n",
     "\n",
     "fig, ax = plt.subplots()\n",
     "\n",
     "ax.scatter(dft_energy, mace_mp_energy, marker=\"o\", label=\"mace-mp-0\")\n",
-    "ax.scatter(dft_energy, sevennet_energy, marker=\"x\", label=\"sevennet\")\n",
+    "ax.scatter(dft_energy, orb_energy, marker=\"x\", label=\"orb\")\n",
     "ax.scatter(dft_energy, chgnet_energy, marker=\"+\", label=\"chgnet\")\n",
     "ax.legend()\n",
     "plt.xlabel(\"MLIP [eV/atom]\")\n",


### PR DESCRIPTION
Resolves #603

Replaced SevenNet with Orb, which is one of the few remaining models consistent with MACE.

This should allow us to do a new release.