### PR TITLE
Fix NEB fmax

### DIFF
--- a/janus_core/calculations/neb.py
+++ b/janus_core/calculations/neb.py
@@ -13,6 +13,7 @@ from ase.mep import NEB as ASE_NEB
 from ase.mep import NEBTools
 from ase.mep.neb import NEBOptimizer
 from matplotlib.figure import Figure
+import numpy as np
 from numpy.linalg import LinAlgError
 from pymatgen.io.ase import AseAtomsAdaptor
 
@@ -526,7 +527,9 @@ class NEB(BaseCalculation):
         """Run NEBTools analysis."""
         self.nebtools = NEBTools(self.images)
         barrier, delta_E = self.nebtools.get_barrier()  # noqa: N806
-        max_force = self.nebtools.get_fmax()
+        # Avoid reinitialising NEB with NEBTools.get_fmax
+        forces = self.neb.get_forces()
+        max_force = np.sqrt((forces**2).sum(axis=1).max())
         self.results = {
             "barrier": barrier,
             "delta_E": delta_E,

--- a/tests/test_neb.py
+++ b/tests/test_neb.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from ase.io import read, write
+from ase.mep.neb import DyNEB
+from ase.optimize import BFGS
+import numpy as np
 import pytest
 
 from janus_core.calculations.neb import NEB
@@ -298,3 +301,28 @@ def test_missing_arch(struct):
     """Test missing arch."""
     with pytest.raises(ValueError, match="A calculator must be attached"):
         NEB(neb_structs=struct)
+
+
+def test_max_force(tmp_path, LFPO_start_b, LFPO_end_b):
+    """Test saved max force corresponds to correct NEB."""
+    neb = NEB(
+        init_struct=LFPO_start_b,
+        final_struct=LFPO_end_b,
+        arch="mace_mp",
+        model=MODEL_PATH,
+        n_images=5,
+        neb_class=DyNEB,
+        neb_kwargs={"climb": True, "method": "eb", "scale_fmax": 1.0},
+        optimizer=BFGS,
+        interpolator="ase",
+        steps=1,
+        file_prefix=tmp_path / "LFPO",
+    )
+    neb.run()
+
+    assert all(key in neb.results for key in ("barrier", "delta_E", "max_force"))
+
+    stored_max_force = neb.results["max_force"]
+    forces = neb.neb.get_forces()
+    max_force = np.sqrt((forces**2).sum(axis=1).max())
+    assert stored_max_force == pytest.approx(max_force)


### PR DESCRIPTION
Resolves #700

Avoids using `NEBTools.get_fmax`, as this runs a new `NEB().get_forces`, which can differ from the NEB class being used.

`test_max_force` fails before the fix is introduced.