### PR TITLE
Fix install extras typo and getting started links

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ We recommend installing uv for dependency management when developing for `janus-
 ```shell
 git clone https://github.com/stfc/janus-core
 cd janus-core
-uv sync --extra [extra] # Create a virtual environment and install dependencies
+uv sync --extra all # Create a virtual environment and install dependencies
 source .venv/bin/activate
 pre-commit install  # Install pre-commit hooks
 pytest -v  # Discover and run all tests

--- a/docs/source/developer_guide/get_started.rst
+++ b/docs/source/developer_guide/get_started.rst
@@ -31,7 +31,7 @@ Extras, such as optional MLIPs, can also be installed by running::
 
 or to install all MLIPs that do not depend on ``dgl``::
 
-    uv sync -p 3.12 --extras all
+    uv sync -p 3.12 --extra all
 
 
 Using uv


### PR DESCRIPTION
Couple of minor issues one typo in install instructions, but also some dead links to the getting started guide.

Closes #624