### PR TITLE
Replace aptitude purge with apt-get purge

### DIFF
--- a/.github/workflows/docker-jupyter-image.yml
+++ b/.github/workflows/docker-jupyter-image.yml
@@ -24,8 +24,7 @@ jobs:
             /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
             /usr/lib/jvm || true
           echo "some directories deleted"
-          sudo apt install aptitude -y >/dev/null 2>&1
-          sudo aptitude purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
+          sudo apt-get purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
             esl-erlang firefox gfortran google-chrome-stable \
             google-cloud-sdk imagemagick \
             libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
@@ -37,12 +36,12 @@ jobs:
             temurin-11-jdk temurin-8-jdk temurin-17-jdk temurin-21-jdk \
             llvm-16-dev llvm-17-dev llvm-18-dev \
             -y -f >/dev/null 2>&1 || true
-          sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
           sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^php' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
           sudo apt-get autoremove -y >/dev/null 2>&1 || true
           sudo apt-get autoclean -y >/dev/null 2>&1 || true
           echo "some packages purged"
@@ -94,8 +93,7 @@ jobs:
             /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
             /usr/lib/jvm || true
           echo "some directories deleted"
-          sudo apt install aptitude -y >/dev/null 2>&1
-          sudo aptitude purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
+          sudo apt-get purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
             esl-erlang firefox gfortran google-chrome-stable \
             google-cloud-sdk imagemagick \
             libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
@@ -107,12 +105,12 @@ jobs:
             temurin-11-jdk temurin-8-jdk temurin-17-jdk temurin-21-jdk \
             llvm-16-dev llvm-17-dev llvm-18-dev \
             -y -f >/dev/null 2>&1 || true
-          sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
           sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^php' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
           sudo apt-get autoremove -y >/dev/null 2>&1 || true
           sudo apt-get autoclean -y >/dev/null 2>&1 || true
           echo "some packages purged"

--- a/.github/workflows/docker-marimo-image.yml
+++ b/.github/workflows/docker-marimo-image.yml
@@ -24,8 +24,7 @@ jobs:
             /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
             /usr/lib/jvm || true
           echo "some directories deleted"
-          sudo apt install aptitude -y >/dev/null 2>&1
-          sudo aptitude purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
+          sudo apt-get purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
             esl-erlang firefox gfortran google-chrome-stable \
             google-cloud-sdk imagemagick \
             libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
@@ -37,12 +36,12 @@ jobs:
             temurin-11-jdk temurin-8-jdk temurin-17-jdk temurin-21-jdk \
             llvm-16-dev llvm-17-dev llvm-18-dev \
             -y -f >/dev/null 2>&1 || true
-          sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
           sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^php' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
           sudo apt-get autoremove -y >/dev/null 2>&1 || true
           sudo apt-get autoclean -y >/dev/null 2>&1 || true
           echo "some packages purged"
@@ -94,8 +93,7 @@ jobs:
             /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
             /usr/lib/jvm || true
           echo "some directories deleted"
-          sudo apt install aptitude -y >/dev/null 2>&1
-          sudo aptitude purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
+          sudo apt-get purge aria2 ansible azure-cli shellcheck rpm xorriso zsync \
             esl-erlang firefox gfortran google-chrome-stable \
             google-cloud-sdk imagemagick \
             libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
@@ -107,12 +105,12 @@ jobs:
             temurin-11-jdk temurin-8-jdk temurin-17-jdk temurin-21-jdk \
             llvm-16-dev llvm-17-dev llvm-18-dev \
             -y -f >/dev/null 2>&1 || true
-          sudo aptitude purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge google-cloud-sdk -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
           sudo apt purge microsoft-edge-stable -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^php' -f -y >/dev/null 2>&1 || true
-          sudo aptitude purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^mysql' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^php' -f -y >/dev/null 2>&1 || true
+          sudo apt-get purge '~n ^dotnet' -f -y >/dev/null 2>&1 || true
           sudo apt-get autoremove -y >/dev/null 2>&1 || true
           sudo apt-get autoclean -y >/dev/null 2>&1 || true
           echo "some packages purged"


### PR DESCRIPTION
Slightly better tested than #677 (by temporarily removing branch/repo requirements): https://github.com/ElliottKasoar/janus-core/actions/runs/22767890941/job/66040526865

Turns out the error in this case wasn't actually from library being changed, but the installation of `aptitude` itself.

We probably could install it again with `apt-get update`, but actually we can just use `apt-get` instead for the purge, which seems simpler and still leads to similar cleanup.