### PR TITLE
Prevent httpx logger breaking tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ Based on https://docs.pytest.org/en/latest/example/simple.html.
 
 from __future__ import annotations
 
+import logging
 import sys
 
 import pytest
@@ -21,10 +22,11 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    """Configure pytest to include marker for extra MLIPs."""
+    """Configure pytest."""
     config.addinivalue_line(
         "markers", "extra_mlips: mark test as containing extra MLIPs"
     )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
This aims to resolve the error we see in the CI:

```
>           calculator = choose_calculator(arch=arch, device=device, **kwargs)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/test_mlip_calculators.py:109: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
janus_core/helpers/mlip_calculators.py:379: in choose_calculator
    calculator = UPETCalculator(
.venv/lib/python3.12/site-packages/upet/calculator.py:147: in __init__
    size, version = upet_resolve_model(
.venv/lib/python3.12/site-packages/upet/_models.py:103: in upet_resolve_model
    all_model_sizes = get_sizes_for_model(model)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/upet/_models.py:45: in get_sizes_for_model
    files = _get_upet_repo_files()
            ^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/upet/_models.py:35: in _get_upet_repo_files
    repo_files = hf_api.list_repo_files("lab-cosmo/upet")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py:89: in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/huggingface_hub/hf_api.py:3235: in list_repo_files
    return [
.venv/lib/python3.12/site-packages/huggingface_hub/hf_api.py:3372: in list_repo_tree
    for path_info in paginate(path=tree_url, headers=headers, params={"recursive": recursive, "expand": expand}):
.venv/lib/python3.12/site-packages/huggingface_hub/utils/_pagination.py:36: in paginate
    r = session.get(path, params=params, headers=headers)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/httpx/_client.py:1053: in get
    return self.request(
.venv/lib/python3.12/site-packages/httpx/_client.py:825: in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/httpx/_client.py:914: in send
    response = self._send_handling_auth(
.venv/lib/python3.12/site-packages/httpx/_client.py:942: in _send_handling_auth
    response = self._send_handling_redirects(
.venv/lib/python3.12/site-packages/httpx/_client.py:979: in _send_handling_redirects
    response = self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/httpx/_client.py:1025: in _send_single_request
    logger.info(
/usr/lib/python3.12/logging/__init__.py:1539: in info
    self._log(INFO, msg, args, **kwargs)
/usr/lib/python3.12/logging/__init__.py:1684: in _log
    self.handle(record)
/usr/lib/python3.12/logging/__init__.py:1700: in handle
    self.callHandlers(record)
/usr/lib/python3.12/logging/__init__.py:1762: in callHandlers
    hdlr.handle(record)
/usr/lib/python3.12/logging/__init__.py:1028: in handle
    self.emit(record)
.venv/lib/python3.12/site-packages/_pytest/logging.py:384: in emit
    super().emit(record)
/usr/lib/python3.12/logging/__init__.py:1168: in emit
    self.handleError(record)
/usr/lib/python3.12/logging/__init__.py:1160: in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/logging/__init__.py:999: in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/_pytest/logging.py:137: in format
    return super().format(record)
           ^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/logging/__init__.py:703: in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <LogRecord: httpx, 20, /home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/httpx/_client.py, 1025, "
    - "HTTP Request: %s %s '%s %d %s'"">

    def getMessage(self):
        """
        Return the message for this LogRecord.
    
        Return the message for this LogRecord after merging any user-supplied
        arguments with the message.
        """
        msg = str(self.msg)
        if self.args:
>           msg = msg % self.args
                  ^^^^^^^^^^^^^^^
E           TypeError: %d format: a real number is required, not str

/usr/lib/python3.12/logging/__init__.py:392: TypeError
----------------------------- Captured stderr call -----------------------------
Warp CUDA warning: Could not find or load the NVIDIA CUDA driver. Proceeding in CPU-only mode.
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/janus-core/janus-core/janus_core/helpers/log.py", line 99, in format
    return super().format(record)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 703, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: %d format: a real number is required, not str
Call stack:
  File "/home/runner/work/janus-core/janus-core/.venv/bin/pytest", line 10, in <module>
    sys.exit(console_main())
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 201, in console_main
    code = main()
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py", line 175, in main
    ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/main.py", line 336, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/main.py", line 289, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/main.py", line 343, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/main.py", line 367, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/runner.py", line 117, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/runner.py", line 136, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/runner.py", line 245, in call_and_report
    call = CallInfo.from_call(
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/runner.py", line 344, in from_call
    result: TResult | None = func()
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/runner.py", line 246, in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/runner.py", line 178, in pytest_runtest_call
    item.runtest()
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/python.py", line 1671, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/_pytest/python.py", line 157, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/home/runner/work/janus-core/janus-core/tests/test_mlip_calculators.py", line 109, in test_mlips
    calculator = choose_calculator(arch=arch, device=device, **kwargs)
  File "/home/runner/work/janus-core/janus-core/janus_core/helpers/mlip_calculators.py", line 379, in choose_calculator
    calculator = UPETCalculator(
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/upet/calculator.py", line 147, in __init__
    size, version = upet_resolve_model(
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/upet/_models.py", line 103, in upet_resolve_model
    all_model_sizes = get_sizes_for_model(model)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/upet/_models.py", line 45, in get_sizes_for_model
    files = _get_upet_repo_files()
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/upet/_models.py", line 35, in _get_upet_repo_files
    repo_files = hf_api.list_repo_files("lab-cosmo/upet")
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 89, in _inner_fn
    return fn(*args, **kwargs)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/huggingface_hub/hf_api.py", line 3235, in list_repo_files
    return [
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/huggingface_hub/hf_api.py", line 3372, in list_repo_tree
    for path_info in paginate(path=tree_url, headers=headers, params={"recursive": recursive, "expand": expand}):
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/huggingface_hub/utils/_pagination.py", line 36, in paginate
    r = session.get(path, params=params, headers=headers)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1053, in get
    return self.request(
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/httpx/_client.py", line 825, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/httpx/_client.py", line 914, in send
    response = self._send_handling_auth(
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/httpx/_client.py", line 942, in _send_handling_auth
    response = self._send_handling_redirects(
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/httpx/_client.py", line 979, in _send_handling_redirects
    response = self._send_single_request(request)
  File "/home/runner/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/httpx/_client.py", line 1025, in _send_single_request
    logger.info(
Message: '\n    - "HTTP Request: %s %s \'%s %d %s\'"'
Arguments: ('GET', 'https://huggingface.co/api/models/lab-cosmo/upet/tree/main?recursive=true&expand=false', 'HTTP/1.1', '200', 'OK')
```

This only occurs for Python 3.12, and only when this test is run alongside other tests, so I think it's relating to interactions with both pytest logging and janus' logging.