### PR TITLE
Use non-interactive matplotlib for Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,6 +11,10 @@ jobs:
       matrix:
         python-version: ["3.10","3.11","3.12"]
 
+    # Use non-interactive backend for plotting
+    env:
+      MPLBACKEND: Agg
+
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Resolves #613

There are probably other solutions, but this seems to be the simplest, which is just to disable the interactive backend for matplotlib, which I believe was the trigger for the various Tcl errors we see on Windows.