### PR TITLE
Optionally reset velocities for MD

### DIFF
--- a/janus_core/calculations/md.py
+++ b/janus_core/calculations/md.py
@@ -108,11 +108,13 @@ class MolecularDynamics(BaseCalculation):
     minimize_kwargs
         Keyword arguments to pass to geometry optimizer. Default is {}.
     rescale_velocities
-        Whether to rescale velocities. Default is False.
+        Whether to rescale velocities before dynamics and during equilibration.
+        Frequency during equilibration depends on `rescale_every`. Default is False.
     remove_rot
-        Whether to remove rotation. Default is False.
+        Whether to remove rotation when rescaling velocities. Default is False.
     rescale_every
-        Frequency to rescale velocities. Default is 10.
+        Frequency to rescale velocities and remove roation during equilibration.
+        Default is 10.
     file_prefix
         Prefix for output filenames. Default is inferred from structure, ensemble,
         and temperature.
@@ -285,11 +287,13 @@ class MolecularDynamics(BaseCalculation):
         minimize_kwargs
             Keyword arguments to pass to geometry optimizer. Default is {}.
         rescale_velocities
-            Whether to rescale velocities. Default is False.
+            Whether to rescale velocities before dynamics and during equilibration.
+            Frequency during equilibration depends on `rescale_every`. Default is False.
         remove_rot
-            Whether to remove rotation. Default is False.
+            Whether to remove rotation when rescaling velocities. Default is False.
         rescale_every
-            Frequency to rescale velocities. Default is 10.
+            Frequency to rescale velocities and remove roation during equilibration.
+            Default is 10.
         file_prefix
             Prefix for output filenames. Default is inferred from structure, ensemble,
             and temperature.
@@ -1371,14 +1375,8 @@ class MolecularDynamics(BaseCalculation):
             raise ValueError("Temperature set for ensemble with no thermostat.")
 
     def run(self) -> None:
-        """Run molecular dynamics simulation and/or temperature ramp."""
+        """Prepare and run molecular dynamics simulation and/or temperature ramp."""
         self._set_info_units(self.info_unit_keys)
-
-        if not self.restart:
-            if self.minimize:
-                self._optimize_structure()
-            if self.rescale_velocities:
-                self._reset_velocities()
 
         if self.offset == 0:
             self._write_header()
@@ -1412,9 +1410,16 @@ class MolecularDynamics(BaseCalculation):
         if self.ramp_temp:
             self.temp = self.temp_start
 
-        # Set velocities to match current temperature
+        # Relax and set velocities to match current temperature
         if not self.restart:
-            self._set_velocity_distribution()
+            if self.minimize:
+                self._optimize_structure()
+            if self.rescale_velocities:
+                self._set_velocity_distribution()
+            if np.isclose(self.struct.get_kinetic_energy(), 0.0, rtol=0, atol=1e-12):
+                if self.logger:
+                    self.logger.warning("Setting velocity due to zero kinetic energy")
+                self._set_velocity_distribution()
 
         # Run temperature ramp
         if self.ramp_temp:

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -549,7 +549,7 @@ def test_reset_velocities_zero_kinetic_energy(tmp_path):
     final_velocities = single_point.struct.get_velocities()
     final_kinetic_energy = single_point.struct.get_kinetic_energy()
 
-    # Final state should be stationary, but with non-zero velocities
+    # Final state should have zero net momentum, but non-zero velocities
     assert init_momentum == pytest.approx(0, abs=1e-10)
     assert init_kinetic_energy == pytest.approx(0)
     assert final_momentum == pytest.approx(0, abs=1e-10)

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -476,8 +476,85 @@ def test_reset_velocities(tmp_path):
 
     final_momentum = np.sum(single_point.struct.get_momenta())
     assert abs(final_momentum) < abs(init_momentum)
