### PR TITLE
Update UMA

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ sevennet = [
     "sevenn == 0.11.2.post1",
 ]
 uma = [
-    "fairchem-core == 2.10.0",
+    "fairchem-core == 2.12.0",
 ]
 
 # MLIPs with dgl dependency


### PR DESCRIPTION
Resolves #623

This unfortunately adds a new conflict, since fairchem now depends on torch>=2.8, but `pet-mad` depends on `metatrain`, which indirectly depends on torch <2.8 currently.