### PR TITLE
Pin fairchem scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ sevennet = [
 ]
 fairchem-2 = [
     "fairchem-core == 2.12.0",
-    "scipy < 1.17.0",
 ]
 
 # MLIPs with dgl dependency


### PR DESCRIPTION
Closes #654 

The ```OCPCalculator``` in ```fairchem_core-1.10.0``` is the issue, which I am assuming won't be updated.

The problem code is still in the [main branch](https://github.com/facebookresearch/fairchem/blob/main/src/fairchem/core/models/utils/basis.py#L16) but does not seem to impact UMA/FairChemCalculator...