### PR TITLE
Fix building tutorials

### DIFF
--- a/docs/source/tutorials/cli/neb.ipynb
+++ b/docs/source/tutorials/cli/neb.ipynb
@@ -167,12 +167,12 @@
     "n_images: 11\n",
     "device: cpu\n",
     "arch: mace_mp\n",
-    "minimize: True\n",
+    "model: medium-omat-0\n",
+    "minimize: False\n",
     "plot_band: True\n",
     "write_band: True\n",
     "calc_kwargs:\n",
     "      dispersion: True\n",
-    "      model: medium-omat-0\n",
     "tracker: False"
    ]
   },

--- a/docs/source/tutorials/cli/phonons.ipynb
+++ b/docs/source/tutorials/cli/phonons.ipynb
@@ -187,10 +187,9 @@
     "minimize-kwargs:\n",
     "  write_results: True\n",
     "arch: mace_mp\n",
+    "model:  medium-mpa-0\n",
     "write-full: False\n",
     "plot-to-file: True\n",
-    "calc-kwargs:\n",
-    "    model:  medium-mpa-0\n",
     "device: cpu\n",
     "tracker: False"
    ]
@@ -275,12 +274,12 @@
     "minimize-kwargs:\n",
     "  write_results: True\n",
     "arch: mace_mp\n",
+    "model:  medium-mpa-0\n",
     "write-full: False\n",
     "plot-to-file: True\n",
     "calc-kwargs:\n",
     "    dispersion: False\n",
     "    skin: 0 \n",
-    "    model:  medium-mpa-0\n",
     "device: cpu\n",
     "tracker: False"
    ]
@@ -348,12 +347,12 @@
     "  filter_kwargs:\n",
     "      scalar_pressure: 1.0\n",
     "arch: mace_mp\n",
+    "model:  medium-mpa-0\n",
     "write-full: False\n",
     "plot-to-file: True\n",
     "calc-kwargs:\n",
     "    dispersion: False\n",
     "    skin: 0 \n",
-    "    model:  medium-mpa-0\n",
     "device: cpu\n",
     "tracker: False"
    ]
@@ -412,12 +411,12 @@
     "  filter_kwargs:\n",
     "    hydrostatic_strain: True\n",
     "arch: mace_mp\n",
+    "model: medium-mpa-0\n",
     "write-full: False\n",
     "plot-to-file: True\n",
     "calc-kwargs:\n",
     "    dispersion: False\n",
     "    skin: 0 \n",
-    "    model:  medium-mpa-0\n",
     "device: cpu\n",
     "tracker: False"
    ]
@@ -502,12 +501,12 @@
     "minimize-kwargs:\n",
     "  write_results: True\n",
     "arch: mace_mp\n",
+    "model: medium-mpa-0\n",
     "write-full: False\n",
     "plot-to-file: True\n",
     "calc-kwargs:\n",
     "    dispersion: False\n",
     "    skin: 0 \n",
-    "    model:  medium-mpa-0\n",
     "device: cpu\n",
     "tracker: False"
    ]
@@ -573,12 +572,12 @@
     "minimize-kwargs:\n",
     "  write_results: True\n",
     "arch: mace_mp\n",
+    "model: medium-mpa-0\n",
     "write-full: False\n",
     "plot-to-file: True\n",
     "calc-kwargs:\n",
     "    dispersion: False\n",
     "    skin: 0 \n",
-    "    model:  medium-mpa-0\n",
     "device: cpu\n",
     "tracker: False"
    ]


### PR DESCRIPTION
Resolves #664

The SVG error in the publish action isn't actually an error with the SVG reader/display, but because the file is missing, due to errors raised by the CLI commands.

I missed this as I had the previous output files locally still, as they live in source, not build, so the docs built successfully until I deleted these.

The first of the errors is the deprecation of `model` via `calc_kwargs`.

However, there also seems to be an issue optimising the geometry of the structures in our NEBs example.

```
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/cli/](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/cli/)neb.py:312 in  │
│ neb                                                                          │
│                                                                              │
│   309 │   )                                                                  │
│   310 │                                                                      │
│   311 │   # Run equation of state calculations                               │
│ ❱ 312 │   neb.run()                                                          │
│   313 │                                                                      │
│   314 │   # Save carbon summary                                              │
│   315 │   if tracker:                                                        │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/calculations/](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/calculations/)neb.p │
│ y:531 in run                                                                 │
│                                                                              │
│   528 │   │   self._set_info_units()                                         │
│   529 │   │                                                                  │
│   530 │   │   if self.minimize:                                              │
│ ❱ 531 │   │   │   GeomOpt(self.init_struct, **self.minimize_kwargs).run()    │
│   532 │   │   │                                                              │
│   533 │   │   │   # Change filename to be written                            │
│   534 │   │   │   self.minimize_kwargs["write_kwargs"]["filename"] = (       │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/calculations/](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/calculations/)geom_ │
│ opt.py:326 in run                                                            │
│                                                                              │
│   323 │                                                                      │
│   324 │   def run(self) -> None:                                             │
│   325 │   │   """Run geometry optimization."""                               │
│ ❱ 326 │   │   s_grp = spacegroup(self.struct, self.symmetry_tolerance, self. │
│   327 │   │   self.struct.info["initial_spacegroup"] = s_grp                 │
│   328 │   │   if self.logger:                                                │
│   329 │   │   │   self.logger.info("Before optimisation spacegroup: %s", s_g │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/processing/](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/janus_core/processing/)symmetr │
│ y.py:32 in spacegroup                                                        │
│                                                                              │
│   29 │   str                                                                 │
│   30 │   │   Spacegroup name.                                                │
│   31 │   """                                                                 │
│ ❱ 32 │   return get_spacegroup(                                              │
│   33 │   │   cell=(                                                          │
│   34 │   │   │   struct.get_cell(),                                          │
│   35 │   │   │   struct.get_scaled_positions(),                              │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac) │
│ kages/spglib/spg.py:482 in get_spacegroup                                    │
│                                                                              │
│   479 │   │   │   _throw=True,                                               │
│   480 │   │   )                                                              │
│   481 │   except Exception as exc:                                           │
│ ❱ 482 │   │   _set_or_throw_error(exc)                                       │
│   483 │   │   return None                                                    │
│   484 │                                                                      │
│   485 │   try:                                                               │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac) │
│ kages/spglib/error.py:117 in _set_or_throw_error                             │
│                                                                              │
│   114 │   if _throw or not _check_OLD_ERROR_HANDLING():                      │
│   115 │   │   if isinstance(exc, SpglibError):                               │
│   116 │   │   │   # Our native errors we pass transparently                  │
│ ❱ 117 │   │   │   raise exc                                                  │
│   118 │   │   # Otherwise we try to recast them to SplibError                │
│   119 │   │   raise SpglibError(f"Generic Spglib error:\n{exc}") from exc    │
│   120 │   warnings.warn(                                                     │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac) │
│ kages/spglib/spg.py:475 in get_spacegroup                                    │
│                                                                              │
│   472 │   _set_no_error()                                                    │
│   473 │                                                                      │
│   474 │   try:                                                               │
│ ❱ 475 │   │   dataset = get_symmetry_dataset(                                │
│   476 │   │   │   cell,                                                      │
│   477 │   │   │   symprec=symprec,                                           │
│   478 │   │   │   angle_tolerance=angle_tolerance,                           │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac) │
│ kages/spglib/spg.py:452 in get_symmetry_dataset                              │
│                                                                              │
│   449 │   │   │   float(angle_tolerance),                                    │
│   450 │   │   )                                                              │
│   451 │   except Exception as exc:                                           │
│ ❱ 452 │   │   _set_or_throw_error(exc, _throw)                               │
│   453 │   │   return None                                                    │
│   454 │                                                                      │
│   455 │   return SpglibDataset(**spg_ds)                                     │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac) │
│ kages/spglib/error.py:117 in _set_or_throw_error                             │
│                                                                              │
│   114 │   if _throw or not _check_OLD_ERROR_HANDLING():                      │
│   115 │   │   if isinstance(exc, SpglibError):                               │
│   116 │   │   │   # Our native errors we pass transparently                  │
│ ❱ 117 │   │   │   raise exc                                                  │
│   118 │   │   # Otherwise we try to recast them to SplibError                │
│   119 │   │   raise SpglibError(f"Generic Spglib error:\n{exc}") from exc    │
│   120 │   warnings.warn(                                                     │
│                                                                              │
│ [/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac](https://file+.vscode-resource.vscode-cdn.net/Users/elliottkasoar/Documents/PSDI/janus-core/.venv/lib/python3.12/site-pac) │
│ kages/spglib/spg.py:443 in get_symmetry_dataset                              │
│                                                                              │
│   440 │   lattice, positions, numbers, _ = _expand_cell(cell)                │
│   441 │                                                                      │
│   442 │   try:                                                               │
│ ❱ 443 │   │   spg_ds = _spglib.dataset(                                      │
│   444 │   │   │   lattice,                                                   │
│   445 │   │   │   positions,                                                 │
│   446 │   │   │   numbers,                                                   │
╰──────────────────────────────────────────────────────────────────────────────╯
SpglibCppError: too close distance between atoms
```

I've removed this for now, since we don't want to block releases, but it does seem to make the NEBs considerably worse, so hopefully we can find a fix later.