### PR TITLE
Fix uv sync when building docs

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: uv sync --extra all
+        run: uv sync --extra mace --extra orb --extra chgnet
 
       - name: Build docs with tutorials
         run: cd docs && uv run make all


### PR DESCRIPTION
Removes leftover 'all' extra from publish workflow.