-    assert init_momentum != pytest.approx(0)
-    assert final_momentum == pytest.approx(0)
+    assert init_momentum != pytest.approx(0, abs=1e-10)
+    # Rescaling sets `Stationary`
+    assert final_momentum == pytest.approx(0, abs=1e-10)
+
+
+def test_no_reset_velocities(tmp_path):
+    """Test not resetting velocities before dynamics."""
+    struct_file = DATA_PATH / "lj-traj.xyz"
+    file_prefix = tmp_path / "md"
+
+    # Check initial velocities are non-zero.
+    struct = read(struct_file)
+    init_momentum = np.sum(struct.get_momenta())
+    init_velocities = struct.get_velocities()
+    assert init_momentum != pytest.approx(0, abs=1e-10)
+
+    nvt = NVT(
+        arch="mace",
+        model=MODEL_PATH,
+        struct=struct_file,
+        temp=300.0,
+        steps=0,
+        traj_every=1,
+        stats_every=1,
+        rescale_velocities=False,
+        file_prefix=file_prefix,
+    )
+    nvt.run()
+
+    # Check final velocities are non-zero and unchanged
+    final_momentum = np.sum(nvt.struct.get_momenta())
+    final_velocities = nvt.struct.get_velocities()
+    assert final_momentum == pytest.approx(init_momentum)
+    assert final_velocities == pytest.approx(init_velocities)
+
+
+def test_reset_velocities_zero_kinetic_energy(tmp_path):
+    """Test velocities are set for zero kinetic energy."""
+    file_prefix = tmp_path / "Cl4Na4-nvt-T300.0"
+    log_file = tmp_path / "nvt.log"
+
+    single_point = SinglePoint(
+        struct=DATA_PATH / "H2O.cif",
+        arch="mace",
+        model=MODEL_PATH,
+    )
+    # Give structure arbitrary velocities
+    single_point.struct.set_velocities(np.zeros((3, 3)))
+    init_momentum = np.sum(single_point.struct.get_momenta())
+    init_velocities = single_point.struct.get_velocities()
+    init_kinetic_energy = single_point.struct.get_kinetic_energy()
+
+    nvt = NVT(
+        struct=single_point.struct,
+        temp=300.0,
+        steps=0,
+        traj_every=1,
+        stats_every=1,
+        rescale_velocities=False,
+        file_prefix=file_prefix,
+        log_kwargs={"filename": log_file},
+    )
+    nvt.run()
+
+    assert_log_contains(
+        log_file,
+        includes=["Setting velocity due to zero kinetic energy"],
+    )
+
+    final_momentum = np.sum(single_point.struct.get_momenta())
+    final_velocities = single_point.struct.get_velocities()
+    final_kinetic_energy = single_point.struct.get_kinetic_energy()
+
+    # Final state should be stationary, but with non-zero velocities
+    assert init_momentum == pytest.approx(0, abs=1e-10)
+    assert init_kinetic_energy == pytest.approx(0)
+    assert final_momentum == pytest.approx(0, abs=1e-10)
+    assert final_kinetic_energy != pytest.approx(0, abs=1e-10)
+    assert final_velocities != pytest.approx(init_velocities)
 
 
 def test_remove_rot(tmp_path):


### PR DESCRIPTION
Resolves #666

This is a slightly different fix to the discussion in the issue, to me it also seems like a reasonable solution that makes sense based on our current parameters (`rescale_velocities` in particular, since this already guarded an effectively duplicated `self._reset_velocities()` call):

- If `rescale_velocities` is `True` (default is `False`) then velocities are reset before heating and/or MD (assuming we're not restarting)
- If `rescale_velocities` is `False`, we don't reset the velocities, unless no velocities have been set, in the same way as `NVT_CSVR`. I'm also happy to leave the velocities at 0 if it makes more sense

I test that reading in a file with velocities (and `rescale_velocities` is `False`) keeps these velocities, so I think it addresses the main point of the issue.

There is also scope for debate about the additional resets we perform in between heating steps, and between heating and MD, but that could also be addressed separately.

How does this look/sound, @trdurrant? 