### PR TITLE
Fix MACE energy in tutorial

### DIFF
--- a/docs/source/tutorials/python/geom_opt.ipynb
+++ b/docs/source/tutorials/python/geom_opt.ipynb
@@ -362,9 +362,9 @@
    "source": [
     "print(f\"Initial energy: {init_energy}\")\n",
     "\n",
-    "print(f\"Final energy (MACE): {optimized_NaCl_mace.struct.get_potential_energy()}\")\n",
-    "print(f\"Final energy (CHGNet): {optimized_NaCl_chgnet.struct.get_potential_energy()}\")\n",
-    "print(f\"Final energy (Orb): {optimized_NaCl_orb.struct.get_potential_energy()}\")"
+    "print(f\"Final energy (MACE): {optimized_NaCl_mace.struct.info[\"mace_mp_energy\"]}\")\n",
+    "print(f\"Final energy (CHGNet): {optimized_NaCl_chgnet.struct.info[\"chgnet_energy\"]}\")\n",
+    "print(f\"Final energy (Orb): {optimized_NaCl_orb.struct.info[\"orb_energy\"]}\")"
    ]
   }
  ],


### PR DESCRIPTION
This should fix the error from the tutorial, which is blocking release:

```
RuntimeError                              Traceback (most recent call last)
Cell In[14], line 3
      1 print(f"Initial energy: {init_energy}")
      2 
----> 3 print(f"Final energy (MACE): {optimized_NaCl_mace.struct.get_potential_energy()}")
      4 print(f"Final energy (CHGNet): {optimized_NaCl_chgnet.struct.get_potential_energy()}")
      5 print(f"Final energy (Orb): {optimized_NaCl_orb.struct.get_potential_energy()}")

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/ase/atoms.py:1964, in Atoms.get_potential_energy(self, force_consistent, apply_constraint)
   1961     energy = self._calc.get_potential_energy(
   1962         self, force_consistent=force_consistent)
   1963 else:
-> 1964     energy = self._calc.get_potential_energy(self)
   1965 if apply_constraint:
   1966     for constraint in self.constraints:

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/ase/calculators/abc.py:27, in GetPropertiesMixin.get_potential_energy(self, atoms, force_consistent)
     25 else:
     26     name = 'energy'
---> 27 return self.get_property(name,atoms)

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/ase/calculators/calculator.py:520, in BaseCalculator.get_property(self, name, atoms, allow_calculation)
    517     if self.use_cache:
    518         self.atoms = atoms.copy()
--> 520     self.calculate(atoms,[name],system_changes)
    522 if name not in self.results:
    523     # For some reason the calculator was not able to do what we want,
    524     # and that is OK.
    525     raise PropertyNotImplementedError(
    526         '{} not present in this ' 'calculation'.format(name)
    527     )

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/mace/calculators/mace.py:445, in MACECalculator.calculate(self, atoms, properties, system_changes)
    443 for i, model in enumerate(self.models):
    444     batch = self._clone_batch(batch_base)
--> 445     out = model(
    446 batch.to_dict(),
    447 compute_stress=compute_stress,
    448 training=self.use_compile,
    449 compute_edge_forces=self.compute_atomic_stresses,
    450 compute_atomic_stresses=self.compute_atomic_stresses,
    451 )
    452     if i == 0:
    453         ret_tensors, node_e0 = self._create_result_tensors(
    454             self.num_models, len(atoms), batch, out
    455         )

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1773, in Module._wrapped_call_impl(self, *args, **kwargs)
   1771     return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1772 else:
-> 1773     return self._call_impl(*args,**kwargs)

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1784, in Module._call_impl(self, *args, **kwargs)
   1779 # If we don't have any hooks, we want to skip the rest of the logic in
   1780 # this function, and just call forward.
   1781 if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
   1782         or _global_backward_pre_hooks or _global_backward_hooks
   1783         or _global_forward_hooks or _global_forward_pre_hooks):
-> 1784     return forward_call(*args,**kwargs)
   1786 result = None
   1787 called_always_called_hooks = set()

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/mace/modules/models.py:490, in ScaleShiftMACE.forward(self, data, training, compute_force, compute_virials, compute_stress, compute_displacement, compute_hessian, compute_edge_forces, compute_atomic_stresses, lammps_mliap)
    487 lammps_class = interaction_kwargs.lammps_class
    489 # Atomic energies
--> 490 node_e0 = self.atomic_energies_fn(data["node_attrs"])[
    491     num_atoms_arange, node_heads
    492 ]
    493 e0 = scatter_sum(
    494     src=node_e0, index=data["batch"], dim=0, dim_size=num_graphs
    495 ).to(
    496     vectors.dtype
    497 )  # [n_graphs, num_heads]
    499 # Embeddings

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1773, in Module._wrapped_call_impl(self, *args, **kwargs)
   1771     return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1772 else:
-> 1773     return self._call_impl(*args,**kwargs)

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1784, in Module._call_impl(self, *args, **kwargs)
   1779 # If we don't have any hooks, we want to skip the rest of the logic in
   1780 # this function, and just call forward.
   1781 if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
   1782         or _global_backward_pre_hooks or _global_backward_hooks
   1783         or _global_forward_hooks or _global_forward_pre_hooks):
-> 1784     return forward_call(*args,**kwargs)
   1786 result = None
   1787 called_always_called_hooks = set()

File ~/work/janus-core/janus-core/.venv/lib/python3.12/site-packages/mace/modules/blocks.py:322, in AtomicEnergiesBlock.forward(self, x)
    319 def forward(
    320     self, x: torch.Tensor  # one-hot of elements [..., n_elements]
    321 ) -> torch.Tensor:  # [..., ]
--> 322     return torch.matmul(x,torch.atleast_2d(self.atomic_energies).T)

RuntimeError: expected m1 and m2 to have the same dtype, but got: float != double

You can ignore this error by setting the following in conf.py:

    nbsphinx_allow_errors = True

make: *** [Makefile:40: tutorials] Error 2
Error: Process completed with exit code 2.
```

I think this is due to changes discussed here: https://github.com/ACEsuit/mace/issues/1279

Since we add info to the `Atoms` during the calculation, MACE's `get_potential_energy` retriggers a full calculation, which then clashes with the data types, as in the process of setting up a different calculator, we change torch's default dtype